### PR TITLE
Features/#165 centralize map zensus to boundaries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -85,6 +85,8 @@ Changed
   `#166 <https://github.com/openego/eGon-data/issues/166>`_
 * Adjust residential heat demand in unpopulated zenus cells
   `#167 <https://github.com/openego/eGon-data/issues/167>`_
+* Introduce mapping between VG250 municipalities and census cells
+  `#165 <https://github.com/openego/eGon-data/issues/165>`_
 
 Bug fixes
 ---------

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -133,6 +133,11 @@ with airflow.DAG(
     population_import >> zensus_misc_import
 
     # Combine Zensus and VG250 data
+    map_zensus_vg250 = PythonOperator(
+        task_id="map_zensus_vg250",
+        python_callable=zensus_vg250.map_zensus_vg250,
+    )
+
     zensus_inside_ger = PythonOperator(
         task_id="zensus-inside-germany",
         python_callable=zensus_vg250.inside_germany,
@@ -153,9 +158,9 @@ with airflow.DAG(
         python_callable=zensus_vg250.add_metadata_vg250_gem_pop,
     )
     [
-        vg250_import,
+        vg250_clean_and_prepare,
         population_import,
-    ] >> zensus_inside_ger >> zensus_inside_ger_metadata
+    ] >> map_zensus_vg250 >> zensus_inside_ger >> zensus_inside_ger_metadata
     zensus_inside_ger >> vg250_population >> vg250_population_metadata
 
     # DemandRegio data import
@@ -171,21 +176,12 @@ with airflow.DAG(
         python_callable=process_zs.create_tables
     )
 
-    map_zensus_nuts3 = PythonOperator(
-        task_id="map-zensus-to-nuts3",
-        python_callable=process_zs.map_zensus_nuts3
-    )
-
-    setup >> prognosis_tables >> map_zensus_nuts3
-    vg250_clean_and_prepare >> map_zensus_nuts3
-    population_import >> map_zensus_nuts3
-
     population_prognosis = PythonOperator(
         task_id="zensus-population-prognosis",
         python_callable=process_zs.population_prognosis_to_zensus
     )
 
-    map_zensus_nuts3 >> population_prognosis
+    map_zensus_vg250 >> population_prognosis
     demandregio_import >> population_prognosis
 
     household_prognosis = PythonOperator(
@@ -193,7 +189,7 @@ with airflow.DAG(
         python_callable=process_zs.household_prognosis_to_zensus
     )
 
-    map_zensus_nuts3 >> household_prognosis
+    map_zensus_vg250 >> household_prognosis
     demandregio_import >> household_prognosis
     zensus_misc_import >> household_prognosis
 

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -167,19 +167,23 @@ with airflow.DAG(
         python_callable=process_zs.create_tables
     )
 
+    setup >> prognosis_tables
+
     population_prognosis = PythonOperator(
         task_id="zensus-population-prognosis",
         python_callable=process_zs.population_prognosis_to_zensus
     )
 
+    prognosis_tables >> population_prognosis
     map_zensus_vg250 >> population_prognosis
     demandregio_import >> population_prognosis
+    population_import >> population_prognosis
 
     household_prognosis = PythonOperator(
         task_id="zensus-household-prognosis",
         python_callable=process_zs.household_prognosis_to_zensus
     )
-
+    prognosis_tables >> household_prognosis
     map_zensus_vg250 >> household_prognosis
     demandregio_import >> household_prognosis
     zensus_misc_import >> household_prognosis
@@ -220,7 +224,6 @@ with airflow.DAG(
     )
     setup >> retrieve_mastr_data
 
-
     # Substation extraction
     substation_tables = PythonOperator(
         task_id="create_substation_tables",
@@ -255,7 +258,6 @@ with airflow.DAG(
     substation_functions >> ehv_substation_extraction >> create_voronoi
     vg250_clean_and_prepare >> hvmv_substation_extraction
     vg250_clean_and_prepare >> ehv_substation_extraction
-
 
     # Import potential areas for wind onshore and ground-mounted PV
     download_re_potential_areas = PythonOperator(

--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -63,7 +63,7 @@ map_zensus_vg250:
       table: 'destatis_zensus_population_per_ha'
     vg250_municipalities:
       schema: 'boundaries'
-      table: 'vg250_gem_clean'
+      table: 'vg250_gem'
   targets:
     map:
       schema: 'boundaries'
@@ -134,13 +134,29 @@ ehv_substation_voronoi:
 
 society_prognosis:
   soucres:
+    zensus_population:
+      schema: 'society'
+      table: 'destatis_zensus_population_per_ha'
+    zensus_households:
+      schema: 'society'
+      table: 'destatis_zensus_household_per_ha'
+    demandregio_population:
+      schema: 'society'
+      table: 'egon_demandregio_population'
+    demandregio_households:
+      schema: 'society'
+      table: 'egon_demandregio_household'
     map_zensus_vg250:
       schema: 'boundaries'
       table: 'egon_map_zensus_vg250'
+
   target:
-    schema: "society"
-    population_prognosis: "egon_population_prognosis"
-    household_prognosis: "egon_household_prognosis"
+    population_prognosis:
+      schema: 'society'
+      table: 'egon_population_prognosis'
+    household_prognosis:
+      schema: 'society'
+      table: 'egon_household_prognosis'
 
 scenario_input:
   eGon2035:

--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -56,6 +56,19 @@ zensus_misc:
       "csv_Gebaeude_100m_Gitter.zip": "destatis_zensus_building_per_ha"
       "csv_Wohnungen_100m_Gitter.zip": "destatis_zensus_apartment_per_ha"
 
+map_zensus_vg250:
+  sources:
+    zensus_population:
+      schema: 'society'
+      table: 'destatis_zensus_population_per_ha'
+    vg250_municipalities:
+      schema: 'boundaries'
+      table: 'vg250_gem_clean'
+  targets:
+    map:
+      schema: 'boundaries'
+      table: 'egon_map_zensus_vg250'
+
 demandregio:
   demand_data:
     schema: "demand"
@@ -120,9 +133,12 @@ ehv_substation_voronoi:
 
 
 society_prognosis:
+  soucres:
+    map_zensus_vg250:
+      schema: 'boundaries'
+      table: 'egon_map_zensus_vg250'
   target:
     schema: "society"
-    map_nuts3: "egon_map_zensus_nuts3"
     population_prognosis: "egon_population_prognosis"
     household_prognosis: "egon_household_prognosis"
 

--- a/src/egon/data/processing/zensus/__init__.py
+++ b/src/egon/data/processing/zensus/__init__.py
@@ -45,7 +45,7 @@ def population_prognosis_to_zensus():
 
     # Input: Zensus2011 population data including the NUTS3-Code
     zensus_district = db.select_dataframe(
-        f"""SELECT zensus_population_id, nuts3
+        f"""SELECT zensus_population_id, vg250_nuts3
         FROM {cfg['soucres']['map_zensus_vg250']['schema']}.
         {cfg['soucres']['map_zensus_vg250']['table']}
         WHERE zensus_population_id IN (
@@ -63,7 +63,7 @@ def population_prognosis_to_zensus():
         index_col="id",
     )
 
-    zensus["nuts3"] = zensus_district.nuts3
+    zensus["nuts3"] = zensus_district.vg250_nuts3
 
     # Rename index
     zensus.index = zensus.index.rename("zensus_population_id")
@@ -153,7 +153,7 @@ def household_prognosis_to_zensus():
 
     # Input: Zensus2011 household data including the NUTS3-Code
     district = db.select_dataframe(
-        f"""SELECT zensus_population_id, nuts3
+        f"""SELECT zensus_population_id, vg250_nuts3
         FROM {cfg['soucres']['map_zensus_vg250']['schema']}.
         {cfg['soucres']['map_zensus_vg250']['table']}""",
         index_col="zensus_population_id",
@@ -169,7 +169,7 @@ def household_prognosis_to_zensus():
     # Group all household types
     zensus = zensus.groupby(zensus.index).sum()
 
-    zensus["nuts3"] = district.loc[zensus.index, "nuts3"]
+    zensus["nuts3"] = district.loc[zensus.index, "vg250_nuts3"]
 
     # Calculate share of households per nuts3 region in each zensus cell
     zensus["share"] = (

--- a/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
+++ b/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
@@ -137,8 +137,8 @@ class MapZensusVg250(Base):
 
     zensus_population_id = Column(Integer, primary_key=True, index=True)
     zensus_geom = Column(Geometry("POINT", 3035))
-    rs_municipality = Column(String)
-    nuts3 = Column(String)
+    vg250_municipality_id = Column(Integer)
+    vg250_nuts3 = Column(String)
 
 
 def map_zensus_vg250():
@@ -200,12 +200,13 @@ def map_zensus_vg250():
         {
             "id": "zensus_population_id",
             "geom_point": "zensus_geom",
-            "nuts": "nuts3",
-            "rs_0": "rs_municipality",
+            "nuts": "vg250_nuts3",
+            "gid": "vg250_municipality_id",
         },
         axis=1,
     )[
-        ["zensus_population_id", "zensus_geom", "rs_municipality", "nuts3"]
+        ["zensus_population_id", "zensus_geom",
+         "vg250_municipality_id", "vg250_nuts3"]
     ].set_geometry(
         "zensus_geom"
     ).to_postgis(


### PR DESCRIPTION
This branch adds a table which maps zensus data to vg250 municipalities and nuts3 regions. 
The table is used by the society prognosis and the population_in_municipalities. 
@gplssm Since it wasn't that easy for me to adjust your SQLalchemy code, I re-wrote it with (geo)pandas because it was much easier for me and also needed less lines of code. Could you please take a look and tell me if you are fine with this? 

As I also posted in #165 I decided to map all zensus cells with a population to municipalities. 

Fixes #165 