### PR TITLE
Start a docker container with a database via a DAG task

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,3 +17,5 @@ include README.rst
 include tox.ini .travis.yml .appveyor.yml .readthedocs.yml .pre-commit-config.yaml
 
 global-exclude *.py[cod] __pycache__/* *.so *.dylib
+global-exclude airflow.db logs/**/* unittests.cfg
+global-exclude *.swp

--- a/src/egon/data/airflow/Dockerfile.postgis
+++ b/src/egon/data/airflow/Dockerfile.postgis
@@ -1,0 +1,7 @@
+FROM postgres:12
+
+RUN apt-get update
+RUN apt-get install -y postgresql-12-postgis-3
+
+
+

--- a/src/egon/data/airflow/airflow.cfg
+++ b/src/egon/data/airflow/airflow.cfg
@@ -1,11 +1,11 @@
 [core]
 # The folder where your airflow pipelines live, most likely a
 # subfolder in a code repository. This path must be absolute.
-dags_folder = /home/dozeumgus/.config/python/virtualenvs/egon-dataprocessing-using-apache-airflow/airflow_home/dags
+# dags_folder = ${AIRFLOW_HOME}
 
 # The folder where airflow should store its log files
 # This path must be absolute
-base_log_folder = /home/dozeumgus/.config/python/virtualenvs/egon-dataprocessing-using-apache-airflow/airflow_home/logs
+# base_log_folder = ${AIRFLOW_HOME}/logs
 
 # Airflow can store logs remotely in AWS S3, Google Cloud Storage or Elastic Search.
 # Set this to True if you want to enable remote logging.
@@ -44,7 +44,7 @@ simple_log_format = %%(asctime)s %%(levelname)s - %%(message)s
 # Log filename format
 log_filename_template = {{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log
 log_processor_filename_template = {{ filename }}.log
-dag_processor_manager_log_location = /home/dozeumgus/.config/python/virtualenvs/egon-dataprocessing-using-apache-airflow/airflow_home/logs/dag_processor_manager/dag_processor_manager.log
+# dag_processor_manager_log_location = ${AIRFLOW_HOME}/logs/dag_processor_manager/dag_processor_manager.log
 
 # Name of handler to read task instance logs.
 # Default to use task handler.
@@ -71,7 +71,7 @@ executor = SequentialExecutor
 # The SqlAlchemy connection string to the metadata database.
 # SqlAlchemy supports many different database engine, more information
 # their website
-sql_alchemy_conn = sqlite:////home/dozeumgus/.config/python/virtualenvs/egon-dataprocessing-using-apache-airflow/airflow_home/airflow.db
+# sql_alchemy_conn = sqlite:///${AIRFLOW_HOME}/airflow.db
 
 # The encoding for the databases
 sql_engine_encoding = utf-8
@@ -133,7 +133,7 @@ max_active_runs_per_dag = 16
 # Whether to load the DAG examples that ship with Airflow. It's good to
 # get started, but you probably want to set this to False in a production
 # environment
-load_examples = True
+load_examples = False
 
 # Whether to load the default connections that ship with Airflow. It's good to
 # get started, but you probably want to set this to False in a production
@@ -141,7 +141,7 @@ load_examples = True
 load_default_connections = True
 
 # Where your Airflow plugins are stored
-plugins_folder = /home/dozeumgus/.config/python/virtualenvs/egon-dataprocessing-using-apache-airflow/airflow_home/plugins
+# plugins_folder = ${AIRFLOW_HOME}/plugins
 
 # Secret key to save connection passwords in the db
 fernet_key = 
@@ -631,7 +631,7 @@ print_stats_interval = 30
 # ago (in seconds), scheduler is considered unhealthy.
 # This is used by the health check in the "/health" endpoint
 scheduler_health_check_threshold = 30
-child_process_log_directory = /home/dozeumgus/.config/python/virtualenvs/egon-dataprocessing-using-apache-airflow/airflow_home/logs/scheduler
+# child_process_log_directory = ${AIRFLOW_HOME}/logs/scheduler
 
 # Local task jobs periodically heartbeat to the DB. If the job has
 # not heartbeat in this many seconds, the scheduler will mark the
@@ -900,7 +900,7 @@ git_sync_root = /git
 git_sync_dest = repo
 
 # Mount point of the volume if git-sync is being used.
-# i.e. /home/dozeumgus/.config/python/virtualenvs/egon-dataprocessing-using-apache-airflow/airflow_home/dags
+# i.e. ${AIRFLOW_HOME}/dags
 git_dags_folder_mount_point =
 
 # To get Git-sync SSH authentication set up follow this format

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -1,0 +1,13 @@
+from airflow.operators.python_operator import PythonOperator
+from airflow.utils.dates import days_ago
+import airflow
+
+from egon.data.airflow.tasks import initdb
+
+
+with airflow.DAG(
+    "egon-data-processing-pipeline",
+    description="The eGo^N data processing DAG.",
+    default_args={"start_date": days_ago(1)},
+) as example:
+    setup = PythonOperator(task_id="initdb", python_callable=initdb)

--- a/src/egon/data/airflow/docker-compose.yml
+++ b/src/egon/data/airflow/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  egon-data-local-database:
+    image: postgres:12-postgis
+    container_name: egon-data-local-database
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: Dockerfile.postgis
+    ports:
+    - "127.0.0.1:54321:5432"
+    environment:
+      POSTGRES_DB: egon-data
+      POSTGRES_USER: egon
+      POSTGRES_PASSWORD: data
+    volumes:
+    - $HOME/docker/volumes/postgres/egon-data:/var/lib/postgresql/data
+    - ./entrypoints:/docker-entrypoint-initdb.d/

--- a/src/egon/data/airflow/entrypoints/create_postgis_extension.sql
+++ b/src/egon/data/airflow/entrypoints/create_postgis_extension.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION postgis;

--- a/src/egon/data/airflow/tasks.py
+++ b/src/egon/data/airflow/tasks.py
@@ -1,0 +1,10 @@
+import subprocess
+import os.path
+
+
+def initdb():
+    """ Initialize the local database used for data processing. """
+    subprocess.run(
+        ["docker-compose", "up", "-d", "--build"],
+        cwd=os.path.dirname(__file__),
+    )


### PR DESCRIPTION
This should address issue #18. It should be as "simple" as

  - running `egon-data serve`,
  - opening `localhost:8080` in a browser window,
  - turning the only available DAG `ON`.

You might have to trigger the DAG explicitly, after turning it `ON`. After a while `docker ps` should show that the container named `egon-data-local-database` is up.
I know that all of this should also be in the documentation. I'll copy it there, once I get to it.