### PR TITLE
Identify medium-voltage grid districts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,7 +65,9 @@ Added
   `#127 <https://github.com/openego/eGon-data/issues/127>`_
 * Creation of the ehv/hv grid model with osmTGmod, see 
   `issue #4 <https://github.com/openego/eGon-data/issues/4>`_ and 
-  `PR #164 <https://github.com/openego/eGon-data/pull/164>`_  
+  `PR #164 <https://github.com/openego/eGon-data/pull/164>`_
+* Identification of medium-voltage grid districts
+  `#10 <https://github.com/openego/eGon-data/pull/10>`_
 
 .. _PR #159: https://github.com/openego/eGon-data/pull/159
 

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -25,6 +25,8 @@ import egon.data.processing.zensus_vg250.zensus_population_inside_germany as zen
 import egon.data.importing.re_potential_areas as re_potential_areas
 import egon.data.importing.heat_demand_data as import_hd
 import egon.data.processing.osmtgmod as osmtgmod
+import egon.data.processing.mv_grid_districts as mvgd
+
 
 with airflow.DAG(
     "egon-data-processing-pipeline",
@@ -249,6 +251,13 @@ with airflow.DAG(
     substation_functions >> ehv_substation_extraction >> create_voronoi
     vg250_clean_and_prepare >> hvmv_substation_extraction
     vg250_clean_and_prepare >> ehv_substation_extraction
+
+    # MV grid districts
+    define_mv_grid_districts = PythonOperator(
+        task_id="define_mv_grid_districts",
+        python_callable=mvgd.define_mv_grid_districts
+    )
+    create_voronoi >> define_mv_grid_districts
 
     # osmTGmod ehv/hv grid model generation
     osmtgmod = PythonOperator(

--- a/src/egon/data/processing/mv_grid_districts.py
+++ b/src/egon/data/processing/mv_grid_districts.py
@@ -1,0 +1,159 @@
+"""
+Implements the methods for creating medium-voltage grid district areas from
+HV-MV substation locations and municipality borders from Hülk et al. (2017)
+(section 2.3)
+https://somaesthetics.aau.dk/index.php/sepm/article/view/1833/1531
+"""
+
+
+from geoalchemy2.types import Geometry
+from sqlalchemy import (
+    ARRAY,
+    Boolean,
+    Column,
+    Float,
+    Integer,
+    Numeric,
+    Sequence,
+    String,
+    func,
+)
+from sqlalchemy.ext.declarative import declarative_base
+
+from egon.data import db
+from egon.data.db import session_scope
+from egon.data.processing.substation import EgonHvmvSubstationVoronoi
+
+Base = declarative_base()
+metadata = Base.metadata
+
+
+class Vg250GemClean(Base):
+    __tablename__ = "vg250_gem_clean"
+    __table_args__ = {"schema": "boundaries"}
+
+    id = Column(Integer, primary_key=True)
+    old_id = Column(Integer)
+    gen = Column(String)
+    bez = Column(String)
+    bem = Column(String)
+    nuts = Column(String)
+    rs_0 = Column(String)
+    ags_0 = Column(String)
+    area_ha = Column(Numeric)
+    count_hole = Column(Integer)
+    path = Column(ARRAY(Integer()))
+    is_hole = Column(Boolean)
+    geometry = Column(Geometry("POLYGON", 3035), index=True)
+
+
+class EgonHvmvSubstation(Base):
+    __tablename__ = "egon_hvmv_substation"
+    __table_args__ = {"schema": "grid"}
+
+    subst_id = Column(Integer, primary_key=True)
+    lon = Column(Float)
+    lat = Column(Float)
+    point = Column(Geometry("POINT", 4326), index=True)
+    polygon = Column(Geometry, index=True)
+    voltage = Column(String)
+    power_type = Column(String)
+    substation = Column(String)
+    osm_id = Column(String)
+    osm_www = Column(String)
+    frequency = Column(String)
+    subst_name = Column(String)
+    ref = Column(String)
+    operator = Column(String)
+    dbahn = Column(String)
+    status = Column(Integer)
+
+
+class HvmvSubstPerMunicipality(Base):
+    __tablename__ = "hvmv_subst_per_municipality"
+    __table_args__ = {"schema": "grid"}
+
+    id = Column(Integer, primary_key=True)
+    old_id = Column(Integer)
+    gen = Column(String)
+    bez = Column(String)
+    bem = Column(String)
+    nuts = Column(String)
+    rs_0 = Column(String)
+    ags_0 = Column(String)
+    area_ha = Column(Numeric)
+    count_hole = Column(Integer)
+    path = Column(ARRAY(Integer()))
+    is_hole = Column(Boolean)
+    geometry = Column(Geometry("POLYGON", 3035))
+    subst_count = Column(Integer)
+
+
+
+def substations_in_municipalities():
+    """
+    Create a table that counts number of HV-MV substations in each MV grid
+
+    Counting is performed in two steps
+
+    1. HV-MV substations are spatially joined on municipalities, grouped by
+       municipality and number of substations counted
+    2. Because (1) works only for number of substations >0, all municipalities
+       not containing a substation, are added
+    """
+    engine = db.engine()
+    HvmvSubstPerMunicipality.__table__.drop(bind=engine, checkfirst=True)
+    HvmvSubstPerMunicipality.__table__.create(bind=engine)
+
+    with session_scope() as session:
+        # Insert municipalities with number of substations > 0
+        q = (
+            session.query(
+                Vg250GemClean,
+                func.count(EgonHvmvSubstation.point).label("subst_count"),
+            )
+            .filter(
+                func.ST_Contains(
+                    Vg250GemClean.geometry,
+                    func.ST_Transform(EgonHvmvSubstation.point, 3035),
+                )
+            )
+            .group_by(Vg250GemClean.id)
+        )
+
+        muns_with_subst = (
+            HvmvSubstPerMunicipality.__table__.insert().from_select(
+                HvmvSubstPerMunicipality.__table__.columns, q
+            )
+        )
+        session.execute(muns_with_subst)
+        session.commit()
+
+        # Insert remaining municipalities
+        already_inserted_muns = session.query(
+            HvmvSubstPerMunicipality.id
+        ).subquery()
+        muns_without_subst = (
+            HvmvSubstPerMunicipality.__table__.insert().from_select(
+                [
+                    _
+                    for _ in HvmvSubstPerMunicipality.__table__.columns
+                    if _.name != "subst_count"
+                ],
+                session.query(Vg250GemClean).filter(
+                    Vg250GemClean.id.notin_(already_inserted_muns)
+                ),
+            )
+        )
+        session.execute(muns_without_subst)
+        session.commit()
+
+        # Set subst_count for municipalities with zero substations to 0
+        session.query(HvmvSubstPerMunicipality).filter(
+            HvmvSubstPerMunicipality.subst_count == None
+        ).update(
+            {HvmvSubstPerMunicipality.subst_count: 0},
+            synchronize_session="fetch",
+        )
+        session.commit()
+

--- a/src/egon/data/processing/mv_grid_districts.py
+++ b/src/egon/data/processing/mv_grid_districts.py
@@ -777,4 +777,3 @@ def define_mv_grid_districts():
         bind=engine, checkfirst=True
     )
     MvGridDistrictsDissolved.__table__.drop(bind=engine, checkfirst=True)
-

--- a/src/egon/data/processing/mv_grid_districts.py
+++ b/src/egon/data/processing/mv_grid_districts.py
@@ -382,5 +382,10 @@ def split_multi_substation_municipalities():
 
         # TODO 3: join cut_1subst and cut_0subst and union/collect geom (polygon)
         # TODO 4: write the joined data to persistent table
+
+
+# substations_in_municipalities()
+split_multi_substation_municipalities()
+
 # TODO: in the original script municipality geometries (i.e. model_draft.ego_grid_mv_griddistrict_type1) are casted into MultiPolyon. Maybe this is required later
 # TODO: later, when grid districts are collected from different processing parts, ST_Multi(ST_Union(geometry)) is called. If geometry is of mixed type (Poylgon and MultiPolygon) results might be unexpected

--- a/src/egon/data/processing/mv_grid_districts.py
+++ b/src/egon/data/processing/mv_grid_districts.py
@@ -603,6 +603,7 @@ def merge_polygons_to_grid_district():
             with_substation = session.query(
                 MvGridDistrictsDissolved.subst_id,
                 MvGridDistrictsDissolved.geom,
+                MvGridDistrictsDissolved.id,
             ).subquery()
             without_substation = (
                 session.query(
@@ -714,6 +715,7 @@ def nearest_polygon_with_substation(
             func.ST_Distance(
                 without_substation.c.geom, with_substation.c.geom
             ),
+            with_substation.c.id
         )
         .subquery()
     )

--- a/src/egon/data/processing/mv_grid_districts.py
+++ b/src/egon/data/processing/mv_grid_districts.py
@@ -715,7 +715,11 @@ def nearest_polygon_with_substation(
             func.ST_Distance(
                 without_substation.c.geom, with_substation.c.geom
             ),
-            with_substation.c.id
+            #with_substation.c.id
+            func.ST_Distance(
+                func.ST_Centroid(without_substation.c.geom), 
+                func.ST_Centroid(with_substation.c.geom)
+            )
         )
         .subquery()
     )

--- a/src/egon/data/processing/mv_grid_districts.py
+++ b/src/egon/data/processing/mv_grid_districts.py
@@ -1,8 +1,16 @@
 """
 Implements the methods for creating medium-voltage grid district areas from
-HV-MV substation locations and municipality borders from Hülk et al. (2017)
-(section 2.3)
-https://somaesthetics.aau.dk/index.php/sepm/article/view/1833/1531
+HV-MV substation locations and municipality borders
+
+Methods are heavily inspired by `Hülk et al. (2017)
+<https://somaesthetics.aau.dk/index.php/sepm/article/view/1833/1531>`_
+(section 2.3), but differ in detail.
+Direct adjacency is preferred over proximity. For polygons of municipalities
+without a substation inside it is iteratively checked for direct adjacent
+other polygons that have a substation inside. Hence, MV grid districts grow
+around a polygon with a substation inside.
+
+See :func:`define_mv_grid_districts` for more details.
 """
 
 from geoalchemy2.types import Geometry

--- a/src/egon/data/processing/mv_grid_districts.py
+++ b/src/egon/data/processing/mv_grid_districts.py
@@ -106,9 +106,7 @@ class VoronoiMunicipalityCutsBase(object):
     geom_sub = Column(Geometry("Point", 3035))
 
 
-class VoronoiMunicipalityCuts(
-    VoronoiMunicipalityCutsBase, Base
-):
+class VoronoiMunicipalityCuts(VoronoiMunicipalityCutsBase, Base):
     __tablename__ = "voronoi_municipality_cuts"
     __table_args__ = {"schema": "grid"}
 
@@ -119,9 +117,7 @@ class VoronoiMunicipalityCuts(
     )
 
 
-class VoronoiMunicipalityCutsAssigned(
-    VoronoiMunicipalityCutsBase, Base
-):
+class VoronoiMunicipalityCutsAssigned(VoronoiMunicipalityCutsBase, Base):
     __tablename__ = "voronoi_municipality_cuts_assigned"
     __table_args__ = {"schema": "grid"}
 
@@ -178,13 +174,13 @@ def substations_in_municipalities():
                 Vg250GemClean,
                 func.count(EgonHvmvSubstation.point).label("subst_count"),
             )
-                .filter(
+            .filter(
                 func.ST_Contains(
                     Vg250GemClean.geometry,
                     func.ST_Transform(EgonHvmvSubstation.point, 3035),
                 )
             )
-                .group_by(Vg250GemClean.id)
+            .group_by(Vg250GemClean.id)
         )
 
         muns_with_subst = (
@@ -246,7 +242,9 @@ def split_multi_substation_municipalities():
     engine = db.engine()
     VoronoiMunicipalityCuts.__table__.drop(bind=engine, checkfirst=True)
     VoronoiMunicipalityCuts.__table__.create(bind=engine)
-    VoronoiMunicipalityCutsAssigned.__table__.drop(bind=engine, checkfirst=True)
+    VoronoiMunicipalityCutsAssigned.__table__.drop(
+        bind=engine, checkfirst=True
+    )
     VoronoiMunicipalityCutsAssigned.__table__.create(bind=engine)
 
     with session_scope() as session:
@@ -266,13 +264,13 @@ def split_multi_substation_municipalities():
                 EgonHvmvSubstationVoronoi.subst_id,
                 EgonHvmvSubstationVoronoi.id.label("voronoi_id"),
             )
-                .filter(HvmvSubstPerMunicipality.subst_count > 1)
-                .filter(
+            .filter(HvmvSubstPerMunicipality.subst_count > 1)
+            .filter(
                 HvmvSubstPerMunicipality.geometry.intersects(
                     func.ST_Transform(EgonHvmvSubstationVoronoi.geom, 3035)
                 )
             )
-                .subquery()
+            .subquery()
         )
 
         voronoi_cuts = VoronoiMunicipalityCuts.__table__.insert().from_select(
@@ -298,22 +296,21 @@ def split_multi_substation_municipalities():
                 ),
                 func.count(EgonHvmvSubstation.point).label("subst_count"),
             )
