### PR TITLE
Features/#148 drop python36 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
         platform: [ubuntu-latest, macos-latest]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -63,6 +63,8 @@ Changed
 * Revise docs CONTRIBUTING section and in particular PR guidelines
   `#88 <https://github.com/openego/eGon-data/issues/88>`_ and
   `#145 <https://github.com/openego/eGon-data/issues/145>`_
+* Drop support for Python3.6
+  `#148 <https://github.com/openego/eGon-data/issues/148>`_
 
 Bug fixes
 ---------

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
@@ -80,7 +79,7 @@ setup(
     keywords=[
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
-    python_requires=">=3.6.*",
+    python_requires=">=3.7.*",
     install_requires=[
         "apache-airflow<2.0",
         "click",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 # Map python versions used in build.yml to tox environments
 # This mapping is used by tox-gh-actions
 python =
-    3.6: py36, clean, check, docs, report
     3.7: py37, clean, check, docs, report
     3.8: py38, clean, check, docs, report
 
@@ -17,7 +16,7 @@ envlist =
     clean,
     check,
     docs,
-    py{36,37,38}-{cover,nocov}-{linux,macos,windows},
+    py{37,38}-{cover,nocov}-{linux,macos,windows},
     report
 
 [testenv]
@@ -93,20 +92,6 @@ commands =
 commands = coverage erase
 skip_install = true
 deps = coverage
-
-[testenv:py36-cover-{linux,macos,windows}]
-basepython = {env:TOXPYTHON:python3.6}
-setenv =
-    {[testenv]setenv}
-usedevelop = true
-commands =
-    {posargs:pytest --cov --cov-report=term-missing -vv}
-deps =
-    {[testenv]deps}
-    pytest-cov
-
-[testenv:py36-nocov-{linux,macos,windows}]
-basepython = {env:TOXPYTHON:python3.6}
 
 [testenv:py37-cover-{linux,macos,windows}]
 basepython = {env:TOXPYTHON:python3.7}


### PR DESCRIPTION
Closes #148 Closes #104 
This branch drops the support for Python3.6 which is already not working with some functions. 
It is also removed from tox testing and GitHub actions. 
@gplssm I don't know much about tox or GitHub actions. I ran tox and it worked as I expected, but could you check this again? 