### PR TITLE
Features/#129-add-note-on-died-workers

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -72,6 +72,24 @@ Once you got this, run :code:`kill -s INT NUMBER`, substituting
 :code:`egon-data serve` should run without errors again.
 
 
+Other runtime errors
+====================
+
+If you trigger the DAG run in the webinterface you may encounter the error
+``ERROR - [0 / 0] Some workers seem to have died ...``. This was observed in
+connection with the scheduler message
+``sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) database is locked``.
+
+If this error persists, it may help to build the database from scratch by
+deleting the docker container using
+
+.. code-block:: bash
+
+   docker stop egon-data-local-database
+   docker rm egon-data-local-database
+
+and re-trigger the DAG.
+
 Other import or incompatible package version errors
 ===================================================
 


### PR DESCRIPTION
Fixes #129

The description is quite unspecific and the errors are likely to occur with different settings too, but I did not dig any deeper here. Nevertheless this hint may help new users to overcome problems by resetting the docker DB.

@gnn Is that ok for you? We can also make this more broad by writing something like "It may help to reset the local docker DB..."