-                .filter(
+            .filter(
                 func.ST_Contains(
                     VoronoiMunicipalityCuts.geom,
                     func.ST_Transform(EgonHvmvSubstation.point, 3035),
                 )
             )
-                .group_by(
+            .group_by(
                 VoronoiMunicipalityCuts.id,
                 EgonHvmvSubstation.subst_id,
                 EgonHvmvSubstation.point,
             )
-                .subquery()
+            .subquery()
         )
         session.query(VoronoiMunicipalityCuts).filter(
-            VoronoiMunicipalityCuts.id
-            == cuts_substation_subquery.c.id
+            VoronoiMunicipalityCuts.id == cuts_substation_subquery.c.id
         ).update(
             {
                 "subst_count": cuts_substation_subquery.c.subst_count,
@@ -329,19 +326,19 @@ def split_multi_substation_municipalities():
         # polygons subsequently
         cut_1subst = (
             session.query(VoronoiMunicipalityCuts)
-                .filter(
-                VoronoiMunicipalityCuts.subst_count == 1)
-                .subquery()
+            .filter(VoronoiMunicipalityCuts.subst_count == 1)
+            .subquery()
         )
 
-        originally_1subst = VoronoiMunicipalityCutsAssigned.__table__.insert().from_select(
-            [
-                _
-                for _ in
-                VoronoiMunicipalityCutsAssigned.__table__.columns
-                if _.name != "temp_id"
-            ],
-            cut_1subst
+        originally_1subst = (
+            VoronoiMunicipalityCutsAssigned.__table__.insert().from_select(
+                [
+                    _
+                    for _ in VoronoiMunicipalityCutsAssigned.__table__.columns
+                    if _.name != "temp_id"
+                ],
+                cut_1subst,
+            )
         )
         session.execute(originally_1subst)
         session.commit()
@@ -360,15 +357,19 @@ def split_multi_substation_municipalities():
             # The assignment process is performed iteratively. In each
             # iteration, touching polygons are used for assignment
             already_assigned_polygons_query = session.query(
-                VoronoiMunicipalityCutsAssigned.id).all()
-            already_assigned_polygons = [p for p, in
-                                         already_assigned_polygons_query]
+                VoronoiMunicipalityCutsAssigned.id
+            ).all()
+            already_assigned_polygons = [
+                p for p, in already_assigned_polygons_query
+            ]
             cut_0subst = (
                 session.query(VoronoiMunicipalityCuts)
-                    .filter(
-                    VoronoiMunicipalityCuts.subst_count == None
+                .filter(VoronoiMunicipalityCuts.subst_count == None)
+                .filter(
+                    VoronoiMunicipalityCuts.id.notin_(
+                        already_assigned_polygons
+                    )
                 )
-                    .filter(VoronoiMunicipalityCuts.id.notin_(already_assigned_polygons))
             )
             remaining_polygons.append(len(cut_0subst.all()))
 
@@ -376,32 +377,41 @@ def split_multi_substation_municipalities():
             # This has to be done iteratively, because already assigned
             # polygons that don't have a substation assigned initially, are
             # considered as assignment target subsequently
-            relevant_columns = [col for col in VoronoiMunicipalityCutsAssigned.__table__.columns if col.name != "temp_id"]
-            polygons_for_assignment = session.query(*relevant_columns).subquery()
-
+            relevant_columns = [
+                col
+                for col in VoronoiMunicipalityCutsAssigned.__table__.columns
+                if col.name != "temp_id"
+            ]
+            polygons_for_assignment = session.query(
+                *relevant_columns
+            ).subquery()
 
             # Check if in the last iteration polygons were assigned. If not,
             # there are no further polygons without a substation that touch
             # another polygon that has a substation or that was already
             # assigned
             if (remaining_polygons[-1]) < remaining_polygons[-2]:
-                assign_substation_municipality_fragments(polygons_for_assignment,
-                                       cut_0subst.subquery(),
-                                       "touches",
-                                       session)
+                assign_substation_municipality_fragments(
+                    polygons_for_assignment,
+                    cut_0subst.subquery(),
+                    "touches",
+                    session,
+                )
             else:
                 break
 
         # Step 5: Assign remaining polygons that are non-touching
-        assign_substation_municipality_fragments(polygons_for_assignment,
-                               cut_0subst.subquery(),
-                               "min_distance",
-                               session)
+        assign_substation_municipality_fragments(
+            polygons_for_assignment,
+            cut_0subst.subquery(),
+            "min_distance",
+            session,
+        )
 
 
-def assign_substation_municipality_fragments(with_substation,
-                                             without_substation, strategy,
-                           session):
+def assign_substation_municipality_fragments(
+    with_substation, without_substation, strategy, session
+):
     """
     Assign subst_id from next neighboring polygon to municipality fragment
 
@@ -436,58 +446,71 @@ def assign_substation_municipality_fragments(with_substation,
     columns_from_cut1_subst = ["subst_id", "subst_count", "geom_sub"]
 
     if strategy == "touches":
-        neighboring_criterion = func.ST_Touches(without_substation.c.geom, with_substation.c.geom)
+        neighboring_criterion = func.ST_Touches(
+            without_substation.c.geom, with_substation.c.geom
+        )
     elif strategy == "min_distance":
         neighboring_criterion = func.ST_DWithin(
-            without_substation.c.geom,
-            with_substation.c.geom, 100000)
+            without_substation.c.geom, with_substation.c.geom, 100000
+        )
     else:
         raise ValueError(f"Invalid input for 'strategy': {strategy}")
     cut_0subst_nearest_neighbor_sub = (
-        session.query(
-            *[
-                c
-                for c in with_substation.columns
-                if c.name in columns_from_cut1_subst
-            ],
-            *[
-                c
-                for c in without_substation.columns
-                if c.name not in columns_from_cut1_subst
-            ],
+        (
+            session.query(
+                *[
+                    c
+                    for c in with_substation.columns
+                    if c.name in columns_from_cut1_subst
+                ],
+                *[
+                    c
+                    for c in without_substation.columns
+                    if c.name not in columns_from_cut1_subst
+                ],
+            )
         )
-    ).filter(
-        without_substation.c.ags_0 == with_substation.c.ags_0
-    ).filter(neighboring_criterion).order_by(
+        .filter(without_substation.c.ags_0 == with_substation.c.ags_0)
+        .filter(neighboring_criterion)
+        .order_by(
             without_substation.c.id,
-            func.ST_Distance(without_substation.c.geom,
-                             with_substation.c.geom),
-        ).subquery()
-
+            func.ST_Distance(
+                without_substation.c.geom, with_substation.c.geom
+            ),
+        )
+        .subquery()
+    )
 
     # Group by id of cut polygons which is unique. The reason that multiple
     # rows for each id exist is that assignment to multiple polygon with
     # a substations would be possible. The are ordered by distance
     cut_0subst_nearest_neighbor_grouped = (
         session.query(cut_0subst_nearest_neighbor_sub.c.id)
-            .group_by(cut_0subst_nearest_neighbor_sub.c.id)
-            .subquery()
+        .group_by(cut_0subst_nearest_neighbor_sub.c.id)
+        .subquery()
     )
 
     # Select one single assignment polygon (with substation) for each of
     # the polygons without a substation
-    cut_0subst_nearest_neighbor = session.query(
-        cut_0subst_nearest_neighbor_sub).filter(
-        cut_0subst_nearest_neighbor_sub.c.id == cut_0subst_nearest_neighbor_grouped.c.id
-    ).distinct(cut_0subst_nearest_neighbor_sub.c.id).subquery()
+    cut_0subst_nearest_neighbor = (
+        session.query(cut_0subst_nearest_neighbor_sub)
+        .filter(
+            cut_0subst_nearest_neighbor_sub.c.id
+            == cut_0subst_nearest_neighbor_grouped.c.id
+        )
+        .distinct(cut_0subst_nearest_neighbor_sub.c.id)
+        .subquery()
+    )
 
-    cut_0subst_insert = VoronoiMunicipalityCutsAssigned.__table__.insert().from_select(
-        [
-            c
-            for c in cut_0subst_nearest_neighbor.columns
-            if c.name not in ["temp_id"]
-        ],
-        cut_0subst_nearest_neighbor,
+    cut_0subst_insert = (
+        VoronoiMunicipalityCutsAssigned.__table__.insert().from_select(
+            [
+                c
+                for c in cut_0subst_nearest_neighbor.columns
+                if c.name not in ["temp_id"]
+            ],
+            cut_0subst_nearest_neighbor,
+        )
     )
     session.execute(cut_0subst_insert)
     session.commit()
@@ -520,41 +543,55 @@ def merge_polygons_to_grid_district():
         # to prior determined associated substation
         joined_municipality_parts = session.query(
             VoronoiMunicipalityCutsAssigned.subst_id,
-        func.ST_Multi(func.ST_Union(VoronoiMunicipalityCutsAssigned.geom)).label("geom"),
-        func.sum(func.ST_Area(VoronoiMunicipalityCutsAssigned.geom)).label("area")
-        ).group_by(
-            VoronoiMunicipalityCutsAssigned.subst_id)
+            func.ST_Multi(
+                func.ST_Union(VoronoiMunicipalityCutsAssigned.geom)
+            ).label("geom"),
+            func.sum(func.ST_Area(VoronoiMunicipalityCutsAssigned.geom)).label(
+                "area"
+            ),
+        ).group_by(VoronoiMunicipalityCutsAssigned.subst_id)
 
-        joined_municipality_parts_insert = \
+        joined_municipality_parts_insert = (
             MvGridDistrictsDissolved.__table__.insert().from_select(
-                [c for c in MvGridDistrictsDissolved.__table__.columns
-                 if c.name != "id"],
-                joined_municipality_parts.subquery()
+                [
+                    c
+                    for c in MvGridDistrictsDissolved.__table__.columns
+                    if c.name != "id"
+                ],
+                joined_municipality_parts.subquery(),
             )
+        )
         session.execute(joined_municipality_parts_insert)
         session.commit()
 
         # Step 2: Insert municipality polygons with exactly one substation
-        one_substation = session.query(
-            EgonHvmvSubstation.subst_id,
-            func.ST_Multi(HvmvSubstPerMunicipality.geometry).label("geom"),
-            func.ST_Area(func.ST_Multi(HvmvSubstPerMunicipality.geometry)
-                         ).label("area"),
-        ).filter(
-            HvmvSubstPerMunicipality.subst_count == 1
-        ).filter(
-            func.ST_Contains(
-                HvmvSubstPerMunicipality.geometry,
-                func.ST_Transform(EgonHvmvSubstation.point, 3035)
+        one_substation = (
+            session.query(
+                EgonHvmvSubstation.subst_id,
+                func.ST_Multi(HvmvSubstPerMunicipality.geometry).label("geom"),
+                func.ST_Area(
+                    func.ST_Multi(HvmvSubstPerMunicipality.geometry)
+                ).label("area"),
+            )
+            .filter(HvmvSubstPerMunicipality.subst_count == 1)
+            .filter(
+                func.ST_Contains(
+                    HvmvSubstPerMunicipality.geometry,
+                    func.ST_Transform(EgonHvmvSubstation.point, 3035),
+                )
             )
         )
 
-        one_substation_insert = \
+        one_substation_insert = (
             MvGridDistrictsDissolved.__table__.insert().from_select(
-                [c for c in MvGridDistrictsDissolved.__table__.columns
-                 if c.name != "id"],
-                one_substation.subquery()
+                [
+                    c
+                    for c in MvGridDistrictsDissolved.__table__.columns
+                    if c.name != "id"
+                ],
+                one_substation.subquery(),
             )
+        )
         session.execute(one_substation_insert)
         session.commit()
 
@@ -565,56 +602,59 @@ def merge_polygons_to_grid_district():
             previous_ids_length = len(already_assigned)
             with_substation = session.query(
                 MvGridDistrictsDissolved.subst_id,
-                MvGridDistrictsDissolved.geom
+                MvGridDistrictsDissolved.geom,
             ).subquery()
             without_substation = (
                 session.query(
                     HvmvSubstPerMunicipality.geometry.label("geom"),
-                    HvmvSubstPerMunicipality.id)
-                    .filter(
-                    HvmvSubstPerMunicipality.subst_count == 0).filter(
-                    HvmvSubstPerMunicipality.id.notin_(already_assigned)
+                    HvmvSubstPerMunicipality.id,
                 )
-                    .subquery()
+                .filter(HvmvSubstPerMunicipality.subst_count == 0)
+                .filter(HvmvSubstPerMunicipality.id.notin_(already_assigned))
+                .subquery()
             )
 
             # Find nearest neighboring polygon from with_substation for each
             # polygon from without_substation
             newly_assigned_ids = nearest_polygon_with_substation(
-                with_substation,
-                without_substation,
-                "touches",
-                session)
+                with_substation, without_substation, "touches", session
+            )
             already_assigned.extend(newly_assigned_ids)
 
             if not len(already_assigned) > previous_ids_length:
                 nearest_polygon_with_substation(
-                    with_substation,
-                    without_substation,
-                    "within",
-                    session)
+                    with_substation, without_substation, "within", session
+                )
                 break
 
         # Step 4: Merge MV grid district parts
         # Forms one (multi-)polygon for each substation
         joined_mv_grid_district_parts = session.query(
             MvGridDistrictsDissolved.subst_id,
-        func.ST_Multi(func.ST_Buffer(func.ST_Buffer(func.ST_Union(MvGridDistrictsDissolved.geom), 0.1), -0.1)).label("geom"),
-        func.sum(MvGridDistrictsDissolved.area).label("area")
-        ).group_by(
-            MvGridDistrictsDissolved.subst_id)
+            func.ST_Multi(
+                func.ST_Buffer(
+                    func.ST_Buffer(
+                        func.ST_Union(MvGridDistrictsDissolved.geom), 0.1
+                    ),
+                    -0.1,
+                )
+            ).label("geom"),
+            func.sum(MvGridDistrictsDissolved.area).label("area"),
+        ).group_by(MvGridDistrictsDissolved.subst_id)
 
-        joined_mv_grid_district_parts_insert = \
+        joined_mv_grid_district_parts_insert = (
             MvGridDistricts.__table__.insert().from_select(
                 MvGridDistricts.__table__.columns,
-                joined_mv_grid_district_parts.subquery()
+                joined_mv_grid_district_parts.subquery(),
             )
+        )
         session.execute(joined_mv_grid_district_parts_insert)
         session.commit()
 
 
-def nearest_polygon_with_substation(with_substation, without_substation,
-                                    strategy, session):
+def nearest_polygon_with_substation(
+    with_substation, without_substation, strategy, session
+):
     """
     Assign next neighboring polygon
 
@@ -647,49 +687,62 @@ def nearest_polygon_with_substation(with_substation, without_substation,
         substation
     """
     if strategy == "touches":
-        neighboring_criterion = func.ST_Touches(without_substation.c.geom, with_substation.c.geom)
+        neighboring_criterion = func.ST_Touches(
+            without_substation.c.geom, with_substation.c.geom
+        )
     elif strategy == "within":
         neighboring_criterion = func.ST_DWithin(
-            without_substation.c.geom,
-            with_substation.c.geom, 100000)
+            without_substation.c.geom, with_substation.c.geom, 100000
+        )
     else:
         raise ValueError(f"Invalid input for 'strategy': {strategy}")
 
     # Find nearest neighboring polygon from with_substation for each
     # polygon from without_substation
-    all_nearest_neighbors = session.query(
-        without_substation.c.id,
-        func.ST_Multi(without_substation.c.geom).label("geom"),
-        with_substation.c.subst_id,
-        func.ST_Area(func.ST_Multi(without_substation.c.geom)).label("area"),
-    ).filter(neighboring_criterion
-    ).order_by(
-        without_substation.c.id,
-        func.ST_Distance(without_substation.c.geom,
-                         with_substation.c.geom)
-    ).subquery()
+    all_nearest_neighbors = (
+        session.query(
+            without_substation.c.id,
+            func.ST_Multi(without_substation.c.geom).label("geom"),
+            with_substation.c.subst_id,
+            func.ST_Area(func.ST_Multi(without_substation.c.geom)).label(
+                "area"
+            ),
+        )
+        .filter(neighboring_criterion)
+        .order_by(
+            without_substation.c.id,
+            func.ST_Distance(
+                without_substation.c.geom, with_substation.c.geom
+            ),
+        )
+        .subquery()
+    )
 
     # Save list of newly assigned polygons
-    newly_assigned = session.query(all_nearest_neighbors.c.id).distinct(
-        all_nearest_neighbors.c.id).all()
+    newly_assigned = (
+        session.query(all_nearest_neighbors.c.id)
+        .distinct(all_nearest_neighbors.c.id)
+        .all()
+    )
     newly_assigned_ids = [i for i, in newly_assigned]
 
     # Take only one candidate polygon for assgning it
     nearest_neighbors = session.query(
         all_nearest_neighbors.c.subst_id,
         all_nearest_neighbors.c.geom,
-        all_nearest_neighbors.c.area
-    ).distinct(
-        all_nearest_neighbors.c.id)
+        all_nearest_neighbors.c.area,
+    ).distinct(all_nearest_neighbors.c.id)
 
     # Insert polygons with newly assigned substation
-    assigned_polygons_insert = MvGridDistrictsDissolved.__table__.insert().from_select(
-        [
-            c
-            for c in MvGridDistrictsDissolved.__table__.columns
-            if c.name not in ["id"]
-        ],
-        nearest_neighbors,
+    assigned_polygons_insert = (
+        MvGridDistrictsDissolved.__table__.insert().from_select(
+            [
+                c
+                for c in MvGridDistrictsDissolved.__table__.columns
+                if c.name not in ["id"]
+            ],
+            nearest_neighbors,
+        )
     )
     session.execute(assigned_polygons_insert)
     session.commit()
@@ -720,5 +773,8 @@ def define_mv_grid_districts():
     engine = db.engine()
     HvmvSubstPerMunicipality.__table__.drop(bind=engine, checkfirst=True)
     VoronoiMunicipalityCuts.__table__.drop(bind=engine, checkfirst=True)
-    VoronoiMunicipalityCutsAssigned.__table__.drop(bind=engine, checkfirst=True)
+    VoronoiMunicipalityCutsAssigned.__table__.drop(
+        bind=engine, checkfirst=True
+    )
     MvGridDistrictsDissolved.__table__.drop(bind=engine, checkfirst=True)
+

--- a/src/egon/data/processing/mv_grid_districts.py
+++ b/src/egon/data/processing/mv_grid_districts.py
@@ -554,7 +554,7 @@ def merge_polygons_to_grid_district():
         # Forms one (multi-)polygon for each substation
         joined_mv_grid_district_parts = session.query(
             MvGridDistrictsDissolved.subst_id,
-        func.ST_Multi(func.ST_Union(MvGridDistrictsDissolved.geom)).label("geom"),
+        func.ST_Multi(func.ST_Buffer(func.ST_Buffer(func.ST_Union(MvGridDistrictsDissolved.geom), 0.1), -0.1)).label("geom"),
         func.sum(MvGridDistrictsDissolved.area).label("area")
         ).group_by(
             MvGridDistrictsDissolved.subst_id)

--- a/src/egon/data/processing/mv_grid_districts.py
+++ b/src/egon/data/processing/mv_grid_districts.py
@@ -328,22 +328,22 @@ def split_multi_substation_municipalities():
         columns_from_cut1_subst = ["subst_id", "subst_count", "geom_sub"]
         cut_0subst_nearest_neighbor_sub = (
             session.query(
-                # TODO: iterate over columns_from_cut1_subst to make sure that same columns are used
-                cut_1subst.c.subst_id,
-                cut_1subst.c.subst_count,
-                cut_1subst.c.geom_sub,
+                *[
+                    c
+                    for c in cut_1subst.columns
+                    if c.name in columns_from_cut1_subst
+                ],
                 *[
                     c
                     for c in cut_0subst.columns
                     if c.name not in columns_from_cut1_subst
                 ]
             )
-            .filter(
+                .filter(
                 cut_0subst.c.ags_0 == cut_1subst.c.ags_0,
                 func.ST_DWithin(func.ST_ExteriorRing(cut_0subst.c.geom), func.ST_ExteriorRing(cut_1subst.c.geom), 100000)
             )
             .order_by(
-                # TODO: order by ST_Touches first
                 func.ST_Distance(func.ST_ExteriorRing(cut_0subst.c.geom), func.ST_ExteriorRing(cut_1subst.c.geom)),
             )
             .subquery()

--- a/src/egon/data/processing/mv_grid_districts.py
+++ b/src/egon/data/processing/mv_grid_districts.py
@@ -111,19 +111,6 @@ class EgonHvmvSubstationVoronoiMunicipalityCuts(
     )
 
 
-class EgonHvmvSubstationVoronoiMunicipalityCuts1Subst(
-    EgonHvmvSubstationVoronoiMunicipalityCutsBase, Base
-):
-    __tablename__ = "egon_hvmv_substation_voronoi_municipality_cuts_1subst"
-    __table_args__ = {"schema": "grid"}
-
-    id = Column(
-        Integer,
-        Sequence(f"{__tablename__}_id_seq", schema="grid"),
-        primary_key=True,
-    )
-
-
 class EgonHvmvSubstationVoronoiMunicipalityCuts0Subst(
     EgonHvmvSubstationVoronoiMunicipalityCutsBase, Base
 ):
@@ -230,11 +217,7 @@ def split_multi_substation_municipalities():
         bind=engine, checkfirst=True
     )
     EgonHvmvSubstationVoronoiMunicipalityCuts.__table__.create(bind=engine)
-    EgonHvmvSubstationVoronoiMunicipalityCuts1Subst.__table__.drop(
         bind=engine, checkfirst=True
-    )
-    EgonHvmvSubstationVoronoiMunicipalityCuts1Subst.__table__.create(
-        bind=engine
     )
     EgonHvmvSubstationVoronoiMunicipalityCuts0Subst.__table__.drop(
         bind=engine, checkfirst=True

--- a/src/egon/data/processing/mv_grid_districts.py
+++ b/src/egon/data/processing/mv_grid_districts.py
@@ -493,6 +493,12 @@ def merge_polygons_to_grid_district():
     a single grid district per one HV-MV substation. Prior determined
     assignment of cut polygons parts is used as well as proximity of entire
     municipality polygons to polygons with a substation inside.
+
+    * Step 1: Merge municipality parts that are assigned to the same substation
+    * Step 2: Insert municipality polygons with exactly one substation
+    * Step 3: Assign municipality polygons without a substation and insert
+      to table
+    * Step 4: Merge MV grid district parts
     """
 
     engine = db.engine()
@@ -502,7 +508,7 @@ def merge_polygons_to_grid_district():
     MvGridDistricts.__table__.create(bind=engine)
 
     with session_scope() as session:
-        # Step 1: Merge municipalitiy parts cut by voronoi polygons according
+        # Step 1: Merge municipality parts cut by voronoi polygons according
         # to prior determined associated substation
         joined_municipality_parts = session.query(
             VoronoiMunicipalityCutsAssigned.subst_id,

--- a/src/egon/data/processing/mv_grid_districts.py
+++ b/src/egon/data/processing/mv_grid_districts.py
@@ -688,6 +688,29 @@ def nearest_polygon_with_substation(with_substation, without_substation,
 
     return newly_assigned_ids
 
-substations_in_municipalities()
-split_multi_substation_municipalities()
-merge_polygons_to_grid_district()
+
+def define_mv_grid_districts():
+    """
+    Define spatial extent of MV grid districts
+
+    The process of identifying the boundary of medium-voltage grid districts
+    is organized in three steps
+
+    1. :func:`substations_in_municipalities`: The number of substations
+      located inside each municipality is calculated
+    2. :func:`split_multi_substation_municipalities`: The municipalities with
+      >1 substation inside are split by Voronoi polygons around substations
+    3. :func:`merge_polygons_to_grid_district`: All polygons are merged such
+      that one polygon has exactly one single substation inside
+
+    Finally, intermediate tables used for storing data temporarily are deleted.
+    """
+    substations_in_municipalities()
+    split_multi_substation_municipalities()
+    merge_polygons_to_grid_district()
+
+    engine = db.engine()
+    HvmvSubstPerMunicipality.__table__.drop(bind=engine, checkfirst=True)
+    VoronoiMunicipalityCuts.__table__.drop(bind=engine, checkfirst=True)
+    VoronoiMunicipalityCutsAssigned.__table__.drop(bind=engine, checkfirst=True)
+    MvGridDistrictsDissolved.__table__.drop(bind=engine, checkfirst=True)


### PR DESCRIPTION
This pull request introduces code for identifying mediu-voltage grid districts based on municipality boundaries, HV-MV substations and voronoi polygons around these. Please see documentation along code for further details.

I couldn't perform a final check if everything runs smoothly in the pipeline because creation of voronoi failed, see #221.

Did not work on [ego_dp_substation_id_to_generator.sql](https://github.com/openego/data_processing/blob/5edca414212ccb4b1df6b046bf916bc2ebb7b4c6/dataprocessing/sql_snippets/ego_dp_substation_id_to_generator.sql) at all, because I assumed power plant data isn't ready yet.

Fixes #10.