### PR TITLE
Integrate weather data and feedin timeseries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -80,6 +80,8 @@ Added
   `#177 <https://github.com/openego/eGon-data/issues/177>`_
 * Extract landuse areas from OSM 
   `#214 <https://github.com/openego/eGon-data/issues/214>`_
+* Integrate weather data and renewable feedin timeseries
+  `#19 <https://github.com/openego/eGon-data/issues/19>`_
 
 .. _PR #159: https://github.com/openego/eGon-data/pull/159
 

--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,8 @@ packages are required too. Right now these are:
 * To download ERA5 weather data you need to register at the CDS
   registration page and install the CDS API key as descibed
   `here <https://cds.climate.copernicus.eu/api-how-to>`_
+  You also have to agree on the `terms of use 
+  <https://cds.climate.copernicus.eu/cdsapp/#!/terms/licence-to-use-copernicus-products>`_
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,10 @@ packages are required too. Right now these are:
   On recent Ubuntu version you can install it via
   :code:`sudo apt install gdal-bin`.
 
+* To download ERA5 weather data you need to register at the CDS
+  registration page and install the CDS API key as descibed
+  `here <https://cds.climate.copernicus.eu/api-how-to>`_
+
 Installation
 ============
 

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
         # eg: 'aspectlib==1.1.1', 'six>=1.7',
         "apache-airflow>=1.10.14,<2.0",
         "atlite==0.0.3",
