### PR TITLE
Allow configuring the database name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,13 @@ Added
 * Docker will not be used if there is already a service listening on the
   HOST:PORT combination configured for the database.
 
+* You can now supply values for the command line arguments for
+  ``egon-data`` using a configuration file. If the configuration file
+  doesn't exist, it will be created by ``egon-data`` on it's first run.
+  Note that the configuration file is read from and writte to the
+  directtory in which ``egon-data`` is started, so it's probably best to
+  run ``egon-data`` in a dedicated directory.
+
 * OSM data import as done in open_ego
   `#1 <https://github.com/openego/eGon-data/issues/1>`_
 * Verwaltungsgebiete data import (vg250) more or less done as in open_ego

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Added
 
 * You can now override the default database configuration using command
   line arguments. Look for the switches starting with ``--database`` in
-  ``egon-data --help``. See :pr:`159`
+  ``egon-data --help``. See `PR #159`_ for more details.
 
 * Docker will not be used if there is already a service listening on the
   HOST:PORT combination configured for the database.
@@ -30,7 +30,8 @@ Added
   directtory in which ``egon-data`` is started, so it's probably best to
   run ``egon-data`` in a dedicated directory.
   There's also the new function `egon.data.config.settings` which
-  returns the current configuration settings. See :pr:`159`
+  returns the current configuration settings. See `PR #159`_ for more
+  details.
 
 * OSM data import as done in open_ego
   `#1 <https://github.com/openego/eGon-data/issues/1>`_
@@ -48,6 +49,9 @@ Added
   `#45 <https://github.com/openego/eGon-data/issues/45>`_
 * Option for running workflow in test mode
   `#112 <https://github.com/openego/eGon-data/issues/112>`_
+
+.. _PR #159: https://github.com/openego/eGon-data/pull/159
+
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,7 @@ Added
 * You can now supply values for the command line arguments for
   ``egon-data`` using a configuration file. If the configuration file
   doesn't exist, it will be created by ``egon-data`` on it's first run.
-  Note that the configuration file is read from and writte to the
+  Note that the configuration file is read from and written to the
   directtory in which ``egon-data`` is started, so it's probably best to
   run ``egon-data`` in a dedicated directory.
   There's also the new function `egon.data.config.settings` which

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,8 @@ Added
   Note that the configuration file is read from and writte to the
   directtory in which ``egon-data`` is started, so it's probably best to
   run ``egon-data`` in a dedicated directory.
+  There's also the new function `egon.data.config.settings` which
+  returns the current configuration settings.
 
 * OSM data import as done in open_ego
   `#1 <https://github.com/openego/eGon-data/issues/1>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,11 +16,9 @@ Added
   displays better error messages than Python's built-in function. Use
   this wrapper wenn calling other programs in Airflow tasks.
 
-* You can now override the default database configuration by putting a
-  "local-database.yaml" into the current working directory. Values read
-  from this file will override the default values. You can also generate
-  this file by specifying command line switches to ``egon-data``. Look
-  for the switches starting with ``--database`` in ``egon-data --help``.
+* You can now override the default database configuration using command
+  line arguments. Look for the switches starting with ``--database`` in
+  ``egon-data --help``.
   Note that this is currently only useful if you are using your own
   database and want ``egon-data`` to use that one, because the
   "Docker"ed database's configuration is not affected by these options.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,9 @@ Added
   from this file will override the default values. You can also generate
   this file by specifying command line switches to ``egon-data``. Look
   for the switches starting with ``--database`` in ``egon-data --help``.
+  Note that this is currently only useful if you are using your own
+  database and want ``egon-data`` to use that one, because the
+  "Docker"ed database's configuration is not affected by these options.
 
 * Docker will not be used if there is already a service listening on the
   HOST:PORT combination configured for the database.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Added
 
 * You can now override the default database configuration using command
   line arguments. Look for the switches starting with ``--database`` in
-  ``egon-data --help``.
+  ``egon-data --help``. See :pr:`159`
 
 * Docker will not be used if there is already a service listening on the
   HOST:PORT combination configured for the database.
@@ -30,7 +30,7 @@ Added
   directtory in which ``egon-data`` is started, so it's probably best to
   run ``egon-data`` in a dedicated directory.
   There's also the new function `egon.data.config.settings` which
-  returns the current configuration settings.
+  returns the current configuration settings. See :pr:`159`
 
 * OSM data import as done in open_ego
   `#1 <https://github.com/openego/eGon-data/issues/1>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,9 +19,6 @@ Added
 * You can now override the default database configuration using command
   line arguments. Look for the switches starting with ``--database`` in
   ``egon-data --help``.
-  Note that this is currently only useful if you are using your own
-  database and want ``egon-data`` to use that one, because the
-  "Docker"ed database's configuration is not affected by these options.
 
 * Docker will not be used if there is already a service listening on the
   HOST:PORT combination configured for the database.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -9,6 +9,20 @@ little bit helps, and credit will always be given.
 Extending the data workflow
 ===========================
 
+Where to save (downloaded) data?
+--------------------------------
+
+If a task requires to retrieve some data from external sources which needs to
+be saved locally, please use `CWD` to store the data. This is achieved by using
+
+.. code-block:: python
+
+  from pathlib import Path
+  from urllib.request import urlretrieve
+
+  filepath = Path(".") / "filename.csv"
+  urlretrieve("https://url/to/file", filepath)
+
 
 Adjusting test mode data
 ------------------------

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -72,6 +72,33 @@ Once you got this, run :code:`kill -s INT NUMBER`, substituting
 :code:`egon-data serve` should run without errors again.
 
 
+``[ERROR] Cannot create container for service egon-data-local-database ...``
+----------------------------------------------------------------------------
+
+During building the docker container for the Postgres database, you might
+encounter an error like
+
+.. code-block::
+
+    ERROR: for egon-data-local-database  Cannot create container for service
+    egon-data-local-database: Conflict. The container name
+    "/egon-data-local-database" is already in use by container
+    "1ff9aadef273a76a0acbf850c0da794d0fb28a30e9840f818cca1a47d1181b00".
+    You have to remove (or rename) that container to be able to reuse that name.
+
+If you're ok with deleting the data, stop and remove the container by
+
+.. code-block::
+
+    docker stop egon-data-local-database
+    docker rm -v egon-data-local-database
+
+The container and its data can be kept by renaming the docker container.
+
+.. code-block::
+
+    docker rename egon-data-local-database NEW_CONTAINER_NAME
+
 Other import or incompatible package version errors
 ===================================================
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -78,26 +78,26 @@ Once you got this, run :code:`kill -s INT NUMBER`, substituting
 During building the docker container for the Postgres database, you might
 encounter an error like
 
-.. code-block::
+.. code-block:: none
 
-    ERROR: for egon-data-local-database  Cannot create container for service
-    egon-data-local-database: Conflict. The container name
-    "/egon-data-local-database" is already in use by container
-    "1ff9aadef273a76a0acbf850c0da794d0fb28a30e9840f818cca1a47d1181b00".
-    You have to remove (or rename) that container to be able to reuse that name.
+  ERROR: for egon-data-local-database  Cannot create container for service
+  egon-data-local-database: Conflict. The container name
+  "/egon-data-local-database" is already in use by container
+  "1ff9aadef273a76a0acbf850c0da794d0fb28a30e9840f818cca1a47d1181b00".
+  You have to remove (or rename) that container to be able to reuse that name.
 
 If you're ok with deleting the data, stop and remove the container by
 
 .. code-block::
 
-    docker stop egon-data-local-database
-    docker rm -v egon-data-local-database
+  docker stop egon-data-local-database
+  docker rm -v egon-data-local-database
 
 The container and its data can be kept by renaming the docker container.
 
 .. code-block::
 
-    docker rename egon-data-local-database NEW_CONTAINER_NAME
+  docker rename egon-data-local-database NEW_CONTAINER_NAME
 
 Other import or incompatible package version errors
 ===================================================

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -88,14 +88,14 @@ encounter an error like
 
 If you're ok with deleting the data, stop and remove the container by
 
-.. code-block::
+.. code-block:: none
 
   docker stop egon-data-local-database
   docker rm -v egon-data-local-database
 
 The container and its data can be kept by renaming the docker container.
 
