### PR TITLE
Fix failing pgrouting installation by updating sources before

### DIFF
--- a/src/egon/data/airflow/Dockerfile.postgis
+++ b/src/egon/data/airflow/Dockerfile.postgis
@@ -2,6 +2,7 @@ FROM postgres:12
 
 RUN apt-get update
 RUN apt-get install -y postgresql-12-postgis-3
+RUN apt-get update
 RUN apt-get install -y postgresql-12-pgrouting
 
 


### PR DESCRIPTION
After removing the container and the related volume, hence, recreating everything from scratch, I ran into the problem that was described in https://github.com/openego/eGon-data/issues/115#issuecomment-810983858 again. In order to avoid further trouble here, I propose this one line fix. 
I would call it harmless. So, if you consider to approve without testing locally, I think it is ok ;-)

Fixes #115 (again).