### PR TITLE
Fix zensus-inside-germany with --dataset-boundary=Everything

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -96,6 +96,8 @@ Changed
   `#166 <https://github.com/openego/eGon-data/issues/166>`_
 * Add gdal to pre-requisites
   `#185 <https://github.com/openego/eGon-data/issues/185>`_
+* Update task zensus-inside-germany
+  `#196 <https://github.com/openego/eGon-data/issues/196>`_
 
 Bug fixes
 ---------

--- a/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
+++ b/src/egon/data/processing/zensus_vg250/zensus_population_inside_germany.py
@@ -233,13 +233,11 @@ def inside_germany():
         bind=engine_local_db, checkfirst=True
     )
 
-    # Selects zensus cells in German boundaries from vg250
-    cells_in_germany = db.select_dataframe(
-        """SELECT zensus_population_id
-        FROM boundaries.egon_map_zensus_vg250"""
-    ).zensus_population_id.values.tolist()
-
     with db.session_scope() as s:
+
+        # Query zensus cells in German boundaries from vg250
+        cells_in_germany = s.query(MapZensusVg250.zensus_population_id)
+
         # Query relevant data from zensus population table
         q = (
             s.query(


### PR DESCRIPTION
I think this fixes #196 but I was not able to test it with` --dataset-boundary=Everything` . @gnn Could you try to run it? 