### PR TITLE
Start a docker container with a database via a DAG task

### DIFF
--- a/src/egon/data/airflow/Dockerfile.postgis
+++ b/src/egon/data/airflow/Dockerfile.postgis
@@ -1,0 +1,7 @@
+FROM postgres:12
+
+RUN apt-get update
+RUN apt-get install -y postgresql-12-postgis-3
+
+
+

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -1,0 +1,13 @@
+from airflow.operators.python_operator import PythonOperator
+from airflow.utils.dates import days_ago
+import airflow
+
+from egon.data.airflow.tasks import initdb
+
+
+with airflow.DAG(
+    "egon-data-processing-pipeline",
+    description="The eGo^N data processing DAG.",
+    default_args={"start_date": days_ago(1)},
+) as example:
+    setup = PythonOperator(task_id="initdb", python_callable=initdb)

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -4,7 +4,6 @@ import airflow
 
 from egon.data.airflow.tasks import initdb
 
-
 with airflow.DAG(
     "egon-data-processing-pipeline",
     description="The eGo^N data processing DAG.",

--- a/src/egon/data/airflow/docker-compose.yml
+++ b/src/egon/data/airflow/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  egon-data-local-database:
+    image: postgres:12-postgis
+    container_name: egon-data-local-database
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: Dockerfile.postgis
+    ports:
+    - "127.0.0.1:54321:5432"
+    environment:
+      POSTGRES_DB: egon-data
+      POSTGRES_USER: egon
+      POSTGRES_PASSWORD: data
+    volumes:
+    - $HOME/docker/volumes/postgres/egon-data:/var/lib/postgresql/data
+    - ./entrypoints:/docker-entrypoint-initdb.d/

--- a/src/egon/data/airflow/entrypoints/create_postgis_extension.sql
+++ b/src/egon/data/airflow/entrypoints/create_postgis_extension.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION postgis;

--- a/src/egon/data/airflow/tasks.py
+++ b/src/egon/data/airflow/tasks.py
@@ -1,5 +1,5 @@
-import subprocess
 import os.path
+import subprocess
 
 
 def initdb():

--- a/src/egon/data/airflow/tasks.py
+++ b/src/egon/data/airflow/tasks.py
@@ -1,0 +1,10 @@
+import subprocess
+import os.path
+
+
+def initdb():
+    """ Initialize the local database used for data processing. """
+    subprocess.run(
+        ["docker-compose", "up", "-d", "--build"],
+        cwd=os.path.dirname(__file__),
+    )

--- a/tests/test_egon-data.py
+++ b/tests/test_egon-data.py
@@ -1,3 +1,5 @@
+from importlib import import_module
+
 from click.testing import CliRunner
 
 from egon.data import __version__
@@ -19,3 +21,15 @@ def test_airflow():
     runner = CliRunner()
     result = runner.invoke(main, ["airflow", "--help"])
     assert result.output == ""
+
+
+def test_pipeline_and_tasks_importability():
+    error = None
+    for m in ["egon.data.airflow.dags.pipeline", "egon.data.airflow.tasks"]:
+        try:
+            import_module(m)
+        except Exception as e:
+            error = e
+        assert error is None, (
+            "\nDid not expect an error when importing:\n\n  `{}`\n\nGot: {}"
+        ).format(m, error)


### PR DESCRIPTION
This should address issue #18. It should be as "simple" as

  - running `egon-data serve`,
  - opening `localhost:8080` in a browser window,
  - turning the only available DAG `ON`.

You might have to trigger the DAG explicitly, after turning it `ON`. After a while `docker ps` should show that the container named `egon-data-local-database` is up.
I know that all of this should also be in the documentation. I'll copy it there, once I get to it.
Also: this PR is the correct version of #29.