### PR TITLE
Drop OSM indices only if exist

### DIFF
--- a/src/egon/data/processing/openstreetmap.py
+++ b/src/egon/data/processing/openstreetmap.py
@@ -19,10 +19,10 @@ def modify_tables():
     ]:
 
         # Drop indices
-        sql_statements = [f"DROP INDEX {table}_index;"]
+        sql_statements = [f"DROP INDEX IF EXISTS {table}_index;"]
 
         # Drop primary keys
-        sql_statements.append(f"DROP INDEX {table}_pkey;")
+        sql_statements.append(f"DROP INDEX IF EXISTS {table}_pkey;")
 
         # Add primary key on newly created column "gid"
         sql_statements.append(f"ALTER TABLE public.{table} ADD gid SERIAL;")


### PR DESCRIPTION
Prevents from breaking the workflow on a fresh database without prior imported OSM data.

Fixes #66.