### PR TITLE
Rename columns to id and zensus_population_id

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,8 @@ Changed
   `#20 <https://github.com/openego/eGon-data/issues/20>`_
 * Switch from Travis to GitHub actions for CI jobs
   `#92 <https://github.com/openego/eGon-data/issues/92>`_
+  * Rename columns to id and zensus_population_id in zensus tables
+  `#140 <https://github.com/openego/eGon-data/issues/140>`_
 
 Bug fixes
 ---------

--- a/src/egon/data/importing/zensus/__init__.py
+++ b/src/egon/data/importing/zensus/__init__.py
@@ -75,7 +75,7 @@ def create_zensus_tables():
 
     db.execute_sql(
         f"CREATE TABLE {population_table}"
-        f""" (gid        SERIAL NOT NULL,
+        f""" (id        SERIAL NOT NULL,
               grid_id    character varying(254) NOT NULL,
               x_mp       int,
               y_mp       int,
@@ -83,7 +83,7 @@ def create_zensus_tables():
               geom_point geometry(Point,3035),
               geom geometry (Polygon, 3035),
               CONSTRAINT {zensus_population_processed['table']}_pkey
-              PRIMARY KEY (gid)
+              PRIMARY KEY (id)
         );
         """
     )
@@ -103,7 +103,7 @@ def create_zensus_tables():
                   characteristics_text text,
                   quantity           smallint,
                   quantity_q         smallint,
-                  gid_ha             int,
+                  zensus_population_id int,
                   CONSTRAINT {table}_pkey PRIMARY KEY (id)
             );
             """
@@ -381,7 +381,7 @@ def zensus_misc_to_postgres(dataset="main"):
 
         db.execute_sql(
             f"""UPDATE {zensus_population_processed['schema']}.{table} as b
-                    SET gid_ha = zs.gid
+                    SET zensus_population_id = zs.id
                     FROM {population_table} zs
                     WHERE b.grid_id = zs.grid_id;"""
         )
@@ -389,6 +389,6 @@ def zensus_misc_to_postgres(dataset="main"):
         db.execute_sql(
             f"""ALTER TABLE {zensus_population_processed['schema']}.{table}
                     ADD CONSTRAINT {table}_fkey
-                    FOREIGN KEY (gid_ha)
-                    REFERENCES {population_table}(gid);"""
+                    FOREIGN KEY (zensus_population_id)
+                    REFERENCES {population_table}(id);"""
         )


### PR DESCRIPTION
Column `gid` in table `society.destatis_zensus_population_per_ha` got renamed to `id`. 
Corresponding columns in other zensus tables got renamed to `zensus_population_id`.