### PR TITLE
Features/#7 transfer zensus vg250 scripts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,8 @@ Added
   `#112 <https://github.com/openego/eGon-data/issues/112>`_
 * Abstraction of hvmv and ehv substations
   `#9 <https://github.com/openego/eGon-data/issues/9>`_
+* Filter zensus being inside Germany and assign population to municipalities
+  `#7 <https://github.com/openego/eGon-data/issues/7>`_
 
 Changed
 -------

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -8,30 +8,33 @@ import importlib_resources as resources
 
 from egon.data.airflow.tasks import initdb
 from egon.data.db import airflow_db_connection
-import egon.data.importing.openstreetmap as import_osm
-import egon.data.importing.vg250 as import_vg250
 import egon.data.importing.demandregio as import_dr
-import egon.data.processing.openstreetmap as process_osm
-import egon.data.importing.zensus as import_zs
-import egon.data.processing.power_plants as power_plants
-import egon.data.importing.nep_input_data as nep_input
 import egon.data.importing.etrago as etrago
 import egon.data.importing.mastr as mastr
+import egon.data.importing.nep_input_data as nep_input
+import egon.data.importing.openstreetmap as import_osm
+import egon.data.importing.vg250 as import_vg250
+import egon.data.importing.zensus as import_zs
+import egon.data.processing.openstreetmap as process_osm
+import egon.data.processing.power_plants as power_plants
 import egon.data.processing.substation as substation
 
 # Prepare connection to db for operators
 airflow_db_connection()
 
 # Temporary set dataset variable here
-dataset = 'Schleswig-Holstein'
+dataset = "Schleswig-Holstein"
 
 with airflow.DAG(
     "egon-data-processing-pipeline",
     description="The eGo^N data processing DAG.",
     default_args={"start_date": days_ago(1)},
     template_searchpath=[
-        os.path.abspath(os.path.join(os.path.dirname(
-            __file__), '..', '..', 'processing', 'vg250'))
+        os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__), "..", "..", "processing", "vg250"
+            )
+        )
     ],
     is_paused_upon_creation=False,
     schedule_interval=None,
