### PR TITLE
Fix automatic checks

### DIFF
--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -259,8 +259,8 @@ def egon_data(context, **kwargs):
     #       import can only be done inside this function, which is generally
     #       frowned upon, instead of at the module level. Maybe there's a
     #       better way to encapsulate this?
-    from airflow.configuration import conf as airflow_cfg
-    from airflow.models import Connection
+    from airflow.configuration import conf as airflow_cfg  # noqa
+    from airflow.models import Connection  # noqa
 
     options = options["egon-data"]
     render(


### PR DESCRIPTION
Fixes #183 by removing a module global function call and putting the corresponding logic into `egon-data`'s startup function, using central configuration `settings` retrieval functionality and adjusting tests to previous changes.