+        "cdsapi",
         "click",
         "disaggregator"
         "@git+https://github.com/openego/disaggregator.git"

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
     install_requires=[
         # eg: 'aspectlib==1.1.1', 'six>=1.7',
         "apache-airflow>=1.10.14,<2.0",
+        "atlite==0.0.3",
         "click",
         "disaggregator"
         "@git+https://github.com/openego/disaggregator.git"

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -426,5 +426,17 @@ with airflow.DAG(
         python_callable=import_feedin.wind_feedin_per_weather_cell,
     )
 
-    import_weather_cells >> feedin_wind_onshore
-    vg250_clean_and_prepare >> feedin_wind_onshore
+    feedin_pv = PythonOperator(
+        task_id="insert-feedin-pv",
+        python_callable=import_feedin.pv_feedin_per_weather_cell,
+    )
+
+    feedin_solar_thermal = PythonOperator(
+        task_id="insert-feedin-solar-thermal",
+        python_callable=import_feedin.solar_thermal_feedin_per_weather_cell,
+    )
+
+    import_weather_cells >> [feedin_wind_onshore,
+                             feedin_pv, feedin_solar_thermal]
+    vg250_clean_and_prepare >> [feedin_wind_onshore,
+                             feedin_pv, feedin_solar_thermal]

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -452,7 +452,7 @@ with airflow.DAG(
         task_id="download-weather-data",
         python_callable=import_era5.download_era5,
     )
-    setup >> download_era5
+    scenario_input_import >> download_era5
 
     create_weather_tables = PythonOperator(
         task_id="create-weather-tables",

--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -316,6 +316,9 @@ renewable_feedin:
     vg250_lan_union:
       schema: 'boundaries'
       table: 'vg250_lan_union'
+    vg250_sta_union:
+      schema: 'boundaries'
+      table: 'vg250_sta_union'
   targets:
     feedin_table:
       schema: 'supply'

--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -364,4 +364,4 @@ renewable_feedin:
   targets:
     feedin_table:
       schema: 'supply'
-      table: 'egon_renewable_feed_in'
+      table: 'egon_era5_renewable_feedin'

--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -297,3 +297,20 @@ power_plants:
   target:
       table: 'egon_power_plants'
       schema: 'supply'
+
+era5_weather_data:
+  targets:
+    weather_data:
+      path: 'cutouts'
+    weather_cells:
+      schema: 'supply'
+      table: 'egon_era5_weather_cells'
+
+renewable_feedin:
+  soucres:
+    era5_weather_data:
+      path: 'cutouts'
+  targets:
+    feedin_table:
+      schema: 'supply'
+      table: 'egon_renewable_feed_in'

--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -307,9 +307,15 @@ era5_weather_data:
       table: 'egon_era5_weather_cells'
 
 renewable_feedin:
-  soucres:
+  sources:
     era5_weather_data:
       path: 'cutouts'
+    weather_cells:
+      schema: 'supply'
+      table: 'egon_era5_weather_cells'
+    vg250_lan_union:
+      schema: 'boundaries'
+      table: 'vg250_lan_union'
   targets:
     feedin_table:
       schema: 'supply'

--- a/src/egon/data/importing/era5/__init__.py
+++ b/src/egon/data/importing/era5/__init__.py
@@ -104,9 +104,9 @@ def download_era5():
 
         cutout = import_cutout()
 
-        if not cutout.prepared:
+    if not cutout.prepared:
 
-            cutout.prepare()
+        cutout.prepare()
 
 
 def insert_weather_cells():

--- a/src/egon/data/importing/era5/__init__.py
+++ b/src/egon/data/importing/era5/__init__.py
@@ -1,0 +1,118 @@
+"""
+Central module containing all code dealing with importing era5 weather data.
+"""
+
+import atlite
+import os
+from pathlib import Path
+
+import geopandas as gpd
+import egon.data.config
+from egon.data import db
+from sqlalchemy import Column, String, Float, Integer, ARRAY
+from sqlalchemy.ext.declarative import declarative_base
+from geoalchemy2 import Geometry
+# will be later imported from another file ###
+Base = declarative_base()
+
+class EgonEra5Cells(Base):
+    __tablename__ = 'egon_era5_weather_cells'
+    __table_args__ = {'schema': 'supply'}
+    w_id = Column(Integer, primary_key=True)
+    geom = Column(Geometry('POLYGON', 4326))
+    geom_point = Column(Geometry('POINT', 4326))
+
+
+class EgonRenewableFeedIn(Base):
+    __tablename__ = 'egon_renewable_feed_in'
+    __table_args__ = {'schema': 'supply'}
+    w_id = Column(Integer, primary_key=True)
+    weather_year = Column(Integer, primary_key=True)
+    carrier = Column(String, primary_key=True)
+    feedin = Column(ARRAY(Float()))
+
+def create_tables():
+
+    db.execute_sql(
+        "CREATE SCHEMA IF NOT EXISTS supply;")
+    engine = db.engine()
+    EgonEra5Cells.__table__.drop(bind=engine, checkfirst=True)
+    EgonEra5Cells.__table__.create(bind=engine, checkfirst=True)
+    EgonRenewableFeedIn.__table__.drop(bind=engine, checkfirst=True)
+    EgonRenewableFeedIn.__table__.create(bind=engine, checkfirst=True)
+
+def import_cutout():
+    """ Import weather data from cutout
+
+    Returns
+    -------
+    cutout : atlite.cutout.Cutout
+        Weather data stored in cutout
+
+    """
+
+    directory = Path(".") / (
+        egon.data.config.datasets()
+        ['era5_weather_data']['targets']['weather_data']['path'])
+
+    # TODO: Replace with scenario table query
+    weather_year = 2011
+
+    cutout = atlite.Cutout(
+            f"europe-{str(weather_year)}-era5",
+            cutout_dir = directory.absolute(),
+            module="era5",
+            xs= slice(7.5, 12),
+            ys=slice(55., 53.),
+            years= slice(weather_year, weather_year)
+            )
+
+    return cutout
+
+def download_era5():
+    """ Download weather data from era5
+
+    Returns
+    -------
+    None.
+
+    """
+
+    directory = Path(".") / (
+        egon.data.config.datasets()
+        ['era5_weather_data']['targets']['weather_data']['path'])
+
+    if not os.path.exists(directory):
+
+        os.mkdir(directory)
+
+        cutout = import_cutout()
+
+        cutout.prepare()
+
+
+def insert_weather_cells():
+    """ Insert weather cells from era5 into database table
+
+    Returns
+    -------
+    None.
+
+    """
+
+    cfg = egon.data.config.datasets()['era5_weather_data']
+
+    cutout = import_cutout()
+
+    df = gpd.GeoDataFrame(
+        {'geom': cutout.grid_cells()}, geometry='geom', crs=4326)
+
+    df.to_postgis(cfg['targets']['weather_cells']['table'],
+                  schema=cfg['targets']['weather_cells']['schema'],
+                  con=db.engine(), if_exists='append')
+
+    db.execute_sql(
+        f"""UPDATE {cfg['targets']['weather_cells']['schema']}.
+        {cfg['targets']['weather_cells']['table']}
+        SET geom_point=ST_Centroid(geom);"""
+        )

--- a/src/egon/data/importing/era5/__init__.py
+++ b/src/egon/data/importing/era5/__init__.py
@@ -102,7 +102,7 @@ def download_era5():
 
         os.mkdir(directory)
 
-        cutout = import_cutout()
+    cutout = import_cutout()
 
     if not cutout.prepared:
 

--- a/src/egon/data/importing/era5/__init__.py
+++ b/src/egon/data/importing/era5/__init__.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import geopandas as gpd
 import egon.data.config
 from egon.data import db
+from egon.data.importing.scenarios import get_sector_parameters
 from sqlalchemy import Column, String, Float, Integer, ARRAY
 from sqlalchemy.ext.declarative import declarative_base
 from geoalchemy2 import Geometry
@@ -71,8 +72,7 @@ def import_cutout(boundary='Europe'):
         egon.data.config.datasets()
         ['era5_weather_data']['targets']['weather_data']['path'])
 
-    # TODO: Replace with scenario table query
-    weather_year = 2011
+    weather_year = get_sector_parameters('global', 'eGon2035')['weather_year']
 
     cutout = atlite.Cutout(
             f"europe-{str(weather_year)}-era5",

--- a/src/egon/data/importing/era5/__init__.py
+++ b/src/egon/data/importing/era5/__init__.py
@@ -25,7 +25,7 @@ class EgonEra5Cells(Base):
 
 
 class EgonRenewableFeedIn(Base):
-    __tablename__ = 'egon_renewable_feed_in'
+    __tablename__ = 'egon_era5_renewable_feedin'
     __table_args__ = {'schema': 'supply'}
     w_id = Column(Integer, primary_key=True)
     weather_year = Column(Integer, primary_key=True)
@@ -104,7 +104,9 @@ def download_era5():
 
         cutout = import_cutout()
 
-        cutout.prepare()
+        if not cutout.prepared:
+
+            cutout.prepare()
 
 
 def insert_weather_cells():

--- a/src/egon/data/importing/era5/__init__.py
+++ b/src/egon/data/importing/era5/__init__.py
@@ -106,7 +106,7 @@ def download_era5():
 
     if not cutout.prepared:
 
-        cutout.prepare()
+        cutout.prepare(nprocesses=1)
 
 
 def insert_weather_cells():

--- a/src/egon/data/processing/renewable_feedin/__init__.py
+++ b/src/egon/data/processing/renewable_feedin/__init__.py
@@ -8,6 +8,7 @@ import numpy as np
 import egon.data.config
 from egon.data import db
 from egon.data.importing.era5 import import_cutout
+from egon.data.importing.scenarios import get_sector_parameters
 
 def weather_cells_in_germany():
     """ Get weather cells which intersect with Germany
@@ -191,9 +192,12 @@ def wind_feedin_per_weather_cell():
     timeseries = gpd.sjoin(
         weather_cells, timeseries_per_turbine)[['E-141', 'E-126']]
 
+    weather_year = get_sector_parameters('global', 'eGon2035')['weather_year']
+
     df = pd.DataFrame(index=weather_cells.index,
                       columns=['weather_year', 'carrier', 'feedin'],
-                      data={'weather_year':2011, 'carrier':'wind_onshore'})
+                      data={'weather_year': weather_year,
+                            'carrier':'wind_onshore'})
 
     # Insert feedin for selected turbine per weather cell
     for turbine in ['E-126', 'E-141']:

--- a/src/egon/data/processing/renewable_feedin/__init__.py
+++ b/src/egon/data/processing/renewable_feedin/__init__.py
@@ -1,0 +1,152 @@
+"""
+Central module containing all code dealing with processing era5 weather data.
+"""
+
+import pandas as pd
+import geopandas as gpd
+import numpy as np
+import egon.data.config
+from egon.data import db
+from egon.data.importing.era5 import import_cutout
+
+def turbine_per_weather_cell():
+    """Assign wind onshore turbine types to weather cells
+
+    Returns
+    -------
+    weather_cells : GeoPandas.GeoDataFrame
+        Weather cells in Germany including turbine type
+
+    """
+
+    cfg = egon.data.config.datasets()['renewable_feedin']['sources']
+
+    # Select representative onshore wind turbines per federal state
+    map_federal_states_turbines = {
+        'Schleswig-Holstein': 'E-126',
+        'Bremen': 'E-126',
+        'Hamburg': 'E-126',
+        'Mecklenburg-Vorpommern': 'E-126',
+        'Niedersachsen': 'E-126',
+        'Berlin': 'E-141',
+        'Brandenburg': 'E-141',
+        'Hessen': 'E-141',
+        'Nordhrein-Westfalen': 'E-141',
+        'Sachsen': 'E-141',
+        'Sachsen-Anhalt': 'E-141',
+        'Thüringen': 'E-141',
+        'Baden-Württemberg': 'E-141',
+        'Bayern': 'E-141',
+        'Rheinland-Pfalz': 'E-141',
+        'Saarland': 'E-141'
+        }
+
+    # Select weather cells and ferear states from database
+    weather_cells = db.select_geodataframe(
+        f"""SELECT w_id, geom_point
+        FROM {cfg['weather_cells']['schema']}.
+        {cfg['weather_cells']['table']}""",
+        geom_col='geom_point', index_col='w_id', epsg=4326)
+
+    federal_states = db.select_geodataframe(
+        f"""SELECT gen, geometry
+        FROM {cfg['vg250_lan_union']['schema']}.
+        {cfg['vg250_lan_union']['table']}""",
+        geom_col='geometry', index_col='gen', epsg=4326)
+
+    # Map federal state and onshore wind turbine to weather cells
+    weather_cells['federal_state'] = gpd.sjoin(
+        weather_cells, federal_states).index_right
+
+    weather_cells['wind_turbine'] = weather_cells['federal_state'].map(
+        map_federal_states_turbines)
+
+    return weather_cells
+
+def feedin_per_turbine():
+    """ Calculate feedin timeseries per turbine type and weather cell
+
+    Returns
+    -------
+    gdf : GeoPandas.GeoDataFrame
+        Feed-in timeseries per turbine type and weather cell
+
+    """
+
+    # Select weather data for Germany
+    cutout = import_cutout(boundary='Germany')
+
+    gdf = gpd.GeoDataFrame(geometry=cutout.grid_cells(), crs=4326)
+
+    # Calculate feedin-timeseries for E-141
+    # source: https://openenergy-platform.org/dataedit/view/supply/wind_turbine_library
+    turbine_e141 = {
+        'name': 'E141 4200 kW',
+        'hub_height': 129,
+        'P': 4.200,
+        'V': np.arange(1, 26, dtype=float),
+        'POW': np.array([
+            0., 0.022, 0.104, 0.26, 0.523, 0.92, 1.471, 2.151, 2.867,
+            3.481, 3.903, 4.119, 4.196, 4.2, 4.2, 4.2, 4.2,
+            4.2, 4.2, 4.2, 4.2, 4.2, 4.2, 4.2, 4.2])
+        }
+    ts_e141 = cutout.wind(turbine_e141,
+                          per_unit=True, shapes=cutout.grid_cells())
+
+    gdf['E-141'] = ts_e141.to_pandas().values.tolist()
+
+    # Calculate feedin-timeseries for E-126
+    # source: https://openenergy-platform.org/dataedit/view/supply/wind_turbine_library
+    turbine_e126 = {
+        'name': 'E126 4200 kW',
+        'hub_height': 159,
+        'P': 4.200,
+        'V': np.arange(1, 26, dtype=float),
+        'POW': np.array([
+            0., 0., 0.058, 0.185, 0.4, 0.745, 1.2, 1.79, 2.45,
+            3.12, 3.66, 4.0, 4.15, 4.2, 4.2, 4.2, 4.2,
+            4.2, 4.2, 4.2, 4.2, 4.2, 4.2, 4.2, 4.2])
+        }
+    ts_e126 = cutout.wind(turbine_e126,
+                          per_unit=True, shapes=cutout.grid_cells())
+
+    gdf['E-126'] = ts_e126.to_pandas().values.tolist()
+
+    return gdf
+
+def wind_feedin_per_weather_cell():
+    """ Insert feed-in timeseries for wind onshore turbines to database
+
+    Returns
+    -------
+    None.
+
+    """
+
+    cfg = egon.data.config.datasets()['renewable_feedin']['targets']
+
+    # Get weather cells with turbine type
+    weather_cells = turbine_per_weather_cell()
+    weather_cells = weather_cells[weather_cells.wind_turbine.notnull()]
+
+    # Calculate feedin timeseries per turbine and weather cell
+    timeseries_per_turbine = feedin_per_turbine()
+
+    # Join weather cells and feedin-timeseries
+    timeseries = gpd.sjoin(
+        weather_cells, timeseries_per_turbine)[['E-141', 'E-126']]
+
+    df = pd.DataFrame(index=weather_cells.index,
+                      columns=['weather_year', 'carrier', 'feedin'],
+                      data={'weather_year':2011, 'carrier':'wind_onshore'})
+
+    # Insert feedin for selected turbine per weather cell
+    for turbine in ['E-126', 'E-141']:
+        idx = weather_cells.index[weather_cells.wind_turbine==turbine]
+        df.loc[idx, 'feedin'] = timeseries.loc[idx, turbine].values
+
+    # Insert values into database
+    df.to_sql(cfg['feedin_table']['table'],
+              schema=cfg['feedin_table']['schema'],
+              con=db.engine(),
+              if_exists='append')

--- a/src/egon/data/processing/renewable_feedin/__init__.py
+++ b/src/egon/data/processing/renewable_feedin/__init__.py
@@ -197,7 +197,8 @@ def wind_feedin_per_weather_cell():
 
     # Insert feedin for selected turbine per weather cell
     for turbine in ['E-126', 'E-141']:
-        idx = weather_cells.index[weather_cells.wind_turbine==turbine]
+        idx = weather_cells.index[(weather_cells.wind_turbine==turbine) &
+                                  (weather_cells.index.isin(timeseries.index))]
         df.loc[idx, 'feedin'] = timeseries.loc[idx, turbine].values
 
     # Insert values into database


### PR DESCRIPTION
Closes #123 , partly solves #19 
This branch adds the download of weather data and creation of feed in time series for wind onshore, pv and solar thermal. 
Since we haven't agreed on parameters for solar thermal and pv yet, I used the ones from pypsa-eur-sec. But this can be adjusted easily. 
Time series for wind offshore and hydro are currently missing due to additional input data sets.