@@ -66,8 +69,9 @@ with airflow.DAG(
         python_callable=import_vg250.download_vg250_files,
     )
     vg250_import = PythonOperator(
-        task_id="import-vg250", python_callable=import_vg250.to_postgres,
-        op_args={dataset}
+        task_id="import-vg250",
+        python_callable=import_vg250.to_postgres,
+        op_args={dataset},
     )
 
     vg250_nuts_mview = PostgresOperator(
@@ -92,29 +96,29 @@ with airflow.DAG(
     # Zensus import
     zensus_download_population = PythonOperator(
         task_id="download-zensus-population",
-        python_callable=import_zs.download_zensus_pop
+        python_callable=import_zs.download_zensus_pop,
     )
 
     zensus_download_misc = PythonOperator(
         task_id="download-zensus-misc",
-        python_callable=import_zs.download_zensus_misc
+        python_callable=import_zs.download_zensus_misc,
     )
 
     zensus_tables = PythonOperator(
         task_id="create-zensus-tables",
-        python_callable=import_zs.create_zensus_tables
+        python_callable=import_zs.create_zensus_tables,
     )
 
     population_import = PythonOperator(
         task_id="import-zensus-population",
         python_callable=import_zs.population_to_postgres,
-        op_args={dataset}
+        op_args={dataset},
     )
 
     zensus_misc_import = PythonOperator(
         task_id="import-zensus-misc",
         python_callable=import_zs.zensus_misc_to_postgres,
-        op_args={dataset}
+        op_args={dataset},
     )
     setup >> zensus_download_population >> zensus_download_misc
     zensus_download_misc >> zensus_tables >> population_import
@@ -131,48 +135,48 @@ with airflow.DAG(
     # Power plant setup
     power_plant_tables = PythonOperator(
         task_id="create-power-plant-tables",
-        python_callable=power_plants.create_tables
+        python_callable=power_plants.create_tables,
     )
     setup >> power_plant_tables
 
     # NEP data import
     create_tables = PythonOperator(
         task_id="create-scenario-tables",
-        python_callable=nep_input.create_scenario_input_tables)
+        python_callable=nep_input.create_scenario_input_tables,
+    )
 
     nep_insert_data = PythonOperator(
         task_id="insert-nep-data",
         python_callable=nep_input.insert_data_nep,
-        op_args={dataset})
+        op_args={dataset},
+    )
 
     setup >> create_tables >> nep_insert_data
     vg250_clean_and_prepare >> nep_insert_data
 
-
     # setting etrago input tables
     etrago_input_data = PythonOperator(
-        task_id = "setting-etrago-input-tables",
-        python_callable = etrago.create_tables
+        task_id="setting-etrago-input-tables",
+        python_callable=etrago.create_tables,
     )
     setup >> etrago_input_data
 
     # Retrieve MaStR data
     retrieve_mastr_data = PythonOperator(
         task_id="retrieve_mastr_data",
-        python_callable=mastr.download_mastr_data
+        python_callable=mastr.download_mastr_data,
     )
     setup >> retrieve_mastr_data
-
 
     # Substation extraction
     substation_tables = PythonOperator(
         task_id="create_substation_tables",
-        python_callable=substation.create_tables
+        python_callable=substation.create_tables,
     )
 
     substation_functions = PythonOperator(
         task_id="substation_functions",
-        python_callable=substation.create_sql_functions
+        python_callable=substation.create_sql_functions,
     )
 
     hvmv_substation_extraction = PostgresOperator(
@@ -188,6 +192,6 @@ with airflow.DAG(
         postgres_conn_id="egon_data",
         autocommit=True,
     )
-    osm_add_metadata  >> substation_tables >> substation_functions
+    osm_add_metadata >> substation_tables >> substation_functions
     substation_functions >> hvmv_substation_extraction
     substation_functions >> ehv_substation_extraction

--- a/src/egon/data/db.py
+++ b/src/egon/data/db.py
@@ -1,7 +1,9 @@
+from contextlib import contextmanager
 from pathlib import Path
 import os
 
 from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
 import yaml
 
 import egon
@@ -117,3 +119,18 @@ def airflow_db_connection():
         f"postgresql://{cred['POSTGRES_USER']}:{cred['POSTGRES_PASSWORD']}"
         f"@{cred['HOST']}:{cred['PORT']}/{cred['POSTGRES_DB']}"
     )
+
+
+@contextmanager
+def session_scope():
+    """Provide a transactional scope around a series of operations."""
+    Session = sessionmaker(bind=engine())
+    session = Session()
+    try:
+        yield session
+        session.commit()
+    except:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
+++ b/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
@@ -271,7 +271,101 @@ def population_in_municipalities():
         session.commit()
 
 
-def add_metadata():
+def add_metadata_zensus_inside_ger():
+    """
+    Create metadata JSON for DestatisZensusPopulationPerHaInsideGermany
+
+    Creates a metdadata JSON string and writes it to the database table comment
+    """
+    metadata = {
+        "title": "DESTATIS - Zensus 2011 - Population per hectar",
+        "description": "National census in Germany in 2011 with the bounds on Germanys boarders.",
+        "language": ["eng", "ger"],
+        "spatial": {
+            "location": "none",
+            "extent": "Germany",
+            "resolution": "1 ha",
+        },
+        "temporal": {
+            "reference_date": "2011",
+            "start": "none",
+            "end": "none",
+            "resolution": "none",
+        },
+        "sources": [
+            {
+                "name": "Statistisches Bundesamt (Destatis) - Ergebnisse des Zensus 2011 zum Download",
+                "description": "Als Download bieten wir Ihnen auf dieser Seite zusätzlich zur Zensusdatenbank CSV- und teilweise Excel-Tabellen mit umfassenden Personen-, Haushalts- und Familien- sowie Gebäude- und Wohnungs­merkmalen. Die Ergebnisse liegen auf Bundes-, Länder-, Kreis- und Gemeinde­ebene vor. Außerdem sind einzelne Ergebnisse für Gitterzellen verfügbar.",
+                "url": "https://www.zensus2011.de/SharedDocs/Aktuelles/Ergebnisse/DemografischeGrunddaten.html;jsessionid=E0A2B4F894B258A3B22D20448F2E4A91.2_cid380?nn=3065474",
+                "license": "",
+                "copyright": "© Statistische Ämter des Bundes und der Länder 2014",
+            },
+            {
+                "name": "Dokumentation - Zensus 2011 - Methoden und Verfahren",
+                "description": "Diese Publikation beschreibt ausführlich die Methoden und Verfahren des registergestützten Zensus 2011; von der Datengewinnung und -aufbereitung bis hin zur Ergebniserstellung und Geheimhaltung. Der vorliegende Band wurde von den Statistischen Ämtern des Bundes und der Länder im Juni 2015 veröffentlicht.",
+                "url": "https://www.destatis.de/DE/Publikationen/Thematisch/Bevoelkerung/Zensus/ZensusBuLaMethodenVerfahren5121105119004.pdf?__blob=publicationFile",
+                "license": "Vervielfältigung und Verbreitung, auch auszugsweise, mit Quellenangabe gestattet.",
+                "copyright": "© Statistisches Bundesamt, Wiesbaden, 2015 (im Auftrag der Herausgebergemeinschaft)",
+            },
+        ],
+        "license": {
+            "id": "dl-de/by-2-0",
+            "name": "Datenlizenz by-2-0",
+            "version": "2.0",
+            "url": "www.govdata.de/dl-de/by-2-0",
+            "instruction": "Empfohlene Zitierweise des Quellennachweises: Datenquelle: Statistisches Bundesamt, Wiesbaden, Genesis-Online, <optional> Abrufdatum; Datenlizenz by-2-0. Quellenvermerk bei eigener Berechnung / Darstellung: Datenquelle: Statistisches Bundesamt, Wiesbaden, Genesis-Online, <optional> Abrufdatum; Datenlizenz by-2-0; eigene Berechnung/eigene Darstellung. In elektronischen Werken ist im Quellenverweis dem Begriff (Datenlizenz by-2-0) der Link www.govdata.de/dl-de/by-2-0 als Verknüpfung zu hinterlegen.",
+            "copyright": "Statistisches Bundesamt, Wiesbaden, Genesis-Online; Datenlizenz by-2-0; eigene Berechnung",
+        },
+        "contributors": [
+            {
+                "title": "Guido Pleßmann",
+                "email": "http://github.com/gplssm",
+                "date": "2021-03-11",
+                "object": "",
+                "comment": "Created processing ",
+            }
+        ],
+        "resources": [
+            {
+                "name": "society.destatis_zensus_population_per_ha",
+                "format": "PostgreSQL",
+                "fields": [
+                    {
+                        "name": "gid",
+                        "description": "Unique identifier",
+                        "unit": "none",
+                    },
+                    {
+                        "name": "grid_id",
+                        "description": "Grid number of source",
+                        "unit": "none",
+                    },
+                    {
+                        "name": "population",
+                        "description": "Number of registred residents",
+                        "unit": "resident",
+                    },
+                    {
+                        "name": "geom_point",
+                        "description": "Geometry centroid",
+                        "unit": "none",
+                    },
+                    {"name": "geom", "description": "Geometry", "unit": ""},
+                ],
+            }
+        ],
+        "metadata_version": "1.3",
+    }
+
+    meta_json = "'" + json.dumps(metadata) + "'"
+
+    db.submit_comment(
+        meta_json,
+        DestatisZensusPopulationPerHaInsideGermany.__table__.schema,
+        DestatisZensusPopulationPerHaInsideGermany.__table__.name,
+    )
+
+
 def add_metadata_vg250_gem_pop():
     """
     Create metadata JSON for Vg250GemPopulation

--- a/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
+++ b/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
@@ -294,18 +294,38 @@ def add_metadata_zensus_inside_ger():
         },
         "sources": [
             {
-                "name": "Statistisches Bundesamt (Destatis) - Ergebnisse des Zensus 2011 zum Download",
-                "description": "Als Download bieten wir Ihnen auf dieser Seite zusätzlich zur Zensusdatenbank CSV- und teilweise Excel-Tabellen mit umfassenden Personen-, Haushalts- und Familien- sowie Gebäude- und Wohnungs­merkmalen. Die Ergebnisse liegen auf Bundes-, Länder-, Kreis- und Gemeinde­ebene vor. Außerdem sind einzelne Ergebnisse für Gitterzellen verfügbar.",
-                "url": "https://www.zensus2011.de/SharedDocs/Aktuelles/Ergebnisse/DemografischeGrunddaten.html;jsessionid=E0A2B4F894B258A3B22D20448F2E4A91.2_cid380?nn=3065474",
+                "name": "Statistisches Bundesamt (Destatis) - Ergebnisse des "
+                        "Zensus 2011 zum Download",
+                "description": "Als Download bieten wir Ihnen auf dieser Seite "
+                               "zusätzlich zur Zensusdatenbank CSV- und "
+                               "teilweise Excel-Tabellen mit umfassenden "
+                               "Personen-, Haushalts- und Familien- sowie "
+                               "Gebäude- und Wohnungs­merkmalen. Die "
+                               "Ergebnisse liegen auf Bundes-, Länder-, Kreis- "
+                               "und Gemeinde­ebene vor. Außerdem sind einzelne "
+                               "Ergebnisse für Gitterzellen verfügbar.",
+                "url": "https://www.zensus2011.de/SharedDocs/Aktuelles/Ergebnis"
+                       "se/DemografischeGrunddaten.html;jsessionid=E0A2B4F894B2"
+                       "58A3B22D20448F2E4A91.2_cid380?nn=3065474",
                 "license": "",
                 "copyright": "© Statistische Ämter des Bundes und der Länder 2014",
             },
             {
                 "name": "Dokumentation - Zensus 2011 - Methoden und Verfahren",
-                "description": "Diese Publikation beschreibt ausführlich die Methoden und Verfahren des registergestützten Zensus 2011; von der Datengewinnung und -aufbereitung bis hin zur Ergebniserstellung und Geheimhaltung. Der vorliegende Band wurde von den Statistischen Ämtern des Bundes und der Länder im Juni 2015 veröffentlicht.",
-                "url": "https://www.destatis.de/DE/Publikationen/Thematisch/Bevoelkerung/Zensus/ZensusBuLaMethodenVerfahren5121105119004.pdf?__blob=publicationFile",
-                "license": "Vervielfältigung und Verbreitung, auch auszugsweise, mit Quellenangabe gestattet.",
-                "copyright": "© Statistisches Bundesamt, Wiesbaden, 2015 (im Auftrag der Herausgebergemeinschaft)",
+                "description": "Diese Publikation beschreibt ausführlich die "
+                               "Methoden und Verfahren des registergestützten "
+                               "Zensus 2011; von der Datengewinnung und "
+                               "-aufbereitung bis hin zur Ergebniserstellung"
+                               " und Geheimhaltung. Der vorliegende Band wurde "
+                               "von den Statistischen Ämtern des Bundes und "
+                               "der Länder im Juni 2015 veröffentlicht.",
+                "url": "https://www.destatis.de/DE/Publikationen/Thematisch/Be"
+                       "voelkerung/Zensus/ZensusBuLaMethodenVerfahren51211051"
+                       "19004.pdf?__blob=publicationFile",
+                "license": "Vervielfältigung und Verbreitung, auch "
+                           "auszugsweise, mit Quellenangabe gestattet.",
+                "copyright": "© Statistisches Bundesamt, Wiesbaden, 2015 "
+                             "(im Auftrag der Herausgebergemeinschaft)",
             },
         ],
         "license": {
@@ -313,8 +333,19 @@ def add_metadata_zensus_inside_ger():
             "name": "Datenlizenz by-2-0",
             "version": "2.0",
             "url": "www.govdata.de/dl-de/by-2-0",
-            "instruction": "Empfohlene Zitierweise des Quellennachweises: Datenquelle: Statistisches Bundesamt, Wiesbaden, Genesis-Online, <optional> Abrufdatum; Datenlizenz by-2-0. Quellenvermerk bei eigener Berechnung / Darstellung: Datenquelle: Statistisches Bundesamt, Wiesbaden, Genesis-Online, <optional> Abrufdatum; Datenlizenz by-2-0; eigene Berechnung/eigene Darstellung. In elektronischen Werken ist im Quellenverweis dem Begriff (Datenlizenz by-2-0) der Link www.govdata.de/dl-de/by-2-0 als Verknüpfung zu hinterlegen.",
-            "copyright": "Statistisches Bundesamt, Wiesbaden, Genesis-Online; Datenlizenz by-2-0; eigene Berechnung",
+            "instruction": "Empfohlene Zitierweise des Quellennachweises: "
+                           "Datenquelle: Statistisches Bundesamt, Wiesbaden, "
+                           "Genesis-Online, <optional> Abrufdatum; Datenlizenz "
+                           "by-2-0. Quellenvermerk bei eigener Berechnung / "
+                           "Darstellung: Datenquelle: Statistisches Bundesamt, "
+                           "Wiesbaden, Genesis-Online, <optional> Abrufdatum; "
+                           "Datenlizenz by-2-0; eigene Berechnung/eigene "
+                           "Darstellung. In elektronischen Werken ist im "
+                           "Quellenverweis dem Begriff (Datenlizenz by-2-0) "
+                           "der Link www.govdata.de/dl-de/by-2-0 als "
+                           "Verknüpfung zu hinterlegen.",
+            "copyright": "Statistisches Bundesamt, Wiesbaden, Genesis-Online; "
+                         "Datenlizenz by-2-0; eigene Berechnung",
         },
         "contributors": [
             {
@@ -396,7 +427,8 @@ def add_metadata_vg250_gem_pop():
     ]
 
     metadata = {
-        "title": "Municipalities (BKG Verwaltungsgebiete 250) and population (Destatis Zensus)",
+        "title": "Municipalities (BKG Verwaltungsgebiete 250) and population "
+                 "(Destatis Zensus)",
         "description": "Municipality data enriched by population data",
         "language": ["DE"],
         "spatial": {

--- a/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
+++ b/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
@@ -53,7 +53,7 @@ class DestatisZensusPopulationPerHa(Base):
     __tablename__ = "destatis_zensus_population_per_ha"
     __table_args__ = {"schema": "society"}
 
-    gid = Column(Integer, primary_key=True)
+    id = Column(Integer, primary_key=True, index=True)
     grid_id = Column(String(254), nullable=False)
     x_mp = Column(Integer)
     y_mp = Column(Integer)
@@ -66,7 +66,7 @@ class DestatisZensusPopulationPerHaInsideGermany(Base):
     __tablename__ = "destatis_zensus_population_per_ha_inside_germany"
     __table_args__ = {"schema": "society"}
 
-    gid = Column(Integer, primary_key=True)
+    gid = Column(Integer, primary_key=True, index=True)
     grid_id = Column(String(254), nullable=False)
     population = Column(SmallInteger)
     geom_point = Column(Geometry("POINT", 3035), index=True)
@@ -111,7 +111,7 @@ def filter_data():
         # Query relevant data from zensus population table
         q = (
             s.query(
-                DestatisZensusPopulationPerHa.gid,
+                DestatisZensusPopulationPerHa.id,
                 DestatisZensusPopulationPerHa.grid_id,
                 DestatisZensusPopulationPerHa.population,
                 DestatisZensusPopulationPerHa.geom_point,

--- a/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
+++ b/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
@@ -1,0 +1,66 @@
+from geoalchemy2 import Geometry
+from sqlalchemy import BigInteger, Column, Integer, SmallInteger, String, func
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+from egon.data import db
+
+Base = declarative_base()
+
+
+class Vg250Sta(Base):
+    __tablename__ = "vg250_sta"
+    __table_args__ = {"schema": "boundaries"}
+
+    gid = Column(BigInteger, primary_key=True, index=True)
+    ade = Column(BigInteger)
+    gf = Column(BigInteger)
+    bsg = Column(BigInteger)
+    ars = Column(String)
+    ags = Column(String)
+    sdv_ars = Column(String)
+    gen = Column(String)
+    bez = Column(String)
+    ibz = Column(BigInteger)
+    bem = Column(String)
+    nbd = Column(String)
+    sn_l = Column(String)
+    sn_r = Column(String)
+    sn_k = Column(String)
+    sn_v1 = Column(String)
+    sn_v2 = Column(String)
+    sn_g = Column(String)
+    fk_s3 = Column(String)
+    nuts = Column(String)
+    ars_0 = Column(String)
+    ags_0 = Column(String)
+    wsk = Column(String)
+    debkg_id = Column(String)
+    rs = Column(String)
+    sdv_rs = Column(String)
+    rs_0 = Column(String)
+    geometry = Column(Geometry(srid=4326), index=True)
+
+
+class DestatisZensusPopulationPerHa(Base):
+    __tablename__ = "destatis_zensus_population_per_ha"
+    __table_args__ = {"schema": "society"}
+
+    gid = Column(Integer, primary_key=True)
+    grid_id = Column(String(254), nullable=False)
+    x_mp = Column(Integer)
+    y_mp = Column(Integer)
+    population = Column(SmallInteger)
+    geom_point = Column(Geometry("POINT", 3035), index=True)
+    geom = Column(Geometry("POLYGON", 3035), index=True)
+
+
+class DestatisZensusPopulationPerHaInsideGermany(Base):
+    __tablename__ = "destatis_zensus_population_per_ha_inside_germany"
+    __table_args__ = {"schema": "society"}
+
+    gid = Column(Integer, primary_key=True)
+    grid_id = Column(String(254), nullable=False)
+    population = Column(SmallInteger)
+    geom_point = Column(Geometry("POINT", 3035), index=True)
+    geom = Column(Geometry("POLYGON", 3035), index=True)

--- a/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
+++ b/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
@@ -273,6 +273,11 @@ def population_in_municipalities():
 
 def add_metadata():
 def add_metadata_vg250_gem_pop():
+    """
+    Create metadata JSON for Vg250GemPopulation
+
+    Creates a metdadata JSON string and writes it to the database table comment
+    """
     vg250_config = egon.data.config.datasets()["vg250"]
 
     licenses = [

--- a/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
+++ b/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
@@ -49,6 +49,40 @@ class Vg250Sta(Base):
     geometry = Column(Geometry(srid=4326), index=True)
 
 
+class Vg250Gem(Base):
+    __tablename__ = 'vg250_gem'
+    __table_args__ = {'schema': 'boundaries'}
+    
+    gid = Column(BigInteger, primary_key=True, index=True)
+    ade = Column(BigInteger)
+    gf = Column(BigInteger)
+    bsg = Column(BigInteger)
+    ars = Column(String)
+    ags = Column(String)
+    sdv_ars = Column(String)
+    gen = Column(String)
+    bez = Column(String)
+    ibz = Column(BigInteger)
+    bem = Column(String)
+    nbd = Column(String)
+    sn_l = Column(String)
+    sn_r = Column(String)
+    sn_k = Column(String)
+    sn_v1 = Column(String)
+    sn_v2 = Column(String)
+    sn_g = Column(String)
+    fk_s3 = Column(String)
+    nuts = Column(String)
+    ars_0 = Column(String)
+    ags_0 = Column(String)
+    wsk = Column(String)
+    debkg_id = Column(String)
+    rs = Column(String)
+    sdv_rs = Column(String)
+    rs_0 = Column(String)
+    geometry = Column(Geometry(srid=4326), index=True)
+
+
 class DestatisZensusPopulationPerHa(Base):
     __tablename__ = "destatis_zensus_population_per_ha"
     __table_args__ = {"schema": "society"}

--- a/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
+++ b/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
@@ -129,7 +129,7 @@ class Vg250GemPopulation(Base):
     geom = Column(Geometry(srid=3035))
 
 
-def filter_data():
+def inside_germany():
     """
     Filter zensus data by data inside Germany and population > 0
     """

--- a/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
+++ b/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
@@ -1,3 +1,4 @@
+import json
 from geoalchemy2 import Geometry
 from sqlalchemy import (
     BigInteger,
@@ -11,6 +12,7 @@ from sqlalchemy import (
 from sqlalchemy.ext.declarative import declarative_base
 
 from egon.data import db
+import egon.data.config
 
 Base = declarative_base()
 
@@ -236,3 +238,117 @@ def population_in_municipalities():
         # Execute and commit (trigger transactions in database)
         session.execute(insert)
         session.commit()
+
+def add_metadata():
+    vg250_config = egon.data.config.datasets()["vg250"]
+
+    licenses = [
+        {
+            "title": "Datenlizenz Deutschland – Namensnennung – Version 2.0",
+            "path": "www.govdata.de/dl-de/by-2-0",
+            "instruction": (
+                "Jede Nutzung ist unter den Bedingungen dieser „Datenlizenz "
+                "Deutschland - Namensnennung - Version 2.0 zulässig.\nDie "
+                "bereitgestellten Daten und Metadaten dürfen für die "
+                "kommerzielle und nicht kommerzielle Nutzung insbesondere:"
+                "(1) vervielfältigt, ausgedruckt, präsentiert, verändert, "
+                "bearbeitet sowie an Dritte übermittelt werden;\n "
+                "(2) mit eigenen Daten und Daten Anderer zusammengeführt und "
+                "zu selbständigen neuen Datensätzen verbunden werden;\n "
+                "(3) in interne und externe Geschäftsprozesse, Produkte und "
+                "Anwendungen in öffentlichen und nicht öffentlichen "
+                "elektronischen Netzwerken eingebunden werden."
+            ),
+            "attribution": "© Bundesamt für Kartographie und Geodäsie",
+        }
+    ]
+
+
+    metadata = {
+            "title": "Municipalities (BKG Verwaltungsgebiete 250) and population (Destatis Zensus)",
+            "description": "Municipality data enriched by population data",
+            "language": ["DE"],
+            "spatial": {
+                "location": "",
+                "extent": "Germany",
+                "resolution": "vector",
+            },
+            "temporal": {
+                "referenceDate": "2020-01-01",
+                "timeseries": {
+                    "start": "",
+                    "end": "",
+                    "resolution": "",
+                    "alignment": "",
+                    "aggregationType": "",
+                },
+            },
+            "sources": [
+                {
+                    "title": "Dienstleistungszentrum des Bundes für "
+                    "Geoinformation und Geodäsie - Open Data",
+                    "description": "Dieser Datenbestand steht über "
+                    "Geodatendienste gemäß "
+                    "Geodatenzugangsgesetz (GeoZG) "
+                    "(http://www.geodatenzentrum.de/auftrag/pdf"
+                    "/geodatenzugangsgesetz.pdf) für die "
+                    "kommerzielle und nicht kommerzielle "
+                    "Nutzung geldleistungsfrei zum Download "
+                    "und zur Online-Nutzung zur Verfügung. Die "
+                    "Nutzung der Geodaten und Geodatendienste "
+                    "wird durch die Verordnung zur Festlegung "
+                    "der Nutzungsbestimmungen für die "
+                    "Bereitstellung von Geodaten des Bundes "
+                    "(GeoNutzV) (http://www.geodatenzentrum.de"
+                    "/auftrag/pdf/geonutz.pdf) geregelt. "
+                    "Insbesondere hat jeder Nutzer den "
+                    "Quellenvermerk zu allen Geodaten, "
+                    "Metadaten und Geodatendiensten erkennbar "
+                    "und in optischem Zusammenhang zu "
+                    "platzieren. Veränderungen, Bearbeitungen, "
+                    "neue Gestaltungen oder sonstige "
+                    "Abwandlungen sind mit einem "
+                    "Veränderungshinweis im Quellenvermerk zu "
+                    "versehen. Quellenvermerk und "
+                    "Veränderungshinweis sind wie folgt zu "
+                    "gestalten. Bei der Darstellung auf einer "
+                    "Webseite ist der Quellenvermerk mit der "
+                    "URL http://www.bkg.bund.de zu verlinken. "
+                    "© GeoBasis-DE / BKG <Jahr des letzten "
+                    "Datenbezugs> © GeoBasis-DE / BKG "
+                    "<Jahr des letzten Datenbezugs> "
+                    "(Daten verändert) Beispiel: "
+                    "© GeoBasis-DE / BKG 2013",
+                    "path": vg250_config["original_data"]["source"]["url"],
+                    "licenses": licenses,
+                    "copyright": "© GeoBasis-DE / BKG 2016 (Daten verändert)",
+                },
+            ],
+            "licenses": licenses,
+            "contributors": [
+                {
+                    "title": "Guido Pleßmann",
+                    "email": "http://github.com/gplssm",
+                    "date": "2021-03-11",
+                    "object": "",
+                    "comment": "Imported data",
+                }
+            ],
+            "metaMetadata": {
+                "metadataVersion": "OEP-1.4.0",
+                "metadataLicense": {
+                    "name": "CC0-1.0",
+                    "title": "Creative Commons Zero v1.0 Universal",
+                    "path": (
+                        "https://creativecommons.org/publicdomain/zero/1.0/"
+                    ),
+                },
+            },
+        }
+
+    meta_json = "'" + json.dumps(metadata) + "'"
+
+    db.submit_comment(
+        meta_json, Vg250GemPopulation.__table__.schema,
+        Vg250GemPopulation.__table__.name
+    )

--- a/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
+++ b/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
@@ -107,12 +107,11 @@ class DestatisZensusPopulationPerHaInsideGermany(Base):
     geom = Column(Geometry("POLYGON", 3035), index=True)
 
 
-class BkgVg250GemPopulation(Base):
-    __tablename__ = "bkg_vg250_6_gem_mview"
+class Vg250GemPopulation(Base):
+    __tablename__ = "vg250_gem_population"
     __table_args__ = {"schema": "boundaries"}
 
-    gid = Column(Integer, primary_key=True)
-    reference_date = Column(String)
+    gid = Column(Integer, primary_key=True, index=True)
     gen = Column(String)
     bez = Column(String)
     bem = Column(String)
@@ -121,11 +120,10 @@ class BkgVg250GemPopulation(Base):
     rs_0 = Column(String)
     area_ha = Column(Float)
     area_km2 = Column(Float)
-    census_sum = Column(Integer)
-    census_count = Column(Integer)
-    census_density = Column(Integer)
-    pd = (Column(Float),)
-    geom = Column(Geometry("MULTIPOLYGON", 3035), index=True)
+    population_total = Column(Integer)
+    cell_count = Column(Integer)
+    population_density = Column(Integer)
+    geom = Column(Geometry(srid=3035))
 
 
 def filter_data():

--- a/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
+++ b/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
@@ -272,6 +272,7 @@ def population_in_municipalities():
 
 
 def add_metadata():
+def add_metadata_vg250_gem_pop():
     vg250_config = egon.data.config.datasets()["vg250"]
 
     licenses = [

--- a/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
+++ b/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
@@ -1,5 +1,13 @@
 from geoalchemy2 import Geometry
-from sqlalchemy import BigInteger, Column, Integer, SmallInteger, String, func
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    Integer,
+    SmallInteger,
+    String,
+    Float,
+    func,
+)
 from sqlalchemy.ext.declarative import declarative_base
 
 from egon.data import db
@@ -63,6 +71,27 @@ class DestatisZensusPopulationPerHaInsideGermany(Base):
     population = Column(SmallInteger)
     geom_point = Column(Geometry("POINT", 3035), index=True)
     geom = Column(Geometry("POLYGON", 3035), index=True)
+
+
+class BkgVg250GemPopulation(Base):
+    __tablename__ = "bkg_vg250_6_gem_mview"
+    __table_args__ = {"schema": "boundaries"}
+
+    gid = Column(Integer, primary_key=True)
+    reference_date = Column(String)
+    gen = Column(String)
+    bez = Column(String)
+    bem = Column(String)
+    nuts = Column(String)
+    ags_0 = Column(String)
+    rs_0 = Column(String)
+    area_ha = Column(Float)
+    area_km2 = Column(Float)
+    census_sum = Column(Integer)
+    census_count = Column(Integer)
+    census_density = Column(Integer)
+    pd = (Column(Float),)
+    geom = Column(Geometry("MULTIPOLYGON", 3035), index=True)
 
 
 def filter_data():


### PR DESCRIPTION
To new tables are introduced by this PR

- society.destatis_zensus_population_per_ha_inside_germany
- boundaries.vg250_gem_population

Some things are different now compared to open_ego

- former "boundaries.bkg_vg250_6_gem_mview" is now "boundaries.vg250_gem_population"
- no intermediate tables are created
- Columns of "boundaries.vg250_gem_population" renamed/changed:
  - dropped former census_population (population / number of cells)
  - also dropped field "pd" and replaced by population_density
  - census_sum -> population_total
- Using only Zensus data inside Germany: before all zensus data (destatis_zensus_population_per_ha) was used for assigning population to municipalities
- The Mview "boundaries.bkg_vg250_6_gem_error_geom_mview" is not created because I don't know if we need it

Fixes #7 