### PR TITLE
Fixes/#202 fix zensus misc without population

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -107,3 +107,5 @@ Bug fixes
   `#157 <https://github.com/openego/eGon-data/issues/157>`_
 * Substation sequence
   `#171 <https://github.com/openego/eGon-data/issues/171>`_
+* Delete zensus buildings, apartments ans households in unpopulated cells
+  `#202 <https://github.com/openego/eGon-data/issues/202>`_

--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -52,9 +52,9 @@ zensus_misc:
   processed:
     schema: "society"
     path_table_map:
-      "csv_Haushalte_100m_Gitter.zip": "destatis_zensus_household_per_ha"
-      "csv_Gebaeude_100m_Gitter.zip": "destatis_zensus_building_per_ha"
-      "csv_Wohnungen_100m_Gitter.zip": "destatis_zensus_apartment_per_ha"
+      "csv_Haushalte_100m_Gitter.zip": "egon_destatis_zensus_household_per_ha"
+      "csv_Gebaeude_100m_Gitter.zip": "egon_destatis_zensus_building_per_ha"
+      "csv_Wohnungen_100m_Gitter.zip": "egon_destatis_zensus_apartment_per_ha"
 
 map_zensus_vg250:
   sources:
@@ -181,7 +181,7 @@ society_prognosis:
       table: 'destatis_zensus_population_per_ha'
     zensus_households:
       schema: 'society'
-      table: 'destatis_zensus_household_per_ha'
+      table: 'egon_destatis_zensus_household_per_ha'
     demandregio_population:
       schema: 'society'
       table: 'egon_demandregio_population'

--- a/src/egon/data/importing/heat_demand_data/__init__.py
+++ b/src/egon/data/importing/heat_demand_data/__init__.py
@@ -499,9 +499,14 @@ def adjust_residential_heat_to_zensus(scenario):
     """
     Adjust residential heat demands to fit to zensus population.
 
+    In some cases, Peta assigns residential heat demand to unpopulated cells.
+    This can be caused by the different population data used in Peta or
+    buildings in zenus cells without a population
+    (see :func:`egon.data.importing.zensus.adjust_zensus_misc`)
+
     Residential heat demand in cells without zensus population is dropped.
     Residential heat demand in cells with zensus population is scaled to meet
-    the formal overall residential heat demands.
+    the overall residential heat demands.
 
     Parameters
     ----------

--- a/src/egon/data/importing/zensus/__init__.py
+++ b/src/egon/data/importing/zensus/__init__.py
@@ -410,3 +410,12 @@ def zensus_misc_to_postgres():
                     FOREIGN KEY (zensus_population_id)
                     REFERENCES {population_table}(id);"""
         )
+
+        # Delete rows whithout a population
+        db.execute_sql(
+            f"""
+            DELETE FROM {zensus_population_processed['schema']}.{table} as b
+            WHERE b.zensus_population_id IN (
+                SELECT id FROM {population_table}
+                WHERE population < 0);"""
+        )


### PR DESCRIPTION
Fixes #202 (I tested it for Schleswig-Holstein and Germany)
All entries of zensus-misc tables in unpopulated cells are dropped. The zensus misc tables are re-named due to this change. 