### PR TITLE
Assign voltage level and bus_id to power plants

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -82,6 +82,8 @@ Added
   `#214 <https://github.com/openego/eGon-data/issues/214>`_
 * Integrate weather data and renewable feedin timeseries
   `#19 <https://github.com/openego/eGon-data/issues/19>`_
+* Assign voltage level and bus_id to power plants
+  `#15 <https://github.com/openego/eGon-data/issues/15>`_
 
 .. _PR #159: https://github.com/openego/eGon-data/pull/159
 

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -392,13 +392,14 @@ with airflow.DAG(
     )
 
     power_plant_import = PythonOperator(
-        task_id="import-power-plants",
+        task_id="import-hydro-biomass-power-plants",
         python_callable=power_plants.insert_power_plants,
     )
 
     setup >> power_plant_tables >> power_plant_import
     nep_insert_data >> power_plant_import
     retrieve_mastr_data >> power_plant_import
+    define_mv_grid_districts >> power_plant_import
 
     # Import and merge data on industrial sites from different sources
 

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -264,13 +264,6 @@ with airflow.DAG(
     demandregio_demand_households >> elec_household_demands_zensus
     map_zensus_vg250 >> elec_household_demands_zensus
 
-    # Power plant setup
-    power_plant_tables = PythonOperator(
-        task_id="create-power-plant-tables",
-        python_callable=power_plants.create_tables,
-    )
-    setup >> power_plant_tables
-
     # NEP data import
     create_tables = PythonOperator(
         task_id="create-scenario-tables",
@@ -360,7 +353,7 @@ with airflow.DAG(
     )
     osmtgmod_substation >> create_voronoi
 
-    
+
     define_mv_grid_districts = PythonOperator(
         task_id="define_mv_grid_districts",
         python_callable=mvgd.define_mv_grid_districts

--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -286,7 +286,7 @@ mastr:
     - "gsgk"
     - "storage"
   file_basename: "bnetza_mastr"
-  deposit_id: 740153
+  deposit_id: 808086
 
 re_potential_areas:
   original_data:

--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -340,9 +340,12 @@ power_plants:
   sources:
       mastr_biomass: "bnetza_mastr_biomass_cleaned.csv"
       mastr_hydro: "bnetza_mastr_hydro_cleaned.csv"
+      mastr_location: "location_elec_generation_raw.csv"
       capacities: "supply.egon_scenario_capacities"
       geom_germany: "boundaries.vg250_sta_union"
       geom_federal_states: "boundaries.vg250_lan"
+      mv_grid_districts: "grid.mv_grid_districts"
+      ehv_voronoi: "grid.egon_ehv_substation_voronoi"
   target:
       table: 'egon_power_plants'
       schema: 'supply'

--- a/src/egon/data/importing/mastr.py
+++ b/src/egon/data/importing/mastr.py
@@ -37,6 +37,7 @@ def download_mastr_data(data_stages=None):
                 f"{data_config['file_basename']}_{technology}_cleaned.csv"
             )
         files.append("datapackage.json")
+        files.append("location_elec_generation_raw.csv")
 
     # Retrieve specified files
     for filename in files:

--- a/src/egon/data/processing/loadarea/__init__.py
+++ b/src/egon/data/processing/loadarea/__init__.py
@@ -36,6 +36,11 @@ def create_landuse_table():
     """
     cfg = egon.data.config.datasets()["landuse"]["target"]
 
+    # Create schema if not exists
+    db.execute_sql(
+        f"""CREATE SCHEMA IF NOT EXISTS {cfg['schema']};"""
+    )
+
     # Drop tables
     db.execute_sql(
         f"""DROP TABLE IF EXISTS

--- a/src/egon/data/processing/power_plants/__init__.py
+++ b/src/egon/data/processing/power_plants/__init__.py
@@ -354,36 +354,31 @@ def assign_voltage_level(mastr_loc):
     mastr_loc['Spannungsebene'] = np.nan
     mastr_loc['voltage_level'] = np.nan
 
-    try:
-
-        location = pd.read_csv('location_elec_generation_raw.csv', usecols=[
+    location = pd.read_csv('location_elec_generation_raw.csv', usecols=[
             'LokationMastrNummer', 'Spannungsebene']).set_index(
                 'LokationMastrNummer')
 
-        location = location[~location.index.duplicated(keep='first')]
+    location = location[~location.index.duplicated(keep='first')]
 
-        mastr_loc.loc[mastr_loc[mastr_loc.LokationMastrNummer.isin(
-            location.index)].index,'Spannungsebene'] = location.Spannungsebene[
-            mastr_loc[mastr_loc.LokationMastrNummer.isin(
-            location.index)].LokationMastrNummer].values
+    mastr_loc.loc[mastr_loc[mastr_loc.LokationMastrNummer.isin(
+        location.index)].index,'Spannungsebene'] = location.Spannungsebene[
+        mastr_loc[mastr_loc.LokationMastrNummer.isin(
+        location.index)].LokationMastrNummer].values
 
-        # Transfer voltage_level as integer from Spanungsebene
-        map_voltage_levels=pd.Series(data={
-            'Höchstspannung': 1,
-            'Hochspannung': 3,
-            'UmspannungZurMittelspannung': 4,
-            'Mittelspannung': 5,
-            'UmspannungZurNiederspannung': 6,
-            'Niederspannung':7})
+    # Transfer voltage_level as integer from Spanungsebene
+    map_voltage_levels=pd.Series(data={
+        'Höchstspannung': 1,
+        'Hochspannung': 3,
+        'UmspannungZurMittelspannung': 4,
+        'Mittelspannung': 5,
+        'UmspannungZurNiederspannung': 6,
+        'Niederspannung':7})
 
+    mastr_loc.loc[mastr_loc[mastr_loc['Spannungsebene'].notnull()].index,
+              'voltage_level'] = map_voltage_levels[
         mastr_loc.loc[mastr_loc[mastr_loc['Spannungsebene'].notnull()].index,
-                  'voltage_level'] = map_voltage_levels[
-            mastr_loc.loc[mastr_loc[mastr_loc['Spannungsebene'].notnull()].index,
-                  'Spannungsebene'].values].values
+              'Spannungsebene'].values].values
 
-    except:
-        print("MaStR location data not available. "
-              "Voltage levels are assigned according to capacity.")
 
     # If no voltage level is available from mastr, choose level according
     # to threshold values

--- a/src/egon/data/processing/power_plants/__init__.py
+++ b/src/egon/data/processing/power_plants/__init__.py
@@ -23,7 +23,7 @@ class EgonPowerPlants(Base):
     chp = Column(Boolean)
     el_capacity = Column(Float)
     th_capacity = Column(Float)
-    subst_id = Column(Integer)
+    bus_id = Column(Integer)
     voltage_level = Column(Integer)
     w_id = Column(Integer)
     scenario = Column(String)

--- a/src/egon/data/processing/power_plants/__init__.py
+++ b/src/egon/data/processing/power_plants/__init__.py
@@ -216,8 +216,8 @@ def insert_biomass_plants(scenario):
 
     # Assign bus_id
     if len(mastr_loc) > 0:
-        mastr_loc['voltage_level'] = assign_voltage_level(mastr_loc)
-        mastr_loc = assign_bus_id(mastr_loc)
+        mastr_loc['voltage_level'] = assign_voltage_level(mastr_loc, cfg)
+        mastr_loc = assign_bus_id(mastr_loc, cfg)
 
     # Insert entries with location
     session = sessionmaker(bind=db.engine())()
@@ -309,8 +309,8 @@ def insert_hydro_plants(scenario):
 
         # Assign bus_id and voltage level
         if len(mastr_loc) > 0:
-            mastr_loc['voltage_level'] = assign_voltage_level(mastr_loc)
-            mastr_loc = assign_bus_id(mastr_loc)
+            mastr_loc['voltage_level'] = assign_voltage_level(mastr_loc, cfg)
+            mastr_loc = assign_bus_id(mastr_loc, cfg)
 
         # Insert entries with location
         session = sessionmaker(bind=db.engine())()
@@ -333,7 +333,7 @@ def insert_hydro_plants(scenario):
 
         session.commit()
 
-def assign_voltage_level(mastr_loc):
+def assign_voltage_level(mastr_loc, cfg):
     """ Assigns voltage level to power plants.
 
     If location data inluding voltage level is available from
@@ -354,7 +354,7 @@ def assign_voltage_level(mastr_loc):
     mastr_loc['Spannungsebene'] = np.nan
     mastr_loc['voltage_level'] = np.nan
 
-    location = pd.read_csv('location_elec_generation_raw.csv', usecols=[
+    location = pd.read_csv(cfg['sources']['mastr_location'], usecols=[
             'LokationMastrNummer', 'Spannungsebene']).set_index(
                 'LokationMastrNummer')
 
@@ -404,7 +404,7 @@ def assign_voltage_level(mastr_loc):
 
     return mastr_loc.voltage_level
 
-def assign_bus_id(power_plants):
+def assign_bus_id(power_plants, cfg):
     """Assigns bus_ids to power plants according to location and voltage level
 
     Parameters
@@ -420,13 +420,13 @@ def assign_bus_id(power_plants):
     """
 
     mv_grid_districts = db.select_geodataframe(
-        """
-        SELECT * FROM grid.mv_grid_districts
+        f"""
+        SELECT * FROM {cfg['sources']['mv_grid_districts']}
         """, epsg=4326)
 
     ehv_grid_districts = db.select_geodataframe(
-        """
-        SELECT * FROM grid.egon_ehv_substation_voronoi
+        f"""
+        SELECT * FROM {cfg['sources']['ehv_voronoi']}
         """, epsg=4326)
 
     # Assign power plants in hv and below to hvmv bus

--- a/src/egon/data/processing/power_plants/__init__.py
+++ b/src/egon/data/processing/power_plants/__init__.py
@@ -9,6 +9,7 @@ from geoalchemy2 import Geometry
 import pandas as pd
 import geopandas as gpd
 import egon.data.config
+import numpy as np
 
 Base = declarative_base()
 
@@ -215,6 +216,7 @@ def insert_biomass_plants(scenario):
 
     # Assign bus_id
     if len(mastr_loc) > 0:
+        mastr_loc['voltage_level'] = assign_voltage_level(mastr_loc)
         mastr_loc = assign_bus_id(mastr_loc)
 
     # Insert entries with location
@@ -233,6 +235,7 @@ def insert_biomass_plants(scenario):
             th_capacity=row.ThermischeNutzleistung / 1000,
             scenario=scenario,
             bus_id = row.bus_id,
+            voltage_level = row.voltage_level,
             geom=f"SRID=4326;POINT({row.Laengengrad} {row.Breitengrad})",
         )
         session.add(entry)
@@ -304,8 +307,9 @@ def insert_hydro_plants(scenario):
         mastr_loc = filter_mastr_geometry(mastr)
         # TODO: Deal with power plants without geometry
 
-        # Assign bus_id
+        # Assign bus_id and voltage level
         if len(mastr_loc) > 0:
+            mastr_loc['voltage_level'] = assign_voltage_level(mastr_loc)
             mastr_loc = assign_bus_id(mastr_loc)
 
         # Insert entries with location
@@ -322,12 +326,131 @@ def insert_hydro_plants(scenario):
                 el_capacity=row.Nettonennleistung,
                 scenario=scenario,
                 bus_id = row.bus_id,
+                voltage_level = row.voltage_level,
                 geom=f"SRID=4326;POINT({row.Laengengrad} {row.Breitengrad})",
             )
             session.add(entry)
 
         session.commit()
 
+def assign_voltage_level(mastr_loc):
+    """ Assigns voltage level to power plants.
+
+    If location data inluding voltage level is available from
+    Marktstammdatenregister, this is used. Otherwise the voltage level is
+    assigned according to the electrical capacity.
+
+    Parameters
+    ----------
+    mastr_loc : pandas.DataFrame
+        Power plants listed in MaStR with geometry inside German boundaries
+
+    Returns
+    -------
+    pandas.DataFrame
+        Power plants including voltage_level
+
+    """
+    mastr_loc['Spannungsebene'] = np.nan
+    mastr_loc['voltage_level'] = np.nan
+
+    try:
+
+        location = pd.read_csv('location_elec_generation_raw.csv', usecols=[
+            'LokationMastrNummer', 'Spannungsebene']).set_index(
+                'LokationMastrNummer')
+
+        location = location[~location.index.duplicated(keep='first')]
+
+        mastr_loc.loc[mastr_loc[mastr_loc.LokationMastrNummer.isin(
+            location.index)].index,'Spannungsebene'] = location.Spannungsebene[
+            mastr_loc[mastr_loc.LokationMastrNummer.isin(
+            location.index)].LokationMastrNummer].values
+
+        # Transfer voltage_level as integer from Spanungsebene
+        map_voltage_levels=pd.Series(data={
+            'Höchstspannung': 1,
+            'Hochspannung': 3,
+            'UmspannungZurMittelspannung': 4,
+            'Mittelspannung': 5,
+            'UmspannungZurNiederspannung': 6,
+            'Niederspannung':7})
+
+        mastr_loc.loc[mastr_loc[mastr_loc['Spannungsebene'].notnull()].index,
+                  'voltage_level'] = map_voltage_levels[
+            mastr_loc.loc[mastr_loc[mastr_loc['Spannungsebene'].notnull()].index,
+                  'Spannungsebene'].values].values
+
+    except:
+        print("MaStR location data not available. "
+              "Voltage levels are assigned according to capacity.")
+
+    # If no voltage level is available from mastr, choose level according
+    # to threshold values
+
+    for i, row in mastr_loc[mastr_loc.voltage_level.isnull()].iterrows():
+
+        if row.Nettonennleistung > 120:
+            level = 1
+        elif row.Nettonennleistung > 20:
+            level = 3
+        elif row.Nettonennleistung > 5.5:
+            level = 4
+        elif row.Nettonennleistung > 0.2:
+            level = 5
+        elif row.Nettonennleistung > 0.1:
+            level = 6
+        else:
+            level = 7
+
+        mastr_loc.loc[i, 'voltage_level'] = level
+
+    mastr_loc.voltage_level = mastr_loc.voltage_level.astype(int)
+
+    return mastr_loc.voltage_level
+
+def assign_bus_id(power_plants):
+    """Assigns bus_ids to power plants according to location and voltage level
+
+    Parameters
+    ----------
+    power_plants : pandas.DataFrame
+        Power plants including voltage level
+
+    Returns
+    -------
+    power_plants : pandas.DataFrame
+        Power plants including voltage level and bus_id
+
+    """
+
+    mv_grid_districts = db.select_geodataframe(
+        """
+        SELECT * FROM grid.mv_grid_districts
+        """, epsg=4326)
+
+    ehv_grid_districts = db.select_geodataframe(
+        """
+        SELECT * FROM grid.egon_ehv_substation_voronoi
+        """, epsg=4326)
+
+    # Assign power plants in hv and below to hvmv bus
+    power_plants_hv = power_plants[power_plants.voltage_level >= 3].index
+    if len(power_plants_hv) > 0:
+        power_plants.loc[power_plants_hv, 'bus_id'] = gpd.sjoin(
+            power_plants[power_plants.index.isin(power_plants_hv)
+                         ], mv_grid_districts).subst_id
+
+    # Assign power plants in ehv to ehv bus
+    power_plants_ehv = power_plants[power_plants.voltage_level < 3].index
+
+    if len(power_plants_ehv) > 0:
+        power_plants.loc[power_plants_ehv, 'bus_id'] = gpd.sjoin(
+            power_plants[power_plants.index.isin(power_plants_hv)
+                         ], ehv_grid_districts).bus_id
+
+
+    return power_plants
 
 def insert_power_plants():
     """Insert power plants in database
@@ -347,14 +470,3 @@ def insert_power_plants():
         insert_hydro_plants(scenario)
 
 
-def assign_bus_id(power_plants):
-
-    mv_grid_districts = db.select_geodataframe(
-        """
-        SELECT * FROM grid.mv_grid_districts
-        """, epsg=4326)
-
-    power_plants['bus_id'] = gpd.sjoin(
-        power_plants, mv_grid_districts).subst_id
-
-    return power_plants


### PR DESCRIPTION
This branch adds voltage level and bus_ids to power plants (see #15), since I needed the mastr location data, I adjusted the mastr download, so this closes #174.

@gplssm Could you check if the location data is downloaded correctly? (I tried it and it worked, I just want to be sure to have the correct deposit_id.)