-.. code-block::
+.. code-block:: none
 
   docker rename egon-data-local-database NEW_CONTAINER_NAME
 

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
     install_requires=[
         "apache-airflow<2.0",
         "click",
+        "importlib_resources",
         "oedialect==0.0.8",
         "pyaml",
         "psycopg2",

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,9 @@ setup(
         "psycopg2",
         "sqlalchemy",
         "geopandas",
-        "disaggregator @ git+https://github.com/openego/disaggregator.git@features/pip_install"
+        "disaggregator"
+        "@git+https://github.com/openego/disaggregator.git"
+        "@features/pip_install"
         # eg: 'aspectlib==1.1.1', 'six>=1.7',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
         "apache-airflow<2.0",
         "click",
         "importlib_resources",
+        "loguru",
         "oedialect==0.0.8",
         "pyaml",
         "psycopg2",

--- a/setup.py
+++ b/setup.py
@@ -84,16 +84,16 @@ setup(
     install_requires=[
         "apache-airflow<2.0",
         "click",
+        "disaggregator"
+        "@git+https://github.com/openego/disaggregator.git"
+        "@features/pip_install",
+        "geopandas",
         "importlib_resources",
         "loguru",
         "oedialect==0.0.8",
-        "pyaml",
         "psycopg2",
+        "pyaml",
         "sqlalchemy",
-        "geopandas",
-        "disaggregator"
-        "@git+https://github.com/openego/disaggregator.git"
-        "@features/pip_install"
         # eg: 'aspectlib==1.1.1', 'six>=1.7',
     ],
     extras_require={

--- a/src/egon/data/__init__.py
+++ b/src/egon/data/__init__.py
@@ -1,1 +1,19 @@
+from textwrap import wrap
+
+from loguru import logger
+import click
+
 __version__ = "0.0.0"
+
+
+def echo(message):
+    prefix, message = message.split(" - ")
+    lines = message.split("\n")
+    width = min(72, click.get_terminal_size()[0])
+    wraps = ["\n".join(wrap(line, width)) for line in lines]
+    message = "\n".join([prefix] + wraps)
+    click.echo(message, err=True)
+
+
+logger.remove()
+logger.add(echo, colorize=True)

--- a/src/egon/data/airflow/airflow.cfg
+++ b/src/egon/data/airflow/airflow.cfg
@@ -66,7 +66,7 @@ default_timezone = utc
 
 # The executor class that airflow should use. Choices include
 # SequentialExecutor, LocalExecutor, CeleryExecutor, DaskExecutor, KubernetesExecutor
-executor = SequentialExecutor
+executor = LocalExecutor
 
 # The SqlAlchemy connection string to the metadata database.
 # SqlAlchemy supports many different database engine, more information

--- a/src/egon/data/airflow/airflow.cfg
+++ b/src/egon/data/airflow/airflow.cfg
@@ -122,7 +122,7 @@ sql_alchemy_schema =
 parallelism = 32
 
 # The number of task instances allowed to run concurrently by the scheduler
-dag_concurrency = 16
+dag_concurrency = {--jobs}
 
 # Are DAGs paused by default at creation
 dags_are_paused_at_creation = False

--- a/src/egon/data/airflow/airflow.cfg
+++ b/src/egon/data/airflow/airflow.cfg
@@ -1,11 +1,11 @@
 [core]
 # The folder where your airflow pipelines live, most likely a
 # subfolder in a code repository. This path must be absolute.
-# dags_folder = ${AIRFLOW_HOME}
+dags_folder = {dags}
 
 # The folder where airflow should store its log files
 # This path must be absolute
-# base_log_folder = ${AIRFLOW_HOME}/logs
+# base_log_folder = ${{AIRFLOW_HOME}}/logs
 
 # Airflow can store logs remotely in AWS S3, Google Cloud Storage or Elastic Search.
 # Set this to True if you want to enable remote logging.
@@ -34,17 +34,17 @@ logging_config_class =
 colored_console_log = True
 
 # Log format for when Colored logs is enabled
-colored_log_format = [%%(blue)s%%(asctime)s%%(reset)s] {%%(blue)s%%(filename)s:%%(reset)s%%(lineno)d} %%(log_color)s%%(levelname)s%%(reset)s - %%(log_color)s%%(message)s%%(reset)s
+colored_log_format = [%%(blue)s%%(asctime)s%%(reset)s] {{%%(blue)s%%(filename)s:%%(reset)s%%(lineno)d}} %%(log_color)s%%(levelname)s%%(reset)s - %%(log_color)s%%(message)s%%(reset)s
 colored_formatter_class = airflow.utils.log.colored_log.CustomTTYColoredFormatter
 
 # Format of Log line
-log_format = [%%(asctime)s] {%%(filename)s:%%(lineno)d} %%(levelname)s - %%(message)s
+log_format = [%%(asctime)s] {{%%(filename)s:%%(lineno)d}} %%(levelname)s - %%(message)s
 simple_log_format = %%(asctime)s %%(levelname)s - %%(message)s
 
 # Log filename format
-log_filename_template = {{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log
-log_processor_filename_template = {{ filename }}.log
-# dag_processor_manager_log_location = ${AIRFLOW_HOME}/logs/dag_processor_manager/dag_processor_manager.log
+log_filename_template = {{{{ ti.dag_id }}}}/{{{{ ti.task_id }}}}/{{{{ ts }}}}/{{{{ try_number }}}}.log
+log_processor_filename_template = {{{{ filename }}}}.log
+# dag_processor_manager_log_location = ${{AIRFLOW_HOME}}/logs/dag_processor_manager/dag_processor_manager.log
 
 # Name of handler to read task instance logs.
 # Default to use task handler.
@@ -71,7 +71,7 @@ executor = SequentialExecutor
 # The SqlAlchemy connection string to the metadata database.
 # SqlAlchemy supports many different database engine, more information
 # their website
-# sql_alchemy_conn = sqlite:///${AIRFLOW_HOME}/airflow.db
+sql_alchemy_conn = postgresql+psycopg2://{--database-user}:{--database-password}@{--database-host}:{--database-port}/{--airflow-database-name}
 
 # The encoding for the databases
 sql_engine_encoding = utf-8
@@ -141,7 +141,7 @@ load_examples = False
 load_default_connections = True
 
 # Where your Airflow plugins are stored
-# plugins_folder = ${AIRFLOW_HOME}/plugins
+# plugins_folder = ${{AIRFLOW_HOME}}/plugins
 
 # Secret key to save connection passwords in the db
 fernet_key =
@@ -237,7 +237,7 @@ backend =
 # The backend_kwargs param is loaded into a dictionary and passed to __init__ of secrets backend class.
 # See documentation for the secrets backend you are using. JSON is expected.
 # Example for AWS Systems Manager ParameterStore:
-# ``{"connections_prefix": "/airflow/connections", "profile_name": "default"}``
+# ``{{"connections_prefix": "/airflow/connections", "profile_name": "default"}}``
 backend_kwargs =
 
 [cli]
@@ -332,7 +332,7 @@ reload_on_plugin_change = False
 
 # Secret key used to run your flask app
 # It should be as random as possible
-secret_key = {SECRET_KEY}
+secret_key = {{SECRET_KEY}}
 
 # Number of workers to run the Gunicorn web server
 workers = 4
@@ -631,7 +631,7 @@ print_stats_interval = 30
 # ago (in seconds), scheduler is considered unhealthy.
 # This is used by the health check in the "/health" endpoint
 scheduler_health_check_threshold = 30
-# child_process_log_directory = ${AIRFLOW_HOME}/logs/scheduler
+# child_process_log_directory = ${{AIRFLOW_HOME}}/logs/scheduler
 
 # Local task jobs periodically heartbeat to the DB. If the job has
 # not heartbeat in this many seconds, the scheduler will mark the
@@ -765,7 +765,7 @@ hide_sensitive_variable_fields = True
 host =
 
 # Format of the log_id, which is used to query for a given tasks logs
-log_id_template = {dag_id}-{task_id}-{execution_date}-{try_number}
+log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
 
 # Used to mark the end of a log stream for a task
 end_of_log_mark = end_of_log
@@ -900,7 +900,7 @@ git_sync_root = /git
 git_sync_dest = repo
 
 # Mount point of the volume if git-sync is being used.
-# i.e. ${AIRFLOW_HOME}/dags
+# i.e. ${{AIRFLOW_HOME}}/dags
 git_dags_folder_mount_point =
 
 # To get Git-sync SSH authentication set up follow this format
@@ -1014,7 +1014,7 @@ kube_client_request_args =
 # This should be an object and can contain any of the options listed in the ``v1DeleteOptions``
 # class defined here:
 # https://github.com/kubernetes-client/python/blob/41f11a09995efcd0142e25946adc7591431bfb2f/kubernetes/client/models/v1_delete_options.py#L19
-# Example: delete_option_kwargs = {"grace_period_seconds": 10}
+# Example: delete_option_kwargs = {{"grace_period_seconds": 10}}
 delete_option_kwargs =
 
 # Specifies the uid to run the first process of the worker pods containers as

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -25,8 +25,11 @@ with airflow.DAG(
     description="The eGo^N data processing DAG.",
     default_args={"start_date": days_ago(1)},
     template_searchpath=[
-        os.path.abspath(os.path.join(os.path.dirname(
-            __file__), '..', '..', 'processing', 'vg250'))
+        os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__), "..", "..", "processing", "vg250"
+            )
+        )
     ],
     is_paused_upon_creation=False,
     schedule_interval=None,
@@ -58,7 +61,8 @@ with airflow.DAG(
         python_callable=import_vg250.download_vg250_files,
     )
     vg250_import = PythonOperator(
-        task_id="import-vg250", python_callable=import_vg250.to_postgres,
+        task_id="import-vg250",
+        python_callable=import_vg250.to_postgres,
     )
 
     vg250_nuts_mview = PostgresOperator(
@@ -83,17 +87,17 @@ with airflow.DAG(
     # Zensus import
     zensus_download_population = PythonOperator(
         task_id="download-zensus-population",
-        python_callable=import_zs.download_zensus_pop
+        python_callable=import_zs.download_zensus_pop,
     )
 
     zensus_download_misc = PythonOperator(
         task_id="download-zensus-misc",
-        python_callable=import_zs.download_zensus_misc
+        python_callable=import_zs.download_zensus_misc,
     )
 
     zensus_tables = PythonOperator(
         task_id="create-zensus-tables",
-        python_callable=import_zs.create_zensus_tables
+        python_callable=import_zs.create_zensus_tables,
     )
 
     population_import = PythonOperator(
@@ -120,35 +124,35 @@ with airflow.DAG(
     # Power plant setup
     power_plant_tables = PythonOperator(
         task_id="create-power-plant-tables",
-        python_callable=power_plants.create_tables
+        python_callable=power_plants.create_tables,
     )
     setup >> power_plant_tables
-
 
     # NEP data import
     create_tables = PythonOperator(
         task_id="create-scenario-tables",
-        python_callable=nep_input.create_scenario_input_tables)
+        python_callable=nep_input.create_scenario_input_tables,
+    )
 
     nep_insert_data = PythonOperator(
         task_id="insert-nep-data",
-        python_callable=nep_input.insert_data_nep,)
+        python_callable=nep_input.insert_data_nep,
+    )
 
     setup >> create_tables >> nep_insert_data
     vg250_clean_and_prepare >> nep_insert_data
     population_import >> nep_insert_data
 
-
     # setting etrago input tables
     etrago_input_data = PythonOperator(
-        task_id = "setting-etrago-input-tables",
-        python_callable = etrago.create_tables
+        task_id="setting-etrago-input-tables",
+        python_callable=etrago.create_tables,
     )
     setup >> etrago_input_data
 
     # Retrieve MaStR data
     retrieve_mastr_data = PythonOperator(
         task_id="retrieve_mastr_data",
-        python_callable=mastr.download_mastr_data
+        python_callable=mastr.download_mastr_data,
     )
     setup >> retrieve_mastr_data

--- a/src/egon/data/airflow/docker-compose.yml
+++ b/src/egon/data/airflow/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   egon-data-local-database-service:
     image: postgres:12-postgis
-    container_name: egon-data-local-database-container
+    container_name: {--docker-container-name}
     restart: unless-stopped
     build:
       context: .

--- a/src/egon/data/airflow/docker-compose.yml
+++ b/src/egon/data/airflow/docker-compose.yml
@@ -10,9 +10,8 @@ services:
     ports:
     - "{--database-host}:{--database-port}:5432"
     environment:
-      POSTGRES_DB: {--database-name}
+      POSTGRES_DB: {--airflow-database-name}
       POSTGRES_USER: {--database-user}
       POSTGRES_PASSWORD: {--database-password}
     volumes:
     - ./var/lib/postgresql/data:/var/lib/postgresql/data
-    - {airflow}/entrypoints:/docker-entrypoint-initdb.d/

--- a/src/egon/data/airflow/docker-compose.yml
+++ b/src/egon/data/airflow/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3'
 services:
-  egon-data-local-database:
+  egon-data-local-database-service:
     image: postgres:12-postgis
-    container_name: egon-data-local-database
+    container_name: egon-data-local-database-container
     restart: unless-stopped
     build:
       context: .
@@ -14,6 +14,6 @@ services:
       POSTGRES_USER: {--database-user}
       POSTGRES_PASSWORD: {--database-password}
     volumes:
-    - egon-data-database-volume:/var/lib/postgresql/data
+    - egon-data-local-database-volume:/var/lib/postgresql/data
 volumes:
-  egon-data-database-volume:
+  egon-data-local-database-volume:

--- a/src/egon/data/airflow/docker-compose.yml
+++ b/src/egon/data/airflow/docker-compose.yml
@@ -6,13 +6,13 @@ services:
     restart: unless-stopped
     build:
       context: .
-      dockerfile: Dockerfile.postgis
+      dockerfile: {airflow}/Dockerfile.postgis
     ports:
-    - "127.0.0.1:54321:5432"
+    - "{--database-host}:{--database-port}:5432"
     environment:
-      POSTGRES_DB: egon-data
-      POSTGRES_USER: egon
-      POSTGRES_PASSWORD: data
+      POSTGRES_DB: {--database-name}
+      POSTGRES_USER: {--database-user}
+      POSTGRES_PASSWORD: {--database-password}
     volumes:
-    - $HOME/docker/volumes/postgres/egon-data:/var/lib/postgresql/data
-    - ./entrypoints:/docker-entrypoint-initdb.d/
+    - ./var/lib/postgresql/data:/var/lib/postgresql/data
+    - {airflow}/entrypoints:/docker-entrypoint-initdb.d/

--- a/src/egon/data/airflow/docker-compose.yml
+++ b/src/egon/data/airflow/docker-compose.yml
@@ -14,4 +14,6 @@ services:
       POSTGRES_USER: {--database-user}
       POSTGRES_PASSWORD: {--database-password}
     volumes:
-    - ./var/lib/postgresql/data:/var/lib/postgresql/data
+    - egon-data-database-volume:/var/lib/postgresql/data
+volumes:
+  egon-data-database-volume:

--- a/src/egon/data/airflow/entrypoints/create_postgis_extension.sql
+++ b/src/egon/data/airflow/entrypoints/create_postgis_extension.sql
@@ -1,2 +1,0 @@
-CREATE EXTENSION hstore;
-CREATE EXTENSION postgis;

--- a/src/egon/data/airflow/tasks.py
+++ b/src/egon/data/airflow/tasks.py
@@ -1,17 +1,9 @@
-from pathlib import Path
-import socket
-
-from egon.data.db import credentials
-import egon.data.subprocess as subprocess
+from egon.data import db
 
 
 def initdb():
     """ Initialize the local database used for data processing. """
-    db = credentials()
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        code = s.connect_ex((db["HOST"], int(db["PORT"])))
-    if code != 0:
-        subprocess.run(
-            ["docker-compose", "up", "-d", "--build"],
-            cwd=str((Path(".") / "docker").absolute()),
-        )
+    engine = db.engine()
+    with engine.connect().execution_options(autocommit=True) as connection:
+        for extension in ["hstore", "postgis", "postgis_raster"]:
+            connection.execute(f"CREATE EXTENSION IF NOT EXISTS {extension}")

--- a/src/egon/data/airflow/tasks.py
+++ b/src/egon/data/airflow/tasks.py
@@ -1,4 +1,4 @@
-import os.path
+from pathlib import Path
 import socket
 
 from egon.data.db import credentials
@@ -13,5 +13,5 @@ def initdb():
     if code != 0:
         subprocess.run(
             ["docker-compose", "up", "-d", "--build"],
-            cwd=os.path.dirname(__file__),
+            cwd=str((Path(".") / "docker").absolute()),
         )

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -118,6 +118,17 @@ def serve(context):
     show_default=True,
 )
 @click.option(
+    "--dataset-boundary",
+    "--clip-datasets-to",
+    type=click.Choice(["Everything", "Schleswig-Holstein"]),
+    default="Everything",
+    help=(
+        "Choose to limit the processed data to one of the available"
+        " built-in boundaries."
+    ),
+    show_default=True,
+)
+@click.option(
     "--jobs",
     default=1,
     metavar="N",

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -90,7 +90,7 @@ def serve(context):
 )
 @click.option(
     "--database-port",
-    default="54321",
+    default="59734",
     metavar="PORT",
     help=("Specify the port on which the local DBMS is listening."),
     show_default=True,

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -14,6 +14,8 @@ Why does this file exist, and why not put this in __main__?
 
   Also see (1) from http://click.pocoo.org/5/setuptools/#setuptools-integration
 """
+from __future__ import annotations
+
 from multiprocessing import Process
 import os
 import os.path
@@ -24,6 +26,44 @@ import yaml
 
 import egon.data
 import egon.data.airflow
+
+
+# TODO: Convert these two functions to an `Enum`, because `Enum`s already
+#       implement bidirectional lookup.
+def names2flags(command: click.Command) -> dict[str, str]:
+    """
+    Returns a dictionary with option names as keys and flags as values.
+
+    The flag representing a command line option is usually a string
+    starting with hyphens, i.e. it is not a legal Python identifier. In
+    order to use the option as a regular argument in a Python function,
+    these flags are converted to legal Python identifiers by `Click`.
+
+    Given a `click.Command` this funtion returns a dictionary containing
+    option names as keys and flags as values. Note that, while there can
+    be multiple flags acting as synonyms for the same option, this
+    implementation treats the first option name it finds for a flag as
+    the "canonical" flag and thus contains only a single option name for
+    each flag.
+    """
+    return {p.name: p.opts[0] for p in command.params}
+
+
+def flags2names(command: click.Command) -> dict[str, str]:
+    """
+    Returns a dictionary with option flags as keys and names as values.
+
+    The `name` of an option flag is the result of converting the command
+    line flag, i.e. the string starting with hyphens, to a legal Python
+    identifier, which is what appears in the actual argument list of the
+    function implementing a command.
+
+    This mapping returned by this function is essentially the result of
+    reversing the roles of keys and values in `names2flags(command)`
+    except that multiple command line flags can map to the same option
+    name, whereas the `flags2names` is injective by construction.
+    """
+    return {flag: p.name for p in command.params for flag in p.opts}
 
 
 @click.command(

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -176,7 +176,7 @@ def egon_data(context, **kwargs):
     Last but not least, if you're using the default behaviour of setting
     up the database in a Docker container, the working directory will
     also contain a directory called "docker", containing the database
-    data as well as other volumes used by the dockered database.
+    data as well as other volumes used by the "Docker"ed database.
 
     """
 

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -115,6 +115,17 @@ def serve(context):
     help=("Specify the password used to access the local database."),
     show_default=True,
 )
+@click.option(
+    "--jobs",
+    default=16,
+    metavar="N",
+    help=(
+        "Spawn at maximum N tasks in parallel. Remember that in addition"
+        " to that, there's always the scheduler and probably the server"
+        " running."
+    ),
+    show_default=True,
+)
 @click.version_option(version=egon.data.__version__)
 @click.pass_context
 def egon_data(context, **kwargs):

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -164,7 +164,7 @@ def egon_data(context, **kwargs):
     commands (e.g. `serve`).
 
     Whenever `egon-data` is executed, it searches for the configuration file
-    "egon-data.configuration.yaml" in PWD. If that file doesn't exist,
+    "egon-data.configuration.yaml" in CWD. If that file doesn't exist,
     `egon-data` will create one, containing the command line parameters
     supplied, as well as the defaults for those switches for which no value
     was supplied.

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -117,7 +117,7 @@ def serve(context):
 )
 @click.option(
     "--jobs",
-    default=16,
+    default=1,
     metavar="N",
     help=(
         "Spawn at maximum N tasks in parallel. Remember that in addition"

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -132,9 +132,15 @@ def egon_data(context, **kwargs):
     """Run and control the eGo^n data processing pipeline.
 
     It is recommended to create a dedicated working directory in which
-    to run `egon-data` because `egon-data` because `egon-data` will use
+    to run `egon-data` because `egon-data` will use
     it's working directory to store configuration files and other data
     generated during a workflow run.
+
+    It is also recommended to use seperate directories for production
+    and test mode. 
+    In test mode, you should also use a different database.
+    This will be created and used by typing e.g.
+    `egon-data --database-name 'test-egon-data' serve`
 
     You can configure `egon-data` by putting a file named
     "egon-data.configuration.yaml" into the directory from which you are

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -14,8 +14,6 @@ Why does this file exist, and why not put this in __main__?
 
   Also see (1) from http://click.pocoo.org/5/setuptools/#setuptools-integration
 """
-from __future__ import annotations
-
 from multiprocessing import Process
 import os
 import os.path
@@ -26,44 +24,6 @@ import yaml
 
 import egon.data
 import egon.data.airflow
-
-
-# TODO: Convert these two functions to an `Enum`, because `Enum`s already
-#       implement bidirectional lookup.
-def names2flags(command: click.Command) -> dict[str, str]:
-    """
-    Returns a dictionary with option names as keys and flags as values.
-
-    The flag representing a command line option is usually a string
-    starting with hyphens, i.e. it is not a legal Python identifier. In
-    order to use the option as a regular argument in a Python function,
-    these flags are converted to legal Python identifiers by `Click`.
-
-    Given a `click.Command` this funtion returns a dictionary containing
-    option names as keys and flags as values. Note that, while there can
-    be multiple flags acting as synonyms for the same option, this
-    implementation treats the first option name it finds for a flag as
-    the "canonical" flag and thus contains only a single option name for
-    each flag.
-    """
-    return {p.name: p.opts[0] for p in command.params}
-
-
-def flags2names(command: click.Command) -> dict[str, str]:
-    """
-    Returns a dictionary with option flags as keys and names as values.
-
-    The `name` of an option flag is the result of converting the command
-    line flag, i.e. the string starting with hyphens, to a legal Python
-    identifier, which is what appears in the actual argument list of the
-    function implementing a command.
-
-    This mapping returned by this function is essentially the result of
-    reversing the roles of keys and values in `names2flags(command)`
-    except that multiple command line flags can map to the same option
-    name, whereas the `flags2names` is injective by construction.
-    """
-    return {flag: p.name for p in command.params for flag in p.opts}
 
 
 @click.command(

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -148,7 +148,7 @@ def egon_data(context, **kwargs):
     to run `egon-data` because `egon-data` will use
     it's working directory to store configuration files and other data
     generated during a workflow run.
-    Goto to a location where you want to store eGon-data project data and
+    Go to to a location where you want to store eGon-data project data and
     create a new directory via:
 
         `mkdir egon-data-production && cd egon-data-production`

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -44,7 +44,7 @@ def airflow(context):
     subprocess.run(["airflow"] + context.args)
 
 
-@click.command()
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.pass_context
 def serve(context):
     """Start the airflow webapp controlling the egon-data pipeline.
@@ -65,7 +65,9 @@ def serve(context):
     subprocess.run(["airflow", "webserver"])
 
 
-@click.group(name="egon-data")
+@click.group(
+    name="egon-data", context_settings={"help_option_names": ["-h", "--help"]}
+)
 @click.option(
     "--airflow-database-name",
     default="airflow",

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -149,7 +149,7 @@ def egon_data(context, **kwargs):
     it's working directory to store configuration files and other data
     generated during a workflow run.
     Goto to a location where you want to store eGon-data project data and
-    create a new directy by (feel free to choose a different directory name):
+    create a new directory by (feel free to choose a different directory name):
 
     `mkdir egon-data-production && cd egon-data-production`
 

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -147,21 +147,15 @@ def egon_data(context, **kwargs):
     data as well as other volumes used by the dockered database.
 
     """
+
+    def options(value, check=None):
+        check = value if check is None else check
+        flags = {p.opts[0]: value(p) for p in egon_data.params if check(p)}
+        return {"egon-data": flags}
+
     options = {
-        "cli": {
-            "egon-data": {
-                option.opts[0]: kwargs[option.name]
-                for option in egon_data.params
-                if option.name in kwargs
-            }
-        },
-        "defaults": {
-            "egon-data": {
-                option.opts[0]: option.default
-                for option in egon_data.params
-                if option.default
-            }
-        },
+        "cli": options(lambda o: kwargs[o.name], lambda o: o.name in kwargs),
+        "defaults": options(lambda o: o.default),
     }
 
     if not config.paths()[0].exists():

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -284,4 +284,7 @@ def main():
     try:
         egon_data.main(sys.argv[1:])
     finally:
-        config.paths(pid="current")[0].unlink(missing_ok=True)
+        try:
+            config.paths(pid="current")[0].unlink()
+        except FileNotFoundError:
+            pass

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -163,6 +163,13 @@ def egon_data(context, **kwargs):
     It is important that options (e.g. `--database-name`) are placed before
     commands (e.g. `serve`).
 
+    For using a smaller dataset in the test mode, use the option
+    `--dataset-boundary`. The complete command for starting Aiflow in test
+    mode with using a separate database is
+
+        `egon-data --database-name 'test-egon-data' --dataset-boundary
+        'Schleswig-Holstein' serve`
+
     Whenever `egon-data` is executed, it searches for the configuration file
     "egon-data.configuration.yaml" in CWD. If that file doesn't exist,
     `egon-data` will create one, containing the command line parameters

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -171,15 +171,8 @@ def egon_data(context, **kwargs):
             f.write(yaml.safe_dump(options))
 
     os.environ["AIRFLOW_HOME"] = os.path.dirname(egon.data.airflow.__file__)
-    translations = {
-        "database_name": "POSTGRES_DB",
-        "database_password": "POSTGRES_PASSWORD",
-        "database_host": "HOST",
-        "database_port": "PORT",
-        "database_user": "POSTGRES_USER",
-    }
     database_configuration = {
-        translations[k]: kwargs[k]
+        k: kwargs[k]
         for k in kwargs
         if "database" in k
         if kwargs[k] is not None

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -171,15 +171,6 @@ def egon_data(context, **kwargs):
             f.write(yaml.safe_dump(options))
 
     os.environ["AIRFLOW_HOME"] = os.path.dirname(egon.data.airflow.__file__)
-    database_configuration = {
-        k: kwargs[k]
-        for k in kwargs
-        if "database" in k
-        if kwargs[k] is not None
-    }
-    if database_configuration:
-        with open("local-database.yaml", "w") as configuration:
-            configuration.write(yaml.safe_dump(database_configuration))
 
 
 def main():

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -142,7 +142,9 @@ def egon_data(context, **kwargs):
 
     if not config.paths()[0].exists():
         with open(config.paths()[0], "w") as f:
-            f.write(yaml.safe_dump(options["defaults"]))
+            f.write(
+                yaml.safe_dump(dict(options["defaults"], **options["cli"]))
+            )
 
     if len(config.paths(pid="*")) > 1:
         message = (

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -135,18 +135,29 @@ def egon_data(context, **kwargs):
     to run `egon-data` because `egon-data` will use
     it's working directory to store configuration files and other data
     generated during a workflow run.
+    Goto to a location where you want to store eGon-data project data and
+    create a new directy by (feel free to choose a different directory name):
 
-    It is also recommended to use seperate directories for production
+    `mkdir egon-data-production && cd egon-data-production`
+
+    It is also recommended to use separate directories for production
     and test mode. 
     In test mode, you should also use a different database.
     This will be created and used by typing e.g.
+
     `egon-data --database-name 'test-egon-data' serve`
 
-    You can configure `egon-data` by putting a file named
-    "egon-data.configuration.yaml" into the directory from which you are
-    running `egon-data`. If that file doesn't exist, `egon-data` will
-    create one, containing the command line parameters supplied, as well
-    as the defaults for those switches for which no value was supplied.
+    Whenever `egon-data` is executed, it searches for the configuration file
+    "egon-data.configuration.yaml" in PWD. If that file doesn't exist,
+    `egon-data` will create one, containing the command line parameters
+    supplied, as well as the defaults for those switches for which no value
+    was supplied.
+    This means, run the above command that specifies a custom database once.
+    Afterwards, it's sufficient to execute `egon-data serve` in the same
+    directory and the same configuration will be used.
+    You can also edit the configuration the file
+    "egon-data.configuration.yaml" manually.
+
     Last but not least, if you're using the default behaviour of setting
     up the database in a Docker container, the working directory will
     also contain a directory called "docker", containing the database

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -139,6 +139,18 @@ def serve(context):
     ),
     show_default=True,
 )
+@click.option(
+    "--docker-container-name",
+    default="egon-data-local-database-container",
+    metavar="NAME",
+    help=(
+        "The name of the Docker container containing the local database."
+        " You usually can stick to the default, unless you run into errors"
+        " due to clashing names and don't want to delete or rename your old"
+        " containers."
+    ),
+    show_default=True,
+)
 @click.version_option(version=egon.data.__version__)
 @click.pass_context
 def egon_data(context, **kwargs):

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -173,7 +173,14 @@ def egon_data(context, **kwargs):
     else:  # len(config.paths(pid="*")) == 0, so need to create one.
         with open(config.paths()[0]) as f:
             options["file"] = yaml.load(f, Loader=yaml.SafeLoader)
-        options = dict(options.get("file", {}), **options["cli"])
+        options = dict(
+            options.get("file", {}),
+            **{
+                flag: options["cli"][flag]
+                for flag in options["cli"]
+                if options["cli"][flag] != options["defaults"][flag]
+            },
+        )
         with open(config.paths(pid="current")[0], "w") as f:
             f.write(yaml.safe_dump(options))
 

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -151,7 +151,7 @@ def egon_data(context, **kwargs):
     Goto to a location where you want to store eGon-data project data and
     create a new directory via:
 
-    `mkdir egon-data-production && cd egon-data-production`
+        `mkdir egon-data-production && cd egon-data-production`
 
     Of course you are free to choose a different directory name.
 
@@ -160,7 +160,7 @@ def egon_data(context, **kwargs):
     In test mode, you should also use a different database.
     This will be created and used by typing e.g.
 
-    `egon-data --database-name 'test-egon-data' serve`
+        `egon-data --database-name 'test-egon-data' serve`
 
     It is important that options (e.g. `--database-name`) are placed before
     commands (e.g. `serve`).

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -149,9 +149,11 @@ def egon_data(context, **kwargs):
     it's working directory to store configuration files and other data
     generated during a workflow run.
     Goto to a location where you want to store eGon-data project data and
-    create a new directory by (feel free to choose a different directory name):
+    create a new directory via:
 
     `mkdir egon-data-production && cd egon-data-production`
+
+    Of course you are free to choose a different directory name.
 
     It is also recommended to use separate directories for production
     and test mode.

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -75,17 +75,17 @@ def serve(context):
     show_default=True,
 )
 @click.option(
+    "--database-user",
+    default="egon",
+    metavar="USERNAME",
+    help=("Specify the user used to access the local database."),
+    show_default=True,
+)
+@click.option(
     "--database-host",
     default="127.0.0.1",
     metavar="HOST",
     help=("Specify the host on which the local database is running."),
-    show_default=True,
-)
-@click.option(
-    "--database-password",
-    default="data",
-    metavar="PW",
-    help=("Specify the password used to access the local database."),
     show_default=True,
 )
 @click.option(
@@ -96,10 +96,10 @@ def serve(context):
     show_default=True,
 )
 @click.option(
-    "--database-user",
-    default="egon",
-    metavar="USERNAME",
-    help=("Specify the user used to access the local database."),
+    "--database-password",
+    default="data",
+    metavar="PW",
+    help=("Specify the password used to access the local database."),
     show_default=True,
 )
 @click.version_option(version=egon.data.__version__)

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -147,6 +147,9 @@ def egon_data(context, **kwargs):
 
     `egon-data --database-name 'test-egon-data' serve`
 
+    It is important that options (e.g. `--database-name`) are placed before
+    commands (e.g. `serve`).
+
     Whenever `egon-data` is executed, it searches for the configuration file
     "egon-data.configuration.yaml" in PWD. If that file doesn't exist,
     `egon-data` will create one, containing the command line parameters

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -143,7 +143,7 @@ def egon_data(context, **kwargs):
     `mkdir egon-data-production && cd egon-data-production`
 
     It is also recommended to use separate directories for production
-    and test mode. 
+    and test mode.
     In test mode, you should also use a different database.
     This will be created and used by typing e.g.
 

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -18,6 +18,7 @@ from multiprocessing import Process
 import os
 import os.path
 import subprocess
+import sys
 
 import click
 import yaml
@@ -56,7 +57,7 @@ def serve(context):
     subprocess.run(["airflow", "webserver"])
 
 
-@click.group()
+@click.group(name="egon-data")
 @click.option(
     "--database-name",
     "--database",
@@ -90,7 +91,7 @@ def serve(context):
 )
 @click.version_option(version=egon.data.__version__)
 @click.pass_context
-def main(context, **kwargs):
+def egon_data(context, **kwargs):
     os.environ["AIRFLOW_HOME"] = os.path.dirname(egon.data.airflow.__file__)
     translations = {
         "database_name": "POSTGRES_DB",
@@ -110,6 +111,7 @@ def main(context, **kwargs):
             configuration.write(yaml.safe_dump(database_configuration))
 
 
-main.name = "egon-data"
-main.add_command(airflow)
-main.add_command(serve)
+def main():
+    egon_data.add_command(airflow)
+    egon_data.add_command(serve)
+    egon_data.main(sys.argv[1:])

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -279,6 +279,7 @@ def egon_data(context, **kwargs):
         Path(".") / "airflow" / "airflow.cfg",
         inserts=options,
         dags=str(resources.files(egon.data.airflow).absolute()),
+        update=False,
     )
     render(
         "docker-compose.yml",

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -144,21 +144,19 @@ def serve(context):
 def egon_data(context, **kwargs):
     """Run and control the eGo^n data processing pipeline.
 
-    It is recommended to create a dedicated working directory in which
-    to run `egon-data` because `egon-data` will use
-    it's working directory to store configuration files and other data
-    generated during a workflow run.
-    Go to to a location where you want to store eGon-data project data and
-    create a new directory via:
+    It is recommended to create a dedicated working directory in which to
+    run `egon-data` because `egon-data` will use it's working directory to
+    store configuration files and other data generated during a workflow
+    run. Go to to a location where you want to store eGon-data project data
+    and create a new directory via:
 
         `mkdir egon-data-production && cd egon-data-production`
 
     Of course you are free to choose a different directory name.
 
-    It is also recommended to use separate directories for production
-    and test mode.
-    In test mode, you should also use a different database.
-    This will be created and used by typing e.g.
+    It is also recommended to use separate directories for production and
+    test mode. In test mode, you should also use a different database. This
+    will be created and used by typing e.g.:
 
         `egon-data --database-name 'test-egon-data' serve`
 
@@ -172,9 +170,8 @@ def egon_data(context, **kwargs):
     was supplied.
     This means, run the above command that specifies a custom database once.
     Afterwards, it's sufficient to execute `egon-data serve` in the same
-    directory and the same configuration will be used.
-    You can also edit the configuration the file
-    "egon-data.configuration.yaml" manually.
+    directory and the same configuration will be used. You can also edit the
+    configuration the file "egon-data.configuration.yaml" manually.
 
     Last but not least, if you're using the default behaviour of setting
     up the database in a Docker container, the working directory will

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -119,7 +119,6 @@ def serve(context):
 )
 @click.option(
     "--dataset-boundary",
-    "--clip-datasets-to",
     type=click.Choice(["Everything", "Schleswig-Holstein"]),
     default="Everything",
     help=(

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -170,6 +170,9 @@ def egon_data(context, **kwargs):
                 yaml.safe_dump(dict(options["defaults"], **options["cli"]))
             )
 
+    # Alternatively:
+    #   `if config.paths(pid="*") != [config.paths(pid="current")]:`
+    #   or compare file contents.
     if len(config.paths(pid="*")) > 1:
         logger.error(
             "Found more than one configuration file belonging to a"

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -17,11 +17,11 @@ Why does this file exist, and why not put this in __main__?
 from multiprocessing import Process
 from textwrap import wrap
 import os
-import os.path
 import subprocess
 import sys
 
 import click
+import importlib_resources as resources
 import yaml
 
 import egon.data
@@ -170,7 +170,7 @@ def egon_data(context, **kwargs):
         with open(config.paths(pid="current")[0], "w") as f:
             f.write(yaml.safe_dump(options))
 
-    os.environ["AIRFLOW_HOME"] = os.path.dirname(egon.data.airflow.__file__)
+    os.environ["AIRFLOW_HOME"] = str(resources.files(egon.data.airflow))
 
 
 def main():

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -58,9 +58,15 @@ def serve(context):
 
 @click.group()
 @click.option(
+    "--database-name",
     "--database",
     metavar="DB",
-    help=("Specify the name of the local database."),
+    help=(
+        "Specify the name of the local database.\n\n\b"
+        ' Note: "--database" is deprecated and will be removed in the'
+        " future. Please use the longer but consistent"
+        ' "--database-name".'
+    ),
 )
 @click.option(
     "--database-host",
@@ -87,7 +93,7 @@ def serve(context):
 def main(context, **kwargs):
     os.environ["AIRFLOW_HOME"] = os.path.dirname(egon.data.airflow.__file__)
     translations = {
-        "database": "POSTGRES_DB",
+        "database_name": "POSTGRES_DB",
         "database_password": "POSTGRES_PASSWORD",
         "database_host": "HOST",
         "database_port": "PORT",

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -211,6 +211,11 @@ def egon_data(context, **kwargs):
     if not config.paths()[0].exists():
         with open(config.paths()[0], "w") as f:
             f.write(yaml.safe_dump(combined))
+    else:
+        with open(config.paths()[0], "r") as f:
+            stored = yaml.safe_load(f)
+        with open(config.paths()[0], "w") as f:
+            f.write(yaml.safe_dump(merge(combined, stored)))
 
     # Alternatively:
     #   `if config.paths(pid="*") != [config.paths(pid="current")]:`

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -16,7 +16,6 @@ Why does this file exist, and why not put this in __main__?
 """
 from multiprocessing import Process
 from pathlib import Path
-from textwrap import wrap
 import os
 import socket
 import subprocess
@@ -30,6 +29,7 @@ import click
 import importlib_resources as resources
 import yaml
 
+from egon.data import logger
 import egon.data
 import egon.data.airflow
 import egon.data.config as config
@@ -171,26 +171,18 @@ def egon_data(context, **kwargs):
             )
 
     if len(config.paths(pid="*")) > 1:
-        message = (
+        logger.error(
             "Found more than one configuration file belonging to a"
             " specific `egon-data` process. Unable to decide which one"
             " to use.\nExiting."
         )
-        click.echo(
-            "\n".join(wrap(message, click.get_terminal_size()[0])),
-            err=True,
-        )
         sys.exit(1)
 
     if len(config.paths(pid="*")) == 1:
-        message = (
+        logger.info(
             "Ignoring supplied options. Found a configuration file"
             " belonging to a different `egon-data` process. Using that"
             " one."
-        )
-        click.echo(
-            "\n".join(wrap(message, click.get_terminal_size()[0])),
-            err=True,
         )
         with open(config.paths(pid="*")[0]) as f:
             options = yaml.load(f, Loader=yaml.SafeLoader)

--- a/src/egon/data/config.py
+++ b/src/egon/data/config.py
@@ -53,6 +53,15 @@ def settings() -> dict[str, dict[str, str]]:
     with open(files[0]) as f:
         return yaml.safe_load(f)
 
+def dataset_boundaries():
+    """Return dataset boundaries from configuration settings"""
+
+    if '--dataset-boundary' in settings()['egon-data']:
+        dataset = settings()['egon-data']['--dataset-boundary']
+    elif '--clip-datasets-to' in settings()['egon-data']:
+        dataset = settings()['egon-data']['--clip-datasets-to']
+
+    return dataset
 
 def datasets(config_file=None):
     """Return dataset configuration.

--- a/src/egon/data/config.py
+++ b/src/egon/data/config.py
@@ -53,15 +53,6 @@ def settings() -> dict[str, dict[str, str]]:
     with open(files[0]) as f:
         return yaml.safe_load(f)
 
-def dataset_boundaries():
-    """Return dataset boundaries from configuration settings"""
-
-    if '--dataset-boundary' in settings()['egon-data']:
-        dataset = settings()['egon-data']['--dataset-boundary']
-    elif '--clip-datasets-to' in settings()['egon-data']:
-        dataset = settings()['egon-data']['--clip-datasets-to']
-
-    return dataset
 
 def datasets(config_file=None):
     """Return dataset configuration.

--- a/src/egon/data/config.py
+++ b/src/egon/data/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 import os
 
@@ -27,6 +29,29 @@ def paths(pid=None):
         return [p.absolute() for p in Path(".").glob(filename)]
     else:
         return [(Path(".") / filename).absolute()]
+
+
+# TODO: Add a command for this, so it's easy to double check the
+#       configuration.
+def settings() -> dict[str, dict[str, str]]:
+    """Return a nested dictionary containing the configuration settings.
+
+    It's a nested dictionary because the top level has command names as keys
+    and dictionaries as values where the second level dictionary has command
+    line switches applicable to the command as keys and the supplied values
+    as values.
+
+    So you would obtain the ``--database-name`` configuration setting used
+    by the current invocation of of ``egon-data`` via
+
+    .. code-block:: python
+
+        settings()["egon-data"]["--database-name"]
+
+    """
+    files = paths(pid="*") + paths()
+    with open(files[0]) as f:
+        return yaml.safe_load(f)
 
 
 def datasets(config_file=None):

--- a/src/egon/data/config.py
+++ b/src/egon/data/config.py
@@ -1,8 +1,32 @@
+from pathlib import Path
 import os
 
 import yaml
 
 import egon
+
+
+def paths(pid=None):
+    """Obtain configuration file paths.
+
+    If no `pid` is supplied, return the location of the standard
+    configuration file. If `pid` is the string `"current"`, the
+    path to the configuration file containing the configuration specific
+    to the currently running process, i.e. the configuration obtained by
+    overriding the values from the standard configuration file with the
+    values explicitly supplied when the currently running process was
+    invoked, is returned. If `pid` is the string `"*"` a list of all
+    configuration belonging to currently running `egon-data` processes
+    is returned. This can be used for error checking, because there
+    should only ever be one such file.
+    """
+    pid = os.getpid() if pid == "current" else pid
+    insert = f".pid-{pid}" if pid is not None else ""
+    filename = f"egon-data{insert}.configuration.yaml"
+    if pid == "*":
+        return [p.absolute() for p in Path(".").glob(filename)]
+    else:
+        return [(Path(".") / filename).absolute()]
 
 
 def datasets(config_file=None):

--- a/src/egon/data/db.py
+++ b/src/egon/data/db.py
@@ -36,10 +36,20 @@ def credentials():
     docker_db_config["HOST"] = docker_db_config_additional[0]
     docker_db_config["PORT"] = docker_db_config_additional[1]
 
+    translated = {
+        "database_name": "POSTGRES_DB",
+        "database_password": "POSTGRES_PASSWORD",
+        "database_host": "HOST",
+        "database_port": "PORT",
+        "database_user": "POSTGRES_USER",
+    }
     custom = Path("local-database.yaml")
     if custom.is_file():
         with open(custom) as f:
-            docker_db_config.update(yaml.safe_load(f))
+            configuration = yaml.safe_load(f)
+        docker_db_config.update(
+            {translated[k]: configuration[k] for k in configuration}
+        )
     return docker_db_config
 
 

--- a/src/egon/data/db.py
+++ b/src/egon/data/db.py
@@ -4,7 +4,6 @@ from sqlalchemy import create_engine, text
 import yaml
 
 from egon.data import config
-import egon
 
 
 def credentials():
@@ -15,27 +14,6 @@ def credentials():
     dict
         Complete DB connection information
     """
-    # Read database configuration from docker-compose.yml
-    package_path = egon.data.__path__[0]
-    docker_compose_file = os.path.join(
-        package_path, "airflow", "docker-compose.yml"
-    )
-    docker_compose = yaml.load(
-        open(docker_compose_file), Loader=yaml.SafeLoader
-    )
-
-    # Select basic connection details
-    docker_db_config = docker_compose["services"]["egon-data-local-database"][
-        "environment"
-    ]
-
-    # Add HOST and PORT
-    docker_db_config_additional = docker_compose["services"][
-        "egon-data-local-database"
-    ]["ports"][0].split(":")
-    docker_db_config["HOST"] = docker_db_config_additional[0]
-    docker_db_config["PORT"] = docker_db_config_additional[1]
-
     translated = {
         "--database-name": "POSTGRES_DB",
         "--database-password": "POSTGRES_PASSWORD",
@@ -47,7 +25,7 @@ def credentials():
     if custom.is_file():
         with open(custom) as f:
             configuration = yaml.safe_load(f)["egon-data"]
-        docker_db_config.update(
+        docker_db_config = (
             {
                 translated[flag]: configuration[flag]
                 for flag in configuration

--- a/src/egon/data/db.py
+++ b/src/egon/data/db.py
@@ -1,9 +1,9 @@
-from pathlib import Path
 import os
 
 from sqlalchemy import create_engine, text
 import yaml
 
+from egon.data import config
 import egon
 
 
@@ -37,18 +37,22 @@ def credentials():
     docker_db_config["PORT"] = docker_db_config_additional[1]
 
     translated = {
-        "database_name": "POSTGRES_DB",
-        "database_password": "POSTGRES_PASSWORD",
-        "database_host": "HOST",
-        "database_port": "PORT",
-        "database_user": "POSTGRES_USER",
+        "--database-name": "POSTGRES_DB",
+        "--database-password": "POSTGRES_PASSWORD",
+        "--database-host": "HOST",
+        "--database-port": "PORT",
+        "--database-user": "POSTGRES_USER",
     }
-    custom = Path("local-database.yaml")
+    custom = config.paths(pid="*")[0]
     if custom.is_file():
         with open(custom) as f:
-            configuration = yaml.safe_load(f)
+            configuration = yaml.safe_load(f)["egon-data"]
         docker_db_config.update(
-            {translated[k]: configuration[k] for k in configuration}
+            {
+                translated[flag]: configuration[flag]
+                for flag in configuration
+                if flag in translated
+            }
         )
     return docker_db_config
 

--- a/src/egon/data/db.py
+++ b/src/egon/data/db.py
@@ -25,14 +25,12 @@ def credentials():
     if custom.is_file():
         with open(custom) as f:
             configuration = yaml.safe_load(f)["egon-data"]
-        docker_db_config = (
-            {
-                translated[flag]: configuration[flag]
-                for flag in configuration
-                if flag in translated
-            }
-        )
-    return docker_db_config
+        configuration = {
+            translated[flag]: configuration[flag]
+            for flag in configuration
+            if flag in translated
+        }
+    return configuration
 
 
 def engine():

--- a/src/egon/data/importing/nep_input_data/__init__.py
+++ b/src/egon/data/importing/nep_input_data/__init__.py
@@ -7,6 +7,7 @@ import egon.data.config
 import pandas as pd
 import numpy as np
 from egon.data import db
+from egon.data.config import settings
 from sqlalchemy import Column, String, Float, Integer
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
@@ -247,7 +248,8 @@ def insert_nep_list_powerplants():
                                  'B 2040:\nLeistung': 'b2040_capacity'})
 
     # Cut data to federal state if in testmode
-    if egon.data.config.dataset_boundaries() != 'Everything':
+    boundary = settings()['egon-data']['--dataset-boundary']
+    if boundary != 'Everything':
         map_states = {'Baden-Württemberg':'BW', 'Nordrhein-Westfalen': 'NW',
                'Hessen': 'HE', 'Brandenburg': 'BB', 'Bremen':'HB',
                'Rheinland-Pfalz': 'RP', 'Sachsen-Anhalt': 'ST',
@@ -257,8 +259,8 @@ def insert_nep_list_powerplants():
                'Berlin': 'BE', 'Bayern': 'BY'}
 
         kw_liste_nep = kw_liste_nep[
-            kw_liste_nep.federal_state.isin(
-                [map_states[egon.data.config.dataset_boundaries()], np.nan])]
+            kw_liste_nep.federal_state.isin([map_states[boundary], np.nan])
+        ]
 
         for col in ['capacity', 'a2035_capacity', 'b2035_capacity',
                     'c2035_capacity', 'b2040_capacity']:
@@ -288,7 +290,7 @@ def district_heating_input():
     df.set_index(['Energietraeger', 'Name'], inplace=True)
 
     # Scale values to population share in testmode
-    if egon.data.config.dataset_boundaries() != 'Everything':
+    if settings()['egon-data']['--dataset-boundary'] != 'Everything':
         df.loc[
             pd.IndexSlice[:, 'Fernwaermeerzeugung'],
             'Wert'] *= population_share()

--- a/src/egon/data/importing/nep_input_data/__init__.py
+++ b/src/egon/data/importing/nep_input_data/__init__.py
@@ -81,7 +81,7 @@ def create_scenario_input_tables():
     EgonScenarioCapacities.__table__.create(bind=engine, checkfirst=True)
     NEP2021ConvPowerPlants.__table__.create(bind=engine, checkfirst=True)
 
-def insert_capacities_per_federal_state_nep(dataset):
+def insert_capacities_per_federal_state_nep():
     """Inserts installed capacities per federal state accordning to
     NEP 2035 (version 2021), scenario 2035 C
 
@@ -189,7 +189,7 @@ def insert_capacities_per_federal_state_nep(dataset):
 
 
     # Add district heating data accordning to energy and full load hours
-    district_heating_input(dataset)
+    district_heating_input()
 
 def population_share():
     """ Calulate share of population in testmode
@@ -206,7 +206,7 @@ def population_share():
     FROM society.destatis_zensus_population_per_ha
     WHERE population>0""", con=db.engine())['sum'][0]/80324282
 
-def insert_nep_list_powerplants(dataset):
+def insert_nep_list_powerplants():
     """Insert list of conventional powerplants attachd to the approval
     of the scenario report by BNetzA
 
@@ -247,7 +247,7 @@ def insert_nep_list_powerplants(dataset):
                                  'B 2040:\nLeistung': 'b2040_capacity'})
 
     # Cut data to federal state if in testmode
-    if dataset != 'main':
+    if egon.data.config.dataset_boundaries() != 'Everything':
         map_states = {'Baden-Württemberg':'BW', 'Nordrhein-Westfalen': 'NW',
                'Hessen': 'HE', 'Brandenburg': 'BB', 'Bremen':'HB',
                'Rheinland-Pfalz': 'RP', 'Sachsen-Anhalt': 'ST',
@@ -257,7 +257,8 @@ def insert_nep_list_powerplants(dataset):
                'Berlin': 'BE', 'Bayern': 'BY'}
 
         kw_liste_nep = kw_liste_nep[
-            kw_liste_nep.federal_state.isin([map_states[dataset], np.nan])]
+            kw_liste_nep.federal_state.isin(
+                [map_states[egon.data.config.dataset_boundaries()], np.nan])]
 
         for col in ['capacity', 'a2035_capacity', 'b2035_capacity',
                     'c2035_capacity', 'b2040_capacity']:
@@ -271,7 +272,7 @@ def insert_nep_list_powerplants(dataset):
                        schema='supply',
                        if_exists='replace')
 
-def district_heating_input(dataset):
+def district_heating_input():
     """Imports data for district heating networks in Germany
 
     Returns
@@ -287,7 +288,7 @@ def district_heating_input(dataset):
     df.set_index(['Energietraeger', 'Name'], inplace=True)
 
     # Scale values to population share in testmode
-    if dataset != 'main':
+    if egon.data.config.dataset_boundaries() != 'Everything':
         df.loc[
             pd.IndexSlice[:, 'Fernwaermeerzeugung'],
             'Wert'] *= population_share()
@@ -326,7 +327,7 @@ def district_heating_input(dataset):
 
     session.commit()
 
-def insert_data_nep(dataset):
+def insert_data_nep():
     """Overall function for importing scenario input data for eGon2035 scenario
 
     Returns
@@ -335,6 +336,6 @@ def insert_data_nep(dataset):
 
     """
 
-    insert_capacities_per_federal_state_nep(dataset)
+    insert_capacities_per_federal_state_nep()
 
-    insert_nep_list_powerplants(dataset)
+    insert_nep_list_powerplants()

--- a/src/egon/data/importing/openstreetmap/__init__.py
+++ b/src/egon/data/importing/openstreetmap/__init__.py
@@ -15,6 +15,7 @@ import os
 import time
 
 from egon.data import db
+from egon.data.config import settings
 import egon.data.config
 import egon.data.subprocess as subprocess
 
@@ -26,7 +27,7 @@ def download_pbf_file():
     data_config = egon.data.config.datasets()
     osm_config = data_config["openstreetmap"]["original_data"]
 
-    if egon.data.config.dataset_boundaries() == 'Everything':
+    if settings()['egon-data']['--dataset-boundary'] == 'Everything':
         source_url =osm_config["source"]["url"]
         target_path = osm_config["target"]["path"]
     else:
@@ -59,7 +60,7 @@ def to_postgres(num_processes=4, cache_size=4096):
     data_config = egon.data.config.datasets()
     osm_config = data_config["openstreetmap"]["original_data"]
 
-    if egon.data.config.dataset_boundaries() == 'Everything':
+    if settings()['egon-data']['--dataset-boundary'] == 'Everything':
         target_path = osm_config["target"]["path"]
     else:
         target_path = osm_config["target"]["path_testmode"]
@@ -100,7 +101,7 @@ def add_metadata():
     # Prepare variables
     osm_config = egon.data.config.datasets()["openstreetmap"]
 
-    if egon.data.config.dataset_boundaries() == 'Everything':
+    if settings()['egon-data']['--dataset-boundary'] == 'Everything':
         osm_url = osm_config["original_data"]["source"]["url"]
         target_path = osm_config["original_data"]["target"]["path"]
     else:

--- a/src/egon/data/importing/openstreetmap/__init__.py
+++ b/src/egon/data/importing/openstreetmap/__init__.py
@@ -19,25 +19,14 @@ import egon.data.config
 import egon.data.subprocess as subprocess
 
 
-def download_pbf_file(dataset='main'):
+def download_pbf_file():
     """Download OpenStreetMap `.pbf` file.
 
-    Parameters
-    ----------
-    dataset: str, optional
-        Toggles between production (`dataset='main'`) and test mode e.g.
-        (`dataset='Schleswig-Holstein'`).
-        In production mode, data covering entire Germany
-        is used. In the test mode a subset of this data is used for testing the
-        workflow.
-        When test mode is activated, data for a federal state instead of
-        Germany gets downloaded.
     """
     data_config = egon.data.config.datasets()
     osm_config = data_config["openstreetmap"]["original_data"]
 
-
-    if dataset == 'main':
+    if egon.data.config.dataset_boundaries() == 'Everything':
         source_url =osm_config["source"]["url"]
         target_path = osm_config["target"]["path"]
     else:
@@ -52,17 +41,11 @@ def download_pbf_file(dataset='main'):
         urlretrieve(source_url, target_file)
 
 
-def to_postgres(dataset='main', num_processes=4, cache_size=4096):
+def to_postgres(num_processes=4, cache_size=4096):
     """Import OSM data from a Geofabrik `.pbf` file into a PostgreSQL database.
 
     Parameters
     ----------
-    dataset: str, optional
-        Toggles between production (`dataset='main'`) and test mode e.g.
-        (`dataset='Schleswig-Holstein'`).
-        In production mode, data covering entire Germany
-        is used. In the test mode a subset of this data is used for testing the
-        workflow.
     num_processes : int, optional
         Number of parallel processes used for processing during data import
     cache_size: int, optional
@@ -76,7 +59,7 @@ def to_postgres(dataset='main', num_processes=4, cache_size=4096):
     data_config = egon.data.config.datasets()
     osm_config = data_config["openstreetmap"]["original_data"]
 
-    if dataset=='main':
+    if egon.data.config.dataset_boundaries() == 'Everything':
         target_path = osm_config["target"]["path"]
     else:
         target_path = osm_config["target"]["path_testmode"]
@@ -110,21 +93,14 @@ def to_postgres(dataset='main', num_processes=4, cache_size=4096):
     )
 
 
-def add_metadata(dataset='main'):
+def add_metadata():
     """Writes metadata JSON string into table comment.
 
-    Parameters
-    ----------
-    dataset: str, optional
-        Toggles between production (`testmode=False`) and test mode
-        (`testmode=False`). In production mode, data covering entire Germany
-        is used. In the test mode a subset of this data is used for testing the
-        workflow.
     """
     # Prepare variables
     osm_config = egon.data.config.datasets()["openstreetmap"]
 
-    if dataset=='main':
+    if egon.data.config.dataset_boundaries() == 'Everything':
         osm_url = osm_config["original_data"]["source"]["url"]
         target_path = osm_config["original_data"]["target"]["path"]
     else:

--- a/src/egon/data/importing/vg250.py
+++ b/src/egon/data/importing/vg250.py
@@ -17,6 +17,7 @@ from geoalchemy2 import Geometry
 import geopandas as gpd
 
 from egon.data import db
+from egon.data.config import settings
 import egon.data.config
 
 
@@ -56,12 +57,13 @@ def to_postgres():
             f"vg250_ebenen_0101/{filename}"
         )
 
-        if egon.data.config.dataset_boundaries() != "Everything":
+        boundary = settings()['egon-data']['--dataset-boundary']
+        if boundary != "Everything":
             # read-in borders of federal state Schleswig-Holstein
             data_sta = gpd.read_file(
                 f"zip://{zip_file}!vg250_01-01.geo84.shape.ebenen/"
                 f"vg250_ebenen_0101/VG250_LAN.shp"
-            ).query(f"GEN == '{egon.data.config.dataset_boundaries()}'")
+            ).query(f"GEN == '{boundary}'")
             data_sta.BEZ = "Bundesrepublik"
             data_sta.NUTS = "DE"
             # import borders of Schleswig-Holstein as borders of state

--- a/src/egon/data/importing/vg250.py
+++ b/src/egon/data/importing/vg250.py
@@ -56,23 +56,22 @@ def to_postgres():
             f"vg250_ebenen_0101/{filename}"
         )
 
-        if egon.data.config.dataset_boundaries() != 'Everything':
+        if egon.data.config.dataset_boundaries() != "Everything":
             # read-in borders of federal state Schleswig-Holstein
             data_sta = gpd.read_file(
-                    f"zip://{zip_file}!vg250_01-01.geo84.shape.ebenen/"
-                    f"vg250_ebenen_0101/VG250_LAN.shp"
-                    ).query(
-                        f"GEN == '{egon.data.config.dataset_boundaries()}'")
-            data_sta.BEZ = 'Bundesrepublik'
-            data_sta.NUTS = 'DE'
+                f"zip://{zip_file}!vg250_01-01.geo84.shape.ebenen/"
+                f"vg250_ebenen_0101/VG250_LAN.shp"
+            ).query(f"GEN == '{egon.data.config.dataset_boundaries()}'")
+            data_sta.BEZ = "Bundesrepublik"
+            data_sta.NUTS = "DE"
             # import borders of Schleswig-Holstein as borders of state
-            if table == 'vg250_sta':
+            if table == "vg250_sta":
                 data = data_sta
             # choose only areas in Schleswig-Holstein
             else:
-                data = data[data.within(
-                    data_sta.dissolve(by='GEN').geometry.values[0])]
-
+                data = data[
+                    data.within(data_sta.dissolve(by="GEN").geometry.values[0])
+                ]
 
         # Set index column and format column headings
         data.index.set_names("gid", inplace=True)
@@ -104,7 +103,6 @@ def to_postgres():
             f"CREATE INDEX {table}_geometry_idx ON "
             f"{vg250_processed['schema']}.{table} USING gist (geometry);"
         )
-
 
 
 def add_metadata():

--- a/src/egon/data/importing/vg250.py
+++ b/src/egon/data/importing/vg250.py
@@ -33,7 +33,7 @@ def download_vg250_files():
         urlretrieve(vg250_config["source"]["url"], target_file)
 
 
-def to_postgres(dataset='main'):
+def to_postgres():
 
     # Get information from data configuraiton file
     data_config = egon.data.config.datasets()
@@ -56,12 +56,13 @@ def to_postgres(dataset='main'):
             f"vg250_ebenen_0101/{filename}"
         )
 
-        if dataset != 'main':
+        if egon.data.config.dataset_boundaries() != 'Everything':
             # read-in borders of federal state Schleswig-Holstein
             data_sta = gpd.read_file(
                     f"zip://{zip_file}!vg250_01-01.geo84.shape.ebenen/"
                     f"vg250_ebenen_0101/VG250_LAN.shp"
-                    ).query(f"GEN == '{dataset}'")
+                    ).query(
+                        f"GEN == '{egon.data.config.dataset_boundaries()}'")
             data_sta.BEZ = 'Bundesrepublik'
             data_sta.NUTS = 'DE'
             # import borders of Schleswig-Holstein as borders of state

--- a/src/egon/data/importing/zensus/__init__.py
+++ b/src/egon/data/importing/zensus/__init__.py
@@ -13,6 +13,7 @@ from shapely.prepared import prep
 import pandas as pd
 
 from egon.data import db, subprocess
+from egon.data.config import settings
 import egon.data.config
 
 
@@ -279,7 +280,7 @@ def population_to_postgres():
     input_file = os.path.join(
         os.path.dirname(__file__), zensus_population_orig["target"]["path"]
     )
-    dataset = egon.data.config.dataset_boundaries()
+    dataset = settings()['egon-data']['--dataset-boundary']
 
     # Read database configuration from docker-compose.yml
     docker_db_config = db.credentials()
@@ -348,7 +349,7 @@ def zensus_misc_to_postgres():
     data_config = egon.data.config.datasets()
     zensus_misc_processed = data_config["zensus_misc"]["processed"]
     zensus_population_processed = data_config["zensus_population"]["processed"]
-    dataset = egon.data.config.dataset_boundaries()
+    dataset = settings()['egon-data']['--dataset-boundary']
 
     population_table = (
         f"{zensus_population_processed['schema']}"


### PR DESCRIPTION
If the configured database doesn't exist, it will be created. This enables seamless usage of multiple databases and should fix #112.