### PR TITLE
Change port of default egon-data-local-database

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,6 +65,8 @@ Changed
   `#145 <https://github.com/openego/eGon-data/issues/145>`_
 * Drop support for Python3.6
   `#148 <https://github.com/openego/eGon-data/issues/148>`_
+* Port of default database egon-data-local-database
+  `#137 <https://github.com/openego/eGon-data/issues/137>`_
 
 Bug fixes
 ---------

--- a/src/egon/data/airflow/docker-compose.yml
+++ b/src/egon/data/airflow/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       context: .
       dockerfile: Dockerfile.postgis
     ports:
-    - "127.0.0.1:54321:5432"
+    - "127.0.0.1:59734:5432"
     environment:
       POSTGRES_DB: egon-data
       POSTGRES_USER: egon


### PR DESCRIPTION
New, randomly chosen port is 59734

Fixes #137 