### PR TITLE
Features/#162 district heating areas

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -82,6 +82,8 @@ Added
   `#214 <https://github.com/openego/eGon-data/issues/214>`_
 * Integrate weather data and renewable feedin timeseries
   `#19 <https://github.com/openego/eGon-data/issues/19>`_
+* Create and import district heating areas
+  `#162 <https://github.com/openego/eGon-data/issues/162>`_
 
 .. _PR #159: https://github.com/openego/eGon-data/pull/159
 

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
         "geopandas>=0.9.0",
         "importlib-resources",
         "loguru",
+        "matplotlib",
         "oedialect==0.0.8",
         "psycopg2",
         "pyaml",

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -333,6 +333,11 @@ with airflow.DAG(
     vg250_clean_and_prepare >> ehv_substation_extraction
 
     # osmTGmod ehv/hv grid model generation
+    osmtgmod_osm_import = PythonOperator(
+        task_id="osmtgmod_osm_import",
+        python_callable=osmtgmod.import_osm_data,
+    )
+
     run_osmtgmod = PythonOperator(
         task_id="run_osmtgmod",
         python_callable=osmtgmod.run_osmtgmod,
@@ -349,6 +354,8 @@ with airflow.DAG(
         postgres_conn_id="egon_data",
         autocommit=True,
     )
+
+    osm_download >> osmtgmod_osm_import >> run_osmtgmod
     ehv_substation_extraction >> run_osmtgmod
     hvmv_substation_extraction >> run_osmtgmod
     run_osmtgmod >> osmtgmod_pypsa
@@ -361,7 +368,7 @@ with airflow.DAG(
     )
     osmtgmod_substation >> create_voronoi
 
-    
+
     define_mv_grid_districts = PythonOperator(
         task_id="define_mv_grid_districts",
         python_callable=mvgd.define_mv_grid_districts

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -31,6 +31,7 @@ import egon.data.processing.mv_grid_districts as mvgd
 import egon.data.importing.scenarios as import_scenarios
 import egon.data.importing.industrial_sites as industrial_sites
 import egon.data.processing.loadarea as loadarea
+import egon.data.processing.district_heating_areas as district_heating_areas
 from egon.data import db
 
 
@@ -444,3 +445,18 @@ with airflow.DAG(
     osm_add_metadata >> landuse_extraction
     vg250_clean_and_prepare >> landuse_extraction
 
+    # District heating areas demarcation
+    create_district_heating_areas_table = PythonOperator(
+        task_id="create-district-heating-areas-table",
+        python_callable=district_heating_areas.create_tables
+    )
+    import_district_heating_areas = PythonOperator(
+        task_id="import-district-heating-areas",
+        python_callable=district_heating_areas.
+        district_heating_areas_demarcation
+    )
+    setup >> create_district_heating_areas_table
+    create_district_heating_areas_table >> import_district_heating_areas
+    zensus_misc_import >> import_district_heating_areas
+    heat_demand_import >> import_district_heating_areas
+    scenario_input_import >> import_district_heating_areas

--- a/src/egon/data/importing/heat_demand_data/__init__.py
+++ b/src/egon/data/importing/heat_demand_data/__init__.py
@@ -460,7 +460,7 @@ def heat_demand_to_db_table():
 
     for source in sources:
 
-        # if not '2015' in source.stem:
+        if not '2015' in source.stem:
             # Create a temporary table and fill the final table using the sql script
             rasters = f"heat_demand_rasters_{source.stem.lower()}"
             import_rasters = subprocess.run(
@@ -841,11 +841,11 @@ def future_heat_demand_data_import():
     # Specifiy the scenario names for loading factors from csv file
     future_heat_demand_germany("eGon2035")
     future_heat_demand_germany("eGon100RE")
-    future_heat_demand_germany("eGon2015")
+    # future_heat_demand_germany("eGon2015")
     heat_demand_to_db_table()
     adjust_residential_heat_to_zensus("eGon2035")
     adjust_residential_heat_to_zensus("eGon100RE")
-    future_heat_demand_germany("eGon2015")
+    # future_heat_demand_germany("eGon2015")
     add_metadata()
 
     return None

--- a/src/egon/data/importing/heat_demand_data/__init__.py
+++ b/src/egon/data/importing/heat_demand_data/__init__.py
@@ -335,12 +335,14 @@ def future_heat_demand_germany(scenario_name):
 
     """
     # Load the values
-    heat_parameters = get_sector_parameters('heat', scenario=scenario_name)
+    if scenario_name == "eGon2015":
+        res_hd_reduction = 1
+        ser_hd_reduction = 1
+    else:
+        heat_parameters = get_sector_parameters('heat', scenario=scenario_name)
 
-    res_hd_reduction = heat_parameters['DE_demand_reduction_residential']
-
-    ser_hd_reduction = heat_parameters['DE_demand_reduction_service']
-
+        res_hd_reduction = heat_parameters['DE_demand_reduction_residential']
+        ser_hd_reduction = heat_parameters['DE_demand_reduction_service']
 
     # Define the directory where the created rasters will be saved
     scenario_raster_directory = "heat_scenario_raster"
@@ -837,9 +839,11 @@ def future_heat_demand_data_import():
     # Specifiy the scenario names for loading factors from csv file
     future_heat_demand_germany("eGon2035")
     future_heat_demand_germany("eGon100RE")
+    future_heat_demand_germany("eGon2015")
     heat_demand_to_db_table()
     adjust_residential_heat_to_zensus("eGon2035")
     adjust_residential_heat_to_zensus("eGon100RE")
+    future_heat_demand_germany("eGon2015")
     add_metadata()
 
     return None

--- a/src/egon/data/importing/heat_demand_data/__init__.py
+++ b/src/egon/data/importing/heat_demand_data/__init__.py
@@ -306,7 +306,7 @@ def future_heat_demand_germany(scenario_name):
     """
     Calculate the future residential and service-sector heat demand per ha.
 
-    The calculation is based on Peta5_0_1 heat demand densities, cutcut for
+    The calculation is based on Peta5_0_1 heat demand densities, cutout for
     Germany, for the year 2015. The given scenario name is used to read the
     adjustment factors for the heat demand rasters from the scenario table.
 

--- a/src/egon/data/importing/heat_demand_data/__init__.py
+++ b/src/egon/data/importing/heat_demand_data/__init__.py
@@ -460,7 +460,7 @@ def heat_demand_to_db_table():
 
     for source in sources:
 
-        if not '2015' in source.stem:
+        # if not '2015' in source.stem:
             # Create a temporary table and fill the final table using the sql script
             rasters = f"heat_demand_rasters_{source.stem.lower()}"
             import_rasters = subprocess.run(

--- a/src/egon/data/importing/heat_demand_data/__init__.py
+++ b/src/egon/data/importing/heat_demand_data/__init__.py
@@ -459,28 +459,30 @@ def heat_demand_to_db_table():
     db.execute_sql("DELETE FROM demand.egon_peta_heat;")
 
     for source in sources:
-        # Create a temporary table and fill the final table using the sql script
-        rasters = f"heat_demand_rasters_{source.stem.lower()}"
-        import_rasters = subprocess.run(
-            ["raster2pgsql", "-e", "-s", "3035", "-I", "-C", "-F", "-a"]
-            + [source]
-            + [f"{rasters}"],
-            text=True,
-        ).stdout
-        with engine.begin() as connection:
-            print(f'CREATE TEMPORARY TABLE "{rasters}"'
-                ' ("rid" serial PRIMARY KEY,"rast" raster,"filename" text);')
-            connection.execute(
-                f'CREATE TEMPORARY TABLE "{rasters}"'
-                ' ("rid" serial PRIMARY KEY,"rast" raster,"filename" text);'
-            )
-            connection.execute(import_rasters)
-            connection.execute(f'ANALYZE "{rasters}"')
-            with open(sql_script) as convert:
+
+        if not '2015' in source.stem:
+            # Create a temporary table and fill the final table using the sql script
+            rasters = f"heat_demand_rasters_{source.stem.lower()}"
+            import_rasters = subprocess.run(
+                ["raster2pgsql", "-e", "-s", "3035", "-I", "-C", "-F", "-a"]
+                + [source]
+                + [f"{rasters}"],
+                text=True,
+            ).stdout
+            with engine.begin() as connection:
+                print(f'CREATE TEMPORARY TABLE "{rasters}"'
+                    ' ("rid" serial PRIMARY KEY,"rast" raster,"filename" text);')
                 connection.execute(
-                    Template(convert.read()).render(version="0.0.0",
-                                                    source=rasters)
+                    f'CREATE TEMPORARY TABLE "{rasters}"'
+                    ' ("rid" serial PRIMARY KEY,"rast" raster,"filename" text);'
                 )
+                connection.execute(import_rasters)
+                connection.execute(f'ANALYZE "{rasters}"')
+                with open(sql_script) as convert:
+                    connection.execute(
+                        Template(convert.read()).render(version="0.0.0",
+                                                        source=rasters)
+                    )
     return None
 
 

--- a/src/egon/data/importing/heat_demand_data/__init__.py
+++ b/src/egon/data/importing/heat_demand_data/__init__.py
@@ -619,7 +619,7 @@ def add_metadata():
 
     # Metadata creation
     meta = {
-        "name": "heat",
+        "name": "egon_peta_heat_metadata",
         "title": "eGo_n scenario-specific future heat demand data",
         "description": "Future heat demands per hectare grid cell of "
         "the residential and service sector",

--- a/src/egon/data/processing/district_heating_areas/__init__.py
+++ b/src/egon/data/processing/district_heating_areas/__init__.py
@@ -898,7 +898,7 @@ def study_prospective_district_heating_areas():
     """
 
     # load the total heat demand by census cell (residential plus service)
-    HD_2015 = load_heat_demands('eGon2015')
+    # HD_2015 = load_heat_demands('eGon2015')
     # status quo heat demand data are part of the regluar database content
     # to get them, line 463 ("if not '2015' in source.stem:") has to be
     # deleted from
@@ -911,7 +911,7 @@ def study_prospective_district_heating_areas():
     HD_2050 = load_heat_demands('eGon100RE')
 
     # select only cells with heat demands > 100 GJ / (ha a)
-    HD_2015_above_100GJ = select_high_heat_demands(HD_2015)
+    # HD_2015_above_100GJ = select_high_heat_demands(HD_2015)
     HD_2035_above_100GJ = select_high_heat_demands(HD_2035)
     HD_2050_above_100GJ = select_high_heat_demands(HD_2050)
 
@@ -921,10 +921,10 @@ def study_prospective_district_heating_areas():
     # after decision for one year/scenario (here 2035), in the pipeline PSDs
     # are only calculeated for the one selected year/scenario;
     # here you can see all years/scenarios:
-    PSD_2015_201m = area_grouping(HD_2015_above_100GJ, distance=200,
-                                  minimum_total_demand=(10000/3.6)
-                                   ).dissolve('area_id', aggfunc='sum')
-    PSD_2015_201m.to_file("PSDs_2015based.shp")
+    # PSD_2015_201m = area_grouping(HD_2015_above_100GJ, distance=200,
+    #                               minimum_total_demand=(10000/3.6)
+    #                                ).dissolve('area_id', aggfunc='sum')
+    # PSD_2015_201m.to_file("PSDs_2015based.shp")
     PSD_2035_201m = area_grouping(HD_2035_above_100GJ, distance=200,
                                   minimum_total_demand=(10000/3.6)
                                   ).dissolve('area_id', aggfunc='sum')
@@ -942,12 +942,12 @@ def study_prospective_district_heating_areas():
     # https://www.earthdatascience.org/courses/scientists-guide-to-plotting-data-in-python/plot-with-matplotlib/introduction-to-matplotlib-plots/customize-plot-colors-labels-matplotlib/
     fig, ax = plt.subplots(1, 1)
     # add the sorted heat demand densities
-    HD_2015 = HD_2015.sort_values('residential_and_service_demand',
-                                  ascending=False).reset_index()
-    HD_2015["Cumulative_Sum"] = (HD_2015.residential_and_service_demand.
-                                 cumsum()) / 1000000
-    ax.plot(HD_2015.Cumulative_Sum,
-            HD_2015.residential_and_service_demand, label='eGon2015')
+    # HD_2015 = HD_2015.sort_values('residential_and_service_demand',
+    #                               ascending=False).reset_index()
+    # HD_2015["Cumulative_Sum"] = (HD_2015.residential_and_service_demand.
+    #                              cumsum()) / 1000000
+    # ax.plot(HD_2015.Cumulative_Sum,
+    #         HD_2015.residential_and_service_demand, label='eGon2015')
 
     HD_2035 = HD_2035.sort_values('residential_and_service_demand',
                                   ascending=False).reset_index()

--- a/src/egon/data/processing/district_heating_areas/__init__.py
+++ b/src/egon/data/processing/district_heating_areas/__init__.py
@@ -11,7 +11,7 @@ This module obtains the information from the census tables and the heat demand
 densities, demarcates so the current and future district heating areas. In the
 end it saves them in the database.
 """
-
+import os
 from egon.data import db
 from egon.data.importing.scenarios import get_sector_parameters, EgonScenario
 
@@ -180,8 +180,8 @@ def load_census_data():
         geom_col="geom_polygon"
     )
 
-    # district_heat.to_file("dh.shp")
-    # heating_type.to_file("heating.shp")
+    # district_heat.to_file(results_path+"dh.shp")
+    # heating_type.to_file(results_path+"heating.shp")
 
     # calculate the connection rate for all census cells with DH
     # adding it to the district_heat geodataframe
@@ -884,6 +884,12 @@ def study_prospective_district_heating_areas():
         be studied
     """
 
+    # create directory to store files
+    results_path = 'district_heating_areas/'
+
+    if not os.path.exists(results_path):
+        os.mkdir(results_path)
+
     # load the total heat demand by census cell (residential plus service)
     # HD_2015 = load_heat_demands('eGon2015')
     # status quo heat demand data are part of the regluar database content
@@ -911,17 +917,17 @@ def study_prospective_district_heating_areas():
     # PSD_2015_201m = area_grouping(HD_2015_above_100GJ, distance=200,
     #                               minimum_total_demand=(10000/3.6)
     #                                ).dissolve('area_id', aggfunc='sum')
-    # PSD_2015_201m.to_file("PSDs_2015based.shp")
+    # PSD_2015_201m.to_file(results_path+"PSDs_2015based.shp")
     PSD_2035_201m = area_grouping(HD_2035_above_100GJ, distance=200,
                                   minimum_total_demand=(10000/3.6)
                                   ).dissolve('area_id', aggfunc='sum')
-    # HD_2035.to_file("HD_2035.shp")
-    # HD_2035_above_100GJ.to_file("HD_2035_above_100GJ.shp")
-    PSD_2035_201m.to_file("PSDs_2035based.shp")
+    # HD_2035.to_file(results_path+"HD_2035.shp")
+    # HD_2035_above_100GJ.to_file(results_path+"HD_2035_above_100GJ.shp")
+    PSD_2035_201m.to_file(results_path+"PSDs_2035based.shp")
     PSD_2050_201m = area_grouping(HD_2050_above_100GJ, distance=200,
                                   minimum_total_demand=(10000/3.6)
                                   ).dissolve('area_id', aggfunc='sum')
-    PSD_2050_201m.to_file("PSDs_2050based.shp")
+    PSD_2050_201m.to_file(results_path+"PSDs_2050based.shp")
 
 
     # plotting all cells - not considering census data
@@ -982,7 +988,7 @@ def study_prospective_district_heating_areas():
     ax.set_ylabel("Heat Demand Densities [MWh / (ha a)]")
 
     plt.legend()
-    plt.savefig('Complete_HeatDemandDensities_Curves.png')
+    plt.savefig(results_path+'Complete_HeatDemandDensities_Curves.png')
 
     return None
 
@@ -1049,7 +1055,7 @@ def district_heating_areas_demarcation(plotting=True):
         plot_heat_density_sorted(heat_density_per_scenario)
     # if you want to study/export the Prospective Supply Districts (PSDs)
     # for all scenarios
-    study_prospective_district_heating_areas()
+    # study_prospective_district_heating_areas()
 
     add_metadata()
 

--- a/src/egon/data/processing/district_heating_areas/__init__.py
+++ b/src/egon/data/processing/district_heating_areas/__init__.py
@@ -25,10 +25,11 @@ import json
 # import time
 
 # packages for ORM class definition
-from sqlalchemy import Column, String, Float, Integer, Sequence, ForeignKey
+from sqlalchemy import Column, String, Integer, Sequence  #, ForeignKey
 from sqlalchemy.ext.declarative import declarative_base
+from geoalchemy2.types import Geometry
 
-# TO DO: Finish the class definition
+# TO DO: Add the foreign key again!
 # egon2015 is not part of the EgonScenario table!
 
 Base = declarative_base()
@@ -46,7 +47,7 @@ class MapZensusDistrictHeatingAreas(Base):
         primary_key=True,
     )
     area_id = Column(Integer)
-    scenario = Column(String, ForeignKey(EgonScenario.name))
+    scenario = Column(String)  #, ForeignKey(EgonScenario.name))
     version = Column(String)
     zensus_population_id = Column(Integer)
 
@@ -63,9 +64,45 @@ class DistrictHeatingAreas(Base):
         primary_key=True,
     )
     area_id = Column(Integer)
-    scenario = Column(String, ForeignKey(EgonScenario.name))
+    scenario = Column(String)  #, ForeignKey(EgonScenario.name))
     version = Column(String)
-    geom_polygon = Column(Geometry)
+    geom_polygon = Column(Geometry('POLYGON', 3035), index=True)
+
+
+
+def create_tables():
+    """Create tables for district heating areas
+
+    Returns
+    -------
+        None
+    """
+
+    # Drop tables
+    db.execute_sql(
+        f"""DROP TABLE IF EXISTS
+            demand.district_heating_areas CASCADE;"""
+    )
+
+    db.execute_sql(
+        f"""DROP TABLE IF EXISTS
+            demand.map_zensus_district_heating_areas CASCADE;"""
+    )
+
+    # Drop sequences
+    db.execute_sql(
+        f"""DROP SEQUENCE IF EXISTS
+            demand.district_heating_areas_seq CASCADE;"""
+    )
+
+    db.execute_sql(
+        f"""DROP SEQUENCE IF EXISTS
+            demand.map_zensus_district_heating_areas_seq CASCADE;"""
+    )
+
+    engine = db.engine()
+    DistrictHeatingAreas.__table__.create(bind=engine, checkfirst=True)
+    MapZensusDistrictHeatingAreas.__table__.create(bind=engine, checkfirst=True)
 
 
 # Methods used are explained here:
@@ -442,6 +479,8 @@ def district_heating_areas_demarcation():
 
         Create diagrams/curves, make better curves with matplotlib
         PSD statistics
+
+        Add datasets to datasets configuration
 
         Check which tasks need to run (according to version number)
     """

--- a/src/egon/data/processing/district_heating_areas/__init__.py
+++ b/src/egon/data/processing/district_heating_areas/__init__.py
@@ -464,12 +464,12 @@ def district_heating_areas(scenario_name, plotting = False):
             new_areas[['residential_and_service_demand', 'geom_polygon']]),
         geometry='geom_polygon')
 
-
     scenario_dh_area = area_grouping(gpd.GeoDataFrame(
         cells[['residential_and_service_demand', 'geom_polygon']].append(
             new_areas[['residential_and_service_demand', 'geom_polygon']]),
         geometry='geom_polygon'), distance=500)
     # scenario_dh_area.plot(column = "area_id")
+
     scenario_dh_area.groupby("area_id").size().sort_values()
     scenario_dh_area.residential_and_service_demand.sum()
     # scenario_dh_area.sort_index()
@@ -502,6 +502,16 @@ def district_heating_areas(scenario_name, plotting = False):
     # type(areas_dissolved["geom"][0])
     # print(type(areas_dissolved))
     # print(areas_dissolved.head())
+
+    if len(areas_dissolved[areas_dissolved.area == 100*100]) > 0:
+        print(f"""District heating areas ids of single zensus cells in
+              district heating areas:
+              {areas_dissolved[areas_dissolved.area == 100*100].index.values}""")
+        print(f"""Zensus_population_ids of single zensus cells
+              in district heating areas:
+              {scenario_dh_area[scenario_dh_area.area_id.isin(
+                  areas_dissolved[areas_dissolved.area == 100*100].index.values
+                  )].index.values}""")
 
     db.execute_sql(f"""DELETE FROM demand.district_heating_areas
                    WHERE scenario = '{scenario_name}'""")

--- a/src/egon/data/processing/district_heating_areas/__init__.py
+++ b/src/egon/data/processing/district_heating_areas/__init__.py
@@ -521,6 +521,12 @@ def district_heating_areas(scenario_name, plotting = False):
         # ones without
 
         fig, ax = plt.subplots(1, 1)
+        # add the district heating share as a line
+        procent = round(district_heating_share * 100, 0)
+        plt.axvline(x=total_district_heat / 1000000, ls = "--", lw = 0.5,
+                    label = (f'District Heating Share of {procent} %'),
+                    color = 'red')
+        # add the sorted heat demand density curve
         no_district_heating = heat_demand_cells[~heat_demand_cells.index.isin(
             scenario_dh_area.index)]
         collection = pd.concat([cells.sort_values(
@@ -537,11 +543,9 @@ def district_heating_areas(scenario_name, plotting = False):
                                         residential_and_service_demand.
                                         cumsum()) / 1000000
 
-        # collection.residential_and_service_demand.plot(ax=ax)
         ax.plot(collection.Cumulative_Sum,
                 collection.residential_and_service_demand, label =
                 " Heat demand densities, sorted")
-        ax.margins(x=0, y=0) # remove empty space between axis and graph
 
         # annotations
         x1 = total_district_heat / 1000000 / 2
@@ -550,7 +554,6 @@ def district_heating_areas(scenario_name, plotting = False):
         #     'residential_and_service_demand'].sum() -
         #     total_district_heat) / 2)) / 1000000
         y = heat_demand_cells['residential_and_service_demand'].max() * 0.7
-        print(f"max = {y}")
 
         ax.text(x1, y, "District\nheat", ha="center", va="center", size=8,
                 bbox=dict(boxstyle="round, pad=0.5", fc="none",
@@ -565,14 +568,10 @@ def district_heating_areas(scenario_name, plotting = False):
         ax.set(title = ("Heat Sector in " + scenario_name))
         ax.set_xlabel("Cumulative Heat Demand [TWh / a]")
         ax.set_ylabel("Heat Demand Densities [MWh / (ha a)]")
-        # ax.set_ylim([0, capacity * 1.1])
 
-        # add the district heating share as a line
-        procent = round(district_heating_share * 100, 0)
-        plt.axvline(x=total_district_heat / 1000000, ls = "--", label =
-                    (f'District Heating Share of {procent} %'),
-                    color = 'red')
-
+        # remove empty space between axis and graph
+        ax.margins(x=0, y=0)
+        # axes style
         ax.spines["top"].set_visible(False)
         ax.spines["right"].set_visible(False)
         ax.plot(1, 0, ">k", transform=ax.get_yaxis_transform(), clip_on=False)
@@ -934,6 +933,7 @@ def district_heating_areas_demarcation():
     # https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.plot.html
     # https://www.earthdatascience.org/courses/scientists-guide-to-plotting-data-in-python/plot-with-matplotlib/introduction-to-matplotlib-plots/customize-plot-colors-labels-matplotlib/
     fig, ax = plt.subplots(1, 1)
+    # add the sorted heat demand densities
     HD_2015 = HD_2015.sort_values('residential_and_service_demand',
                                   ascending=False).reset_index()
     HD_2015["Cumulative_Sum"] = (HD_2015.residential_and_service_demand.
@@ -955,8 +955,18 @@ def district_heating_areas_demarcation():
     ax.plot(HD_2050.Cumulative_Sum,
             HD_2050.residential_and_service_demand, label='eGon100RE')
 
-    ax.margins(x=0, y=0) # default is 0.05
+    # add the district heating shares
+    plt.axvline(x=HD_2035.residential_and_service_demand.sum()/1000000*0.14,
+                ls = ":", lw = 0.5,
+                label = '72TWh DH in 2035 in Germany => 14% DH',
+                color = 'black')
+    plt.axvline(x=HD_2050.residential_and_service_demand.sum()/1000000*0.19,
+                ls = "-.", lw = 0.5,
+                label = '75TWh DH in 100RE in Germany => 19% DH',
+                color = 'black')
 
+    # axes meet in (0/0)
+    ax.margins(x=0, y=0) # default is 0.05
     # axis style
     # https://matplotlib.org/stable/gallery/ticks_and_spines/centered_spines_with_arrows.html
     # Hide the right and top spines
@@ -968,15 +978,6 @@ def district_heating_areas_demarcation():
     ax.set(title = "Heat Demand in eGo^n")
     ax.set_xlabel("Cumulative Heat Demand [TWh / a]")
     ax.set_ylabel("Heat Demand Densities [MWh / (ha a)]")
-
-    plt.axvline(x=HD_2035.residential_and_service_demand.sum()/1000000*0.14,
-                ls = ":", lw = 0.5,
-                label = '72TWh DH in 2035 in Germany => 14% DH',
-                color = 'black')
-    plt.axvline(x=HD_2050.residential_and_service_demand.sum()/1000000*0.19,
-                ls = "-.", lw = 0.5,
-                label = '75TWh DH in 100RE in Germany => 19% DH',
-                color = 'black')
 
     plt.legend()
     plt.savefig('Complete_HeatDemandDensities_Curves.png')

--- a/src/egon/data/processing/district_heating_areas/__init__.py
+++ b/src/egon/data/processing/district_heating_areas/__init__.py
@@ -552,15 +552,18 @@ def district_heating_areas(scenario_name, plotting = False):
     # print(areas_dissolved.head())
 
     if len(areas_dissolved[areas_dissolved.area == 100*100]) > 0:
-        print(f"""District heating areas ids of single zensus cells in
-              district heating areas:
-              {areas_dissolved[areas_dissolved.area == 100*100].index.values
+        print(f"""Number of district heating areas of single zensus cells:
+              {len(areas_dissolved[areas_dissolved.area == 100*100])
                }""")
-        print(f"""Zensus_population_ids of single zensus cells
-              in district heating areas:
-              {scenario_dh_area[scenario_dh_area.area_id.isin(
-                  areas_dissolved[areas_dissolved.area == 100*100].index.values
-                  )].index.values}""")
+        # print(f"""District heating areas ids of single zensus cells in
+        #       district heating areas:
+        #       {areas_dissolved[areas_dissolved.area == 100*100].index.values
+        #        }""")
+        # print(f"""Zensus_population_ids of single zensus cells
+        #       in district heating areas:
+        #       {scenario_dh_area[scenario_dh_area.area_id.isin(
+        #           areas_dissolved[areas_dissolved.area == 100*100].index.values
+        #           )].index.values}""")
 
     db.execute_sql(f"""DELETE FROM demand.district_heating_areas
                    WHERE scenario = '{scenario_name}'""")

--- a/src/egon/data/processing/district_heating_areas/__init__.py
+++ b/src/egon/data/processing/district_heating_areas/__init__.py
@@ -156,7 +156,7 @@ def load_census_data():
         f"""SELECT flats.zensus_population_id, flats.characteristics_text,
         flats.quantity, flats.quantity_q, pop.geom_point,
         pop.geom AS geom_polygon
-        FROM society.destatis_zensus_apartment_per_ha AS flats
+        FROM society.egon_destatis_zensus_apartment_per_ha AS flats
         JOIN society.destatis_zensus_population_per_ha AS pop
         ON flats.zensus_population_id = pop.id
         AND flats.characteristics_text = 'Fernheizung (Fernwärme)'
@@ -169,7 +169,7 @@ def load_census_data():
     heating_type = db.select_geodataframe(
         f"""SELECT flats.zensus_population_id,
         SUM(flats.quantity) AS quantity, pop.geom AS geom_polygon
-        FROM society.destatis_zensus_apartment_per_ha AS flats
+        FROM society.egon_destatis_zensus_apartment_per_ha AS flats
         JOIN society.destatis_zensus_population_per_ha AS pop
         ON flats.zensus_population_id = pop.id
         AND flats.attribute = 'HEIZTYP'

--- a/src/egon/data/processing/district_heating_areas/__init__.py
+++ b/src/egon/data/processing/district_heating_areas/__init__.py
@@ -12,12 +12,13 @@ densities, demarcates so the current and future district heating areas. In the
 end it saves them in the database.
 """
 
-from egon.data import db  # , subprocess
-# import egon.data.config
+from egon.data import db
 from egon.data.importing.scenarios import get_sector_parameters, EgonScenario
 
-# import pandas as pd
+import pandas as pd
 import geopandas as gpd
+from shapely.geometry.multipolygon import MultiPolygon
+from shapely.geometry.polygon import Polygon
 from matplotlib import pyplot as plt
 
 # for metadata creation
@@ -25,12 +26,10 @@ import json
 # import time
 
 # packages for ORM class definition
-from sqlalchemy import Column, String, Integer, Sequence, Float  #, ForeignKey
+from sqlalchemy import Column, String, Integer, Sequence, Float, ForeignKey
 from sqlalchemy.ext.declarative import declarative_base
 from geoalchemy2.types import Geometry
 
-# TO DO: Add the foreign key again!
-# egon2015 is not part of the EgonScenario table!
 
 Base = declarative_base()
 
@@ -47,7 +46,7 @@ class MapZensusDistrictHeatingAreas(Base):
         primary_key=True,
     )
     area_id = Column(Integer)
-    scenario = Column(String)  #, ForeignKey(EgonScenario.name))
+    scenario = Column(String, ForeignKey(EgonScenario.name))
     version = Column(String)
     zensus_population_id = Column(Integer)
 
@@ -64,9 +63,9 @@ class DistrictHeatingAreas(Base):
         primary_key=True,
     )
     area_id = Column(Integer)
-    scenario = Column(String)  #, ForeignKey(EgonScenario.name))
+    scenario = Column(String, ForeignKey(EgonScenario.name))
     version = Column(String)
-    geom_polygon = Column(Geometry('POLYGON', 3035))
+    geom_polygon = Column(Geometry('MULTIPOLYGON', 3035))
     residential_and_service_demand = Column(Float)
 
 
@@ -183,7 +182,8 @@ def load_census_data():
     # calculate the connection rate for all census cells with DH
     # adding it to the district_heat geodataframe
 
-    district_heat['connection_rate'] = district_heat['quantity'].div(heating_type['quantity'])[district_heat.index]
+    district_heat['connection_rate'] = district_heat['quantity'].div(
+        heating_type['quantity'])[district_heat.index]
     # district_heat.head
     # district_heat['connection_rate'].describe()
 
@@ -191,7 +191,7 @@ def load_census_data():
     # district_heat.columns
 
     """
-    Alternative
+    Alternative:
     Return a geodataframe with the number of DH supplied flats and all flats
     to calculate the connection rate in a PSD from the number of flats instead
     of the calculation of an average
@@ -212,7 +212,7 @@ def load_heat_demands(scenario_name):
     Returns
     -------
     heat_demand: geopandas.geodataframe.GeoDataFrame
-             polygons (hectare cells) with heat demand data
+        polygons (hectare cells) with heat demand data
 
     """
 
@@ -263,7 +263,7 @@ def select_high_heat_demands(heat_demand):
     return high_heat_demand
 
 
-def area_grouping(raw_polygons):
+def area_grouping(raw_polygons, distance = 200, minimum_total_demand = None):
     """
     This function groups polygons which are close to each other.
 
@@ -285,6 +285,12 @@ def area_grouping(raw_polygons):
     raw_polygons: geopandas.geodataframe.GeoDataFrame
         polygons to be grouped.
 
+    distance: integer
+        distance for buffering
+
+    minimum_total_demand: integer
+        optional minimum total heat demand to achieve a minimum size of areas
+
     Returns
     -------
     join: geopandas.geodataframe.GeoDataFrame
@@ -296,19 +302,14 @@ def area_grouping(raw_polygons):
 
     TODO
     ----
-        Make the buffer distance a parameter, 501 m for Census DH areas?
 
-        Implement the total minimum demand for PSDs:
-        There is a minimum total heat demand of 10,000 GJ / a for PSDs.
-        It could be an optional parameter.
 
     """
 
-    # WARNING:
-    # A value is trying to be set on a copy of a slice from a DataFrame.
-    # Try using .loc[row_indexer,col_indexer] = value instead
-    cell_buffers = raw_polygons
-    cell_buffers['geom_polygon'] = cell_buffers['geom_polygon'].buffer(201)
+    buffer_distance = distance + 1
+    cell_buffers = raw_polygons.copy()
+    cell_buffers['geom_polygon'] = cell_buffers['geom_polygon'
+                                                ].buffer(buffer_distance)
     # print(cell_buffers.area)
 
     # create a shapely Multipolygon which is split into a list
@@ -323,15 +324,39 @@ def area_grouping(raw_polygons):
     columnname = "area_id"
     join = gpd.sjoin(raw_polygons, buffer_polygons_gdf, how="inner",
                      op="intersects")
+
     join = join.rename({'index_right': columnname}, axis=1)
     # join.plot(column=columnname)
+
+    # minimum total heat demand for the areas with minimum criterium
+    if (minimum_total_demand is not None and
+        'residential_and_service_demand' in raw_polygons.columns):
+         # total_heat_demand = join.dissolve('area_id', aggfunc='sum')
+         # type(large_areas)
+         # filtered = join.groupby(['area_id'])['residential_and_service_demand'].agg('sum') > 0.7
+         large_areas = gpd.GeoDataFrame(join.groupby(['area_id'])
+                                        ['residential_and_service_demand'].
+                                        agg('sum'))
+         # large_areas = large_areas[large_areas['residential_and_service_demand'] > minimum_total_demand]
+         large_areas = (large_areas['residential_and_service_demand'] >
+                        minimum_total_demand)
+         join = join[join.area_id.isin(large_areas[large_areas].index)]
+
+    elif (minimum_total_demand is not None and
+          'residential_and_service_demand' not in raw_polygons.columns):
+        print("""The minimum total heat demand criterium can only be applied
+              on geodataframe having a column named
+              'residential_and_service_demand' """)
 
     return join
 
 
-def district_heating_areas(scenario_name):
+def district_heating_areas(scenario_name, plotting = False):
     """
-    Load district heating share from a sceanto table.
+    This function creates scenario specific district heating areas.
+
+    Load district heating share from the scenario table and demarcate the
+    areas.
 
     ...
 
@@ -339,6 +364,9 @@ def district_heating_areas(scenario_name):
     ----------
     scenario_name: str
         name of scenario to be studies
+
+    plotting: boolean
+        if True, figures will be created
 
 
     Returns
@@ -351,16 +379,19 @@ def district_heating_areas(scenario_name):
 
     TODO
     ----
-        Error messages when the amount of DH is lower than today
-
         Do "area_grouping(load_census_data()[0])" only once, not for all
         scenarios.
+
+        There are one-cell sized district heating areas (because of the
+        census information). Implement
+        - a minimum number of cells z.B. 2/3 or
+        - a minimum heat demand?
+        in the areas_grouping function.
 
         Make sure that puting data into the area_grouping, does not lead
         totally wrong data e.g. aggregated connection rates.
 
         Create the diagram with the curve, maybe in the final function or here
-
     """
 
     # Load district heating shares from the scenario table
@@ -374,7 +405,10 @@ def district_heating_areas(scenario_name):
     # Firstly, supply the cells which already have district heating according
     # to 2011 Census data and which are within likely dh areas (created
     # by the area grouping function), load only the first returned result: [0]
-    cells = area_grouping(load_census_data()[0])
+    # min_hd_census = 10000 / 3.6
+    cells = area_grouping(load_census_data()[0], distance = 500,
+                          # minimum_total_demand = min_hd_census
+                          )
     # heat_demand is scenario specific
     heat_demand_cells = load_heat_demands(scenario_name)
     cells['residential_and_service_demand'] = heat_demand_cells.loc[
@@ -385,11 +419,19 @@ def district_heating_areas(scenario_name):
 
     diff = total_district_heat - cells['residential_and_service_demand'].sum()
 
+
+    assert diff > 0, (
+        """The chosen district heating share in combination with the heat
+        demand reduction leads to an amount of district heat which is
+        lower than the current one. This case is not implemented yet.""")
+
     # Secondly, supply the cells with the highest heat demand not having
     # district heating yet
     # ASSUMPTION HERE: 2035 HD defined the PSDs
+    min_hd = 10000 / 3.6
     PSDs = area_grouping(select_high_heat_demands(
-        load_heat_demands("eGon2035")))
+        load_heat_demands("eGon2035")), distance = 200,
+        minimum_total_demand = min_hd)
 
     # select all cells not already suppied with district heat
     new_areas = heat_demand_cells[~heat_demand_cells.index.isin(cells.index)]
@@ -428,20 +470,90 @@ def district_heating_areas(scenario_name):
     areas_dissolved["scenario"] = scenario_name
     areas_dissolved["version"] = '0.0.0'
 
+    areas_dissolved["geom_polygon"] = [MultiPolygon([feature]) \
+                                       if type(feature) == Polygon \
+                                           else feature for feature in \
+                                               areas_dissolved["geom_polygon"]]
+    # type(areas_dissolved["geom"][0])
+    # print(type(areas_dissolved))
+    # print(areas_dissolved.head())
+
     db.execute_sql(f"""DELETE FROM demand.district_heating_areas
                    WHERE scenario = '{scenario_name}'""")
-    areas_dissolved.to_postgis('district_heating_areas', schema='demand',
-                               con=db.engine(), if_exists="append")
+    areas_dissolved.reset_index().to_postgis('district_heating_areas',
+                                             schema='demand',
+                                             con=db.engine(),
+                                             if_exists="append")
     # Alternative:
     # join.groupby("columnname").demand.sum()
 
-    # create diagrams for visualisation, sorted by HDD
-    # sorted census dh first, sorted new areas, left overs, DH share
-    fig, ax = plt.subplots(1, 1)
-    new_areas.sort_values('residential_and_service_demand', ascending=False
-                          ).reset_index().residential_and_service_demand.plot(
-                              ax=ax)
-    plt.savefig(f'HeatDemandDensities_Curve_{scenario_name}.png')
+    if plotting:
+
+        # create diagrams for visualisation, sorted by HDD
+        # sorted census dh first, sorted new areas, left overs, DH share
+        # create one dataframe with all data: first the cells with existing,
+        # then the cells with new district heating systems and in the end the
+        # ones without
+
+        fig, ax = plt.subplots(1, 1)
+        no_district_heating = heat_demand_cells[~heat_demand_cells.index.isin(
+            scenario_dh_area.index)]
+        collection = pd.concat([cells.sort_values(
+                                    'residential_and_service_demand',
+                                    ascending=False),
+                                new_areas.sort_values(
+                                    'residential_and_service_demand',
+                                    ascending=False),
+                                no_district_heating.sort_values(
+                                    'residential_and_service_demand',
+                                    ascending=False)],
+                               ignore_index=True)
+        collection["Cumulative_Sum"] = (collection.
+                                        residential_and_service_demand.
+                                        cumsum()) / 1000000
+
+        # collection.residential_and_service_demand.plot(ax=ax)
+        ax.plot(collection.Cumulative_Sum,
+                collection.residential_and_service_demand, label =
+                " Heat demand densities, sorted")
+        ax.margins(x=0, y=0) # remove empty space between axis and graph
+
+        # annotations
+        x1 = total_district_heat / 1000000 / 2
+        x2 = x1 * 4
+        # x2 = (total_district_heat + ((heat_demand_cells[
+        #     'residential_and_service_demand'].sum() -
+        #     total_district_heat) / 2)) / 1000000
+        y = heat_demand_cells['residential_and_service_demand'].max() * 0.7
+        print(f"max = {y}")
+
+        ax.text(x1, y, "District\nheat", ha="center", va="center", size=8,
+                bbox=dict(boxstyle="round, pad=0.5", fc="none",
+                          ec="red", # lw=2
+                          ))
+        ax.text(x2, y, "Individual\nheat supply", ha='center', va="center",
+                size=8,
+                bbox=dict(boxstyle="round, pad=0.5", fc="none",
+                          ec="red", # lw=2
+                          ))
+
+        ax.set(title = ("Heat Sector in " + scenario_name))
+        ax.set_xlabel("Cumulative Heat Demand [TWh / a]")
+        ax.set_ylabel("Heat Demand Densities [MWh / (ha a)]")
+        # ax.set_ylim([0, capacity * 1.1])
+
+        # add the district heating share as a line
+        procent = round(district_heating_share * 100, 0)
+        plt.axvline(x=total_district_heat / 1000000, ls = "--", label =
+                    (f'District Heating Share of {procent} %'),
+                    color = 'red')
+
+        ax.spines["top"].set_visible(False)
+        ax.spines["right"].set_visible(False)
+        ax.plot(1, 0, ">k", transform=ax.get_yaxis_transform(), clip_on=False)
+        ax.plot(0, 1, "^k", transform=ax.get_xaxis_transform(), clip_on=False)
+        ax.legend()  # or: plt.legend()
+        plt.savefig(f'HeatDemandDensities_Curve_{scenario_name}.png')
 
     return None
 
@@ -476,31 +588,42 @@ def district_heating_areas_demarcation():
 
     TODO
     ----
-        Find out which scenario year defines the PSDs
+        Run the model for 20150, 2035 and 2050 to find out which scenario year
+        defines the PSDs -> 2035; implement it accordingly and remove the 2015
+        data, if they are not needed anymore.
+
+        Run the model for Germany and see if there are created large district
+        heating systems in the Ruhr area which need to be split by the
+        municiplality boundaries for example
 
         Create diagrams/curves, make better curves with matplotlib
-        PSD statistics
+
+        Make PSD and DH system statistics
 
         Add datasets to datasets configuration
 
         Check which tasks need to run (according to version number)
     """
+
     # load the census district heat data on apartments, and group them
     # This is currently done in the grouping function:
     # district_heat_zensus, heating_type_zensus = load_census_data()
     # Zenus_DH_areas_201m = area_grouping(district_heat_zensus)
 
     # load the total heat demand by census cell (residential plus service)
-    #HD_2015 = load_heat_demands('eGon2015')
-    # status quo heat demand data is not inserted yet
-    # to do that, line 463 has to be deleted from importing/heat_demand_data/__init__.py
-    # and an emty row has to be added to scenario table (
-    # INSERT INTO scenario.egon_scenario_parameters (name)....)
+    HD_2015 = load_heat_demands('eGon2015')
+    # status quo heat demand data are part of the regluar database content
+    # to get them, line 463 has to be deleted from
+    # importing/heat_demand_data/__init__.py
+    # and an empty row has to be added to scenario table:
+    # INSERT INTO scenario.egon_scenario_parameters (name)
+    # VALUES ('eGon2015');
+    # because egon2015 is not part of the regular EgonScenario table!
     HD_2035 = load_heat_demands('eGon2035')
     HD_2050 = load_heat_demands('eGon100RE')
 
     # select only cells with heat demands > 100 GJ / (ha a)
-    # HD_2015_above_100GJ = select_high_heat_demands(HD_2015)
+    HD_2015_above_100GJ = select_high_heat_demands(HD_2015)
     HD_2035_above_100GJ = select_high_heat_demands(HD_2035)
     HD_2050_above_100GJ = select_high_heat_demands(HD_2050)
 
@@ -508,31 +631,78 @@ def district_heating_areas_demarcation():
     # grouping cells applying the 201m distance buffer, including heat demand
     # aggregation
     # KEEP ONLY ONE after decision
-    # PSD_2015_201m = area_grouping(HD_2015_above_100GJ
-    #                               ).dissolve('area_id', aggfunc='sum')
-    # PSD_2015_201m.to_file("PSDs_2015based.shp")
-    PSD_2035_201m = area_grouping(HD_2035_above_100GJ
+    PSD_2015_201m = area_grouping(HD_2015_above_100GJ, distance=200,
+                                  minimum_total_demand=(10000/3.6)
+                                   ).dissolve('area_id', aggfunc='sum')
+    PSD_2015_201m.to_file("PSDs_2015based.shp")
+    PSD_2035_201m = area_grouping(HD_2035_above_100GJ, distance=200,
+                                  minimum_total_demand=(10000/3.6)
                                   ).dissolve('area_id', aggfunc='sum')
+    HD_2035.to_file("HD_2035.shp")
+    HD_2035_above_100GJ.to_file("HD_2035_above_100GJ.shp")
+
     PSD_2035_201m.to_file("PSDs_2035based.shp")
-    PSD_2050_201m = area_grouping(HD_2050_above_100GJ
+    PSD_2050_201m = area_grouping(HD_2050_above_100GJ, distance=200,
+                                  minimum_total_demand=(10000/3.6)
                                   ).dissolve('area_id', aggfunc='sum')
     PSD_2050_201m.to_file("PSDs_2050based.shp")
 
     # PSD Statistics: average PSD connection rate, total HD
 
     # scenario specific district heating areas
-    district_heating_areas('eGon2035')
-    district_heating_areas('eGon100RE')
+    district_heating_areas('eGon2035', plotting = True)
+    district_heating_areas('eGon100RE', plotting = True)
 
     # plotting all cells
+    # https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.plot.html
+    # https://www.earthdatascience.org/courses/scientists-guide-to-plotting-data-in-python/plot-with-matplotlib/introduction-to-matplotlib-plots/customize-plot-colors-labels-matplotlib/
     fig, ax = plt.subplots(1, 1)
-    # HD_2015.sort_values('demand', ascending=False
-    #                     ).reset_index().demand.plot(ax=ax)
-    HD_2035.sort_values('demand', ascending=False
-                        ).reset_index().demand.plot(ax=ax)
-    HD_2050.sort_values('demand', ascending=False
-                        ).reset_index().demand.plot(ax=ax)
-    plt.savefig('complete_HeatDemandDensities_Curves.png')
+    HD_2015 = HD_2015.sort_values('residential_and_service_demand',
+                                  ascending=False).reset_index()
+    HD_2015["Cumulative_Sum"] = (HD_2015.residential_and_service_demand.
+                                 cumsum()) / 1000000
+    ax.plot(HD_2015.Cumulative_Sum,
+            HD_2015.residential_and_service_demand, label='eGon2015')
+
+    HD_2035 = HD_2035.sort_values('residential_and_service_demand',
+                                  ascending=False).reset_index()
+    HD_2035["Cumulative_Sum"] = (HD_2035.residential_and_service_demand.
+                                 cumsum()) / 1000000
+    ax.plot(HD_2035.Cumulative_Sum,
+            HD_2035.residential_and_service_demand, label='eGon2035')
+
+    HD_2050 = HD_2050.sort_values('residential_and_service_demand',
+                                  ascending=False).reset_index()
+    HD_2050["Cumulative_Sum"] = (HD_2050.residential_and_service_demand.
+                                 cumsum()) / 1000000
+    ax.plot(HD_2050.Cumulative_Sum,
+            HD_2050.residential_and_service_demand, label='eGon100RE')
+
+    ax.margins(x=0, y=0) # default is 0.05
+
+    # axis style
+    # https://matplotlib.org/stable/gallery/ticks_and_spines/centered_spines_with_arrows.html
+    # Hide the right and top spines
+    ax.spines['right'].set_visible(False)
+    ax.spines['top'].set_visible(False)
+    ax.plot(1, 0, ">k", transform=ax.get_yaxis_transform(), clip_on=False)
+    ax.plot(0, 1, "^k", transform=ax.get_xaxis_transform(), clip_on=False)
+
+    ax.set(title = "Heat Demand in eGo^n")
+    ax.set_xlabel("Cumulative Heat Demand [TWh / a]")
+    ax.set_ylabel("Heat Demand Densities [MWh / (ha a)]")
+
+    plt.axvline(x=HD_2035.residential_and_service_demand.sum()/1000000*0.14,
+                ls = ":", lw = 0.5,
+                label = '72TWh DH in 2035 in Germany => 14% DH',
+                color = 'black')
+    plt.axvline(x=HD_2050.residential_and_service_demand.sum()/1000000*0.19,
+                ls = "-.", lw = 0.5,
+                label = '75TWh DH in 100RE in Germany => 19% DH',
+                color = 'black')
+
+    plt.legend()
+    plt.savefig('Complete_HeatDemandDensities_Curves.png')
 
     add_metadata()
 

--- a/src/egon/data/processing/district_heating_areas/__init__.py
+++ b/src/egon/data/processing/district_heating_areas/__init__.py
@@ -1,0 +1,495 @@
+# -*- coding: utf-8 -*-
+
+# This script is part of eGon-data.
+
+# license text - to be added.
+
+"""
+Central module containing all code creating with district heating areas.
+
+This module obtains the information from the census tables and the heat demand
+densities, demarcates so the current and future district heating areas. In the
+end it saves them in the database.
+"""
+
+from egon.data import db  # , subprocess
+# import egon.data.config
+from egon.data.importing.scenarios import get_sector_parameters, EgonScenario
+
+# import pandas as pd
+import geopandas as gpd
+from matplotlib import pyplot as plt
+
+# for metadata creation
+import json
+# import time
+
+# packages for ORM class definition
+from sqlalchemy import Column, String, Float, Integer, Sequence, ForeignKey
+from sqlalchemy.ext.declarative import declarative_base
+
+# TO DO: Finish the class definition
+# egon2015 is not part of the EgonScenario table!
+
+Base = declarative_base()
+
+
+class MapZensusDistrictHeatingAreas(Base):
+    __tablename__ = "map_zensus_district_heating_areas"
+    __table_args__ = {"schema": "demand"}
+    id = Column(
+        Integer,
+        Sequence("map_zensus_district_heating_areas_seq", schema="demand"),
+        server_default=Sequence(
+            "map_zensus_district_heating_areas_seq", schema="demand"
+        ).next_value(),
+        primary_key=True,
+    )
+    area_id = Column(Integer)
+    scenario = Column(String, ForeignKey(EgonScenario.name))
+    version = Column(String)
+    zensus_population_id = Column(Integer)
+
+
+class DistrictHeatingAreas(Base):
+    __tablename__ = "district_heating_areas"
+    __table_args__ = {"schema": "demand"}
+    id = Column(
+        Integer,
+        Sequence("district_heating_areas_seq", schema="demand"),
+        server_default=Sequence(
+            "district_heating_areas_seq", schema="demand"
+        ).next_value(),
+        primary_key=True,
+    )
+    area_id = Column(Integer)
+    scenario = Column(String, ForeignKey(EgonScenario.name))
+    version = Column(String)
+    geom_polygon = Column(Geometry)
+
+
+# Methods used are explained here:
+# https://geopandas.org/docs/user_guide/geometric_manipulations.html
+
+
+def load_census_data():
+    """
+    Load the heating type information from the census database table.
+
+    The census apartment and the census building table contains information
+    about the heating type. The information are loaded from the apartment
+    table, because they might be more useful when it comes to the estimation of
+    the connection rates.
+
+    Parameters
+    ----------
+        None
+
+    Returns
+    -------
+    district_heat: geopandas.geodataframe.GeoDataFrame
+        polygons (hectare cells) with district heat information
+
+    heating_type: geopandas.geodataframe.GeoDataFrame
+        polygons (hectare cells) with the number of flats having heating
+        type information
+
+    Notes
+    -----
+        The census contains only information on residential buildings.
+        Therefore, also connection rate of the residential buildings can be
+        estimated.
+
+    TODO
+    ----
+        - ONLY load cells with flats.quantity_q <2
+        - remove heating_type return, if not needed
+        - store less columns in the district_heat (pop.geom_point),
+            drop characteristics_text after use
+
+    """
+
+    # only census cells where egon-data has a heat demand are considered
+
+    district_heat = db.select_geodataframe(
+        f"""SELECT flats.zensus_population_id, flats.characteristics_text,
+        flats.quantity, flats.quantity_q, pop.geom_point,
+        pop.geom AS geom_polygon
+        FROM society.destatis_zensus_apartment_per_ha AS flats
+        JOIN society.destatis_zensus_population_per_ha AS pop
+        ON flats.zensus_population_id = pop.id
+        AND flats.characteristics_text = 'Fernheizung (Fernwärme)'
+        AND flats.zensus_population_id IN
+        (SELECT zensus_population_id FROM demand.egon_peta_heat);""",
+        index_col="zensus_population_id",
+        geom_col="geom_polygon"
+    )
+
+    heating_type = db.select_geodataframe(
+        f"""SELECT flats.zensus_population_id,
+        SUM(flats.quantity) AS quantity, pop.geom AS geom_polygon
+        FROM society.destatis_zensus_apartment_per_ha AS flats
+        JOIN society.destatis_zensus_population_per_ha AS pop
+        ON flats.zensus_population_id = pop.id
+        AND flats.attribute = 'HEIZTYP'
+        AND flats.zensus_population_id IN
+        (SELECT zensus_population_id FROM demand.egon_peta_heat)
+        GROUP BY flats.zensus_population_id, pop.geom;""",
+        index_col="zensus_population_id",
+        geom_col="geom_polygon"
+    )
+
+    # district_heat.to_file("dh.shp")
+    # heating_type.to_file("heating.shp")
+
+    # calculate the connection rate for all census cells with DH
+    # adding it to the district_heat geodataframe
+
+    district_heat['connection_rate'] = district_heat['quantity'].div(heating_type['quantity'])[district_heat.index]
+    # district_heat.head
+    # district_heat['connection_rate'].describe()
+
+    district_heat = district_heat[district_heat['connection_rate'] >= 0.3]
+    # district_heat.columns
+
+    """
+    Alternative
+    Return a geodataframe with the number of DH supplied flats and all flats
+    to calculate the connection rate in a PSD from the number of flats instead
+    of the calculation of an average
+    """
+
+    return district_heat, heating_type
+
+
+def load_heat_demands(scenario_name):
+    """
+    Load scenario specific heat demand data from the local database.
+
+    Parameters
+    ----------
+    scenario_name: str
+        name of the scenario studied
+
+    Returns
+    -------
+    heat_demand: geopandas.geodataframe.GeoDataFrame
+             polygons (hectare cells) with heat demand data
+
+    """
+
+    # load the total heat demand (residential plus service sector)
+    heat_demand = db.select_geodataframe(
+        f"""SELECT demand.zensus_population_id,
+        SUM(demand.demand) AS residential_and_service_demand,
+        pop.geom AS geom_polygon
+        FROM demand.egon_peta_heat AS demand
+        JOIN society.destatis_zensus_population_per_ha AS pop
+        ON demand.zensus_population_id = pop.id
+        AND demand.version = '0.0.0'
+        AND demand.scenario = '{scenario_name}'
+        GROUP BY demand.zensus_population_id, pop.geom;""",
+        index_col="zensus_population_id",
+        geom_col="geom_polygon"
+    )
+
+    return heat_demand
+
+
+def select_high_heat_demands(heat_demand):
+    """
+    Take heat demand cells and select cells with higher heat demand.
+
+    Those can be used to identify prospective district heating supply areas.
+
+    Parameters
+    ----------
+    heat_demand: geopandas.geodataframe.GeoDataFrame
+        dataset of heat demand cells.
+
+    Returns
+    -------
+    high_heat_demand: geopandas.geodataframe.GeoDataFrame
+             polygons (hectare cells) with heat demands high enough to be
+             potentially high enough to be in a district heating area
+    """
+
+    # starting point are 100 or 200 GJ/ (ha a), converted into MWh
+    minimum_demand = 100 / 3.6
+
+    high_heat_demand = heat_demand[heat_demand[
+        'residential_and_service_demand'] > minimum_demand]
+    # high_heat_demand.head()
+    # print(high_heat_demand.area) # all cells are 10,000 m²
+
+    return high_heat_demand
+
+
+def area_grouping(raw_polygons):
+    """
+    This function groups polygons which are close to each other.
+
+    Heat demand density polygons can be grouped into prospective district
+    heating supply districts (PSDs). Only cells with a minimum heat demand
+    density (e.g. >100 GJ/(ha a)) are considered. Therefore, the
+    select_high_heat_demands() function is used.
+
+    Census cells with district heating supply can be grouped into
+    existing district heating system areas.
+
+    Method
+    - buffer around the cell polygons
+    - union the intersecting buffer polygons
+    - union the cell polygons which are within one unioned buffer polygon
+
+    Parameters
+    ----------
+    raw_polygons: geopandas.geodataframe.GeoDataFrame
+        polygons to be grouped.
+
+    Returns
+    -------
+    join: geopandas.geodataframe.GeoDataFrame
+        cell polygons with area id
+
+    Notes
+    -----
+        None
+
+    TODO
+    ----
+        Make the buffer distance a parameter, 501 m for Census DH areas?
+
+        Implement the total minimum demand for PSDs:
+        There is a minimum total heat demand of 10,000 GJ / a for PSDs.
+        It could be an optional parameter.
+
+    """
+
+    # WARNING:
+    # A value is trying to be set on a copy of a slice from a DataFrame.
+    # Try using .loc[row_indexer,col_indexer] = value instead
+    cell_buffers = raw_polygons
+    cell_buffers['geom_polygon'] = cell_buffers['geom_polygon'].buffer(201)
+    # print(cell_buffers.area)
+
+    # create a shapely Multipolygon which is split into a list
+    buffer_polygons = list(cell_buffers['geom_polygon'].unary_union)
+
+    # change the data type into geopandas geodataframe
+    buffer_polygons_gdf = gpd.GeoDataFrame(geometry=buffer_polygons,
+                                           crs=3035)
+    # buffer_polygons_gdf.plot()
+
+    # Join studied cells with buffer polygons
+    columnname = "area_id"
+    join = gpd.sjoin(raw_polygons, buffer_polygons_gdf, how="inner",
+                     op="intersects")
+    join = join.rename({'index_right': columnname}, axis=1)
+    # join.plot(column=columnname)
+
+    return join
+
+
+def district_heating_areas(scenario_name):
+    """
+    Load district heating share from a sceanto table.
+
+    ...
+
+    Parameters
+    ----------
+    scenario_name: str
+        name of scenario to be studies
+
+
+    Returns
+    -------
+        None
+
+    Notes
+    -----
+        None
+
+    TODO
+    ----
+        Error messages when the amount of DH is lower than today
+
+        Do "area_grouping(load_census_data()[0])" only once, not for all
+        scenarios.
+
+        Make sure that puting data into the area_grouping, does not lead
+        totally wrong data e.g. aggregated connection rates.
+
+        Create the diagram with the curve, maybe in the final function or here
+
+    """
+
+    # Load district heating shares from the scenario table
+    if scenario_name == "eGon2015":
+        district_heating_share = 0.08
+    else:
+        heat_parameters = get_sector_parameters('heat', scenario=scenario_name)
+
+        district_heating_share = heat_parameters['DE_district_heating_share']
+
+    # Firstly, supply the cells which already have district heating according
+    # to 2011 Census data and which are within likely dh areas (created
+    # by the area grouping function), load only the first returned result: [0]
+    cells = area_grouping(load_census_data()[0])
+    # heat_demand is scenario specific
+    heat_demand_cells = load_heat_demands(scenario_name)
+    cells['residential_and_service_demand'] = heat_demand_cells.loc[
+        cells.index.values, 'residential_and_service_demand']
+
+    total_district_heat = (heat_demand_cells['residential_and_service_demand'
+                                             ].sum() * district_heating_share)
+
+    diff = total_district_heat - cells['residential_and_service_demand'].sum()
+
+    # Secondly, supply the cells with the highest heat demand not having
+    # district heating yet
+    # ASSUMPTION HERE: 2035 HD defined the PSDs
+    PSDs = area_grouping(select_high_heat_demands(
+        load_heat_demands("eGon2035")))
+
+    # select all cells not already suppied with district heat
+    new_areas = heat_demand_cells[~heat_demand_cells.index.isin(cells.index)]
+    # sort by heat demand density
+    new_areas = new_areas[new_areas.index.isin(PSDs.index)].sort_values(
+        'residential_and_service_demand', ascending=False)
+    new_areas["Cumulative_Sum"] = new_areas.residential_and_service_demand.cumsum()
+    # select cells to be supplied with district heating until district
+    # heating share is reached
+    new_areas = new_areas[new_areas["Cumulative_Sum"] <= diff]
+    # group the resulting scenario specify district heating areas
+    scenario_dh_area = area_grouping(gpd.GeoDataFrame(
+        cells[['residential_and_service_demand', 'geom_polygon']].append(
+            new_areas[['residential_and_service_demand', 'geom_polygon']]),
+        geometry='geom_polygon'))
+    # scenario_dh_area.plot(column = "area_id")
+
+    # store the results in the database
+    scenario_dh_area["scenario"] = scenario_name
+    scenario_dh_area["version"] = '0.0.0'
+
+    db.execute_sql(f"""DELETE FROM demand.map_zensus_district_heating_areas
+                   WHERE scenario = '{scenario_name}'""")
+    # LATER HERE THE GEO INFORMATION COULD BE DELETED WHEN SAVING IN DB:
+    # .drop('geom_polygon', axis=1) - how to drop two?
+    scenario_dh_area.drop('residential_and_service_demand', axis=1
+                          ).to_postgis('map_zensus_district_heating_areas',
+                                       schema='demand', con=db.engine(),
+                                       if_exists="append")
+    # scenario_dh_area.columns
+
+    # Create polygons around the grouped cells and store them in the database
+    # CHECK ALTERNATIVE METHODS
+    # join.dissolve(columnname).convex_hull.plot() # without holes, too big
+    areas_dissolved = scenario_dh_area.dissolve('area_id', aggfunc='sum')
+    areas_dissolved["scenario"] = scenario_name
+    areas_dissolved["version"] = '0.0.0'
+
+    db.execute_sql(f"""DELETE FROM demand.district_heating_areas
+                   WHERE scenario = '{scenario_name}'""")
+    areas_dissolved.to_postgis('district_heating_areas', schema='demand',
+                               con=db.engine(), if_exists="append")
+    # Alternative:
+    # join.groupby("columnname").demand.sum()
+
+    # create diagrams for visualisation, sorted by HDD
+    # sorted census dh first, sorted new areas, left overs, DH share
+    fig, ax = plt.subplots(1, 1)
+    new_areas.sort_values('residential_and_service_demand', ascending=False
+                          ).reset_index().residential_and_service_demand.plot(
+                              ax=ax)
+    plt.savefig(f'HeatDemandDensities_Curve_{scenario_name}.png')
+
+    return None
+
+
+def add_metadata():
+    """
+    Writes metadata JSON string into table comment.
+
+    TODO
+    ----
+        Do it!
+    """
+
+
+def district_heating_areas_demarcation():
+    """
+    Call all functions related to the creation of district heating areas.
+
+    This function executes the functions that....
+
+    Parameters
+    ----------
+        None
+
+    Returns
+    -------
+        None
+
+    Notes
+    -----
+        None
+
+    TODO
+    ----
+        Find out which scenario year defines the PSDs
+
+        Create diagrams/curves, make better curves with matplotlib
+        PSD statistics
+
+        Check which tasks need to run (according to version number)
+    """
+    # load the census district heat data on apartments, and group them
+    # This is currently done in the grouping function:
+    # district_heat_zensus, heating_type_zensus = load_census_data()
+    # Zenus_DH_areas_201m = area_grouping(district_heat_zensus)
+
+    # load the total heat demand by census cell (residential plus service)
+    HD_2015 = load_heat_demands('eGon2015')
+    HD_2035 = load_heat_demands('eGon2035')
+    HD_2050 = load_heat_demands('eGon100RE')
+
+    # select only cells with heat demands > 100 GJ / (ha a)
+    HD_2015_above_100GJ = select_high_heat_demands(HD_2015)
+    HD_2035_above_100GJ = select_high_heat_demands(HD_2035)
+    HD_2050_above_100GJ = select_high_heat_demands(HD_2050)
+
+    # PSDs
+    # grouping cells applying the 201m distance buffer, including heat demand
+    # aggregation
+    # KEEP ONLY ONE after decision
+    PSD_2015_201m = area_grouping(HD_2015_above_100GJ
+                                  ).dissolve('area_id', aggfunc='sum')
+    PSD_2015_201m.to_file("PSDs_2015based.shp")
+    PSD_2035_201m = area_grouping(HD_2035_above_100GJ
+                                  ).dissolve('area_id', aggfunc='sum')
+    PSD_2035_201m.to_file("PSDs_2035based.shp")
+    PSD_2050_201m = area_grouping(HD_2050_above_100GJ
+                                  ).dissolve('area_id', aggfunc='sum')
+    PSD_2050_201m.to_file("PSDs_2050based.shp")
+
+    # PSD Statistics: average PSD connection rate, total HD
+
+    # scenario specific district heating areas
+    district_heating_areas('eGon2035')
+    district_heating_areas('eGon2050')
+
+    # plotting all cells
+    fig, ax = plt.subplots(1, 1)
+    HD_2015.sort_values('demand', ascending=False
+                        ).reset_index().demand.plot(ax=ax)
+    HD_2035.sort_values('demand', ascending=False
+                        ).reset_index().demand.plot(ax=ax)
+    HD_2050.sort_values('demand', ascending=False
+                        ).reset_index().demand.plot(ax=ax)
+    plt.savefig('complete_HeatDemandDensities_Curves.png')
+
+    add_metadata()
+
+    return None

--- a/src/egon/data/processing/district_heating_areas/__init__.py
+++ b/src/egon/data/processing/district_heating_areas/__init__.py
@@ -492,6 +492,10 @@ def district_heating_areas_demarcation():
 
     # load the total heat demand by census cell (residential plus service)
     #HD_2015 = load_heat_demands('eGon2015')
+    # status quo heat demand data is not inserted yet
+    # to do that, line 463 has to be deleted from importing/heat_demand_data/__init__.py
+    # and an emty row has to be added to scenario table (
+    # INSERT INTO scenario.egon_scenario_parameters (name)....)
     HD_2035 = load_heat_demands('eGon2035')
     HD_2050 = load_heat_demands('eGon100RE')
 
@@ -518,7 +522,7 @@ def district_heating_areas_demarcation():
 
     # scenario specific district heating areas
     district_heating_areas('eGon2035')
-    district_heating_areas('eGon2050')
+    district_heating_areas('eGon100RE')
 
     # plotting all cells
     fig, ax = plt.subplots(1, 1)

--- a/src/egon/data/processing/district_heating_areas/__init__.py
+++ b/src/egon/data/processing/district_heating_areas/__init__.py
@@ -564,8 +564,260 @@ def add_metadata():
 
     TODO
     ----
-        Do it!
+
+        Meta data must be check and adjusted to the egon_data standard:
+            - Add context
+            - authors and institutions
+
     """
+
+    # Prepare variables
+    license_district_heating_areas = [
+        {
+            # this could be the license of the "district_heating_areas"
+            "name": "Creative Commons Attribution 4.0 International",
+            "title": "CC BY 4.0",
+            "path": "https://creativecommons.org/licenses/by/4.0/",
+            "instruction": (
+                "You are free: To Share, To Adapt;"
+                " As long as you: Attribute!"
+            ),
+            "attribution": "© Europa-Universität Flensburg",  # if all agree
+            # "attribution": "© ZNES Flensburg",  # alternative
+        }
+    ]
+
+    # Metadata creation for district heating areas (polygons)
+    meta = {
+        "name": "district_heating_areas_metadata",
+        "title": "eGo^n scenario-specific future district heating areas",
+        "description": "Modelled future district heating areas for "
+        "the supply of residential and service-sector heat demands",
+        "language": ["EN"],
+        "spatial": {
+            "location": "",
+            "extent": "Germany",
+            "resolution": "",
+        },
+        "temporal": {
+            "referenceDate": "scenario-specific",
+            "timeseries": {
+                "start": "",
+                "end": "",
+                "resolution": "",
+                "alignment": "",
+                "aggregationType": "",
+            },
+        },
+        "sources": [
+            {
+                # eGon scenario specific heat demand distribution based
+                # on Peta5_0_1, using vg250 boundaries
+                },
+            {
+                # Census gridded apartment data
+            },
+        ],
+
+        "resources": [
+            {
+                "profile": "tabular-data-resource",
+                "name": "district_heating_areas",
+                "path": "",
+                "format": "PostgreSQL",
+                "encoding": "UTF-8",
+                "schema": {
+                    "fields": [
+                        {
+                            "name": "id",
+                            "description": "Unique identifier",
+                            "type": "serial",
+                            "unit": "none",
+                        },
+                        {
+                            "name": "area_id",
+                            "description": "District heating area id",
+                            "type": "integer",
+                            "unit": "none",
+                        },
+                        {
+                            "name": "scenario",
+                            "description": "scenario name",
+                            "type": "text",
+                            "unit": "none",
+                        },
+                        {
+                            "name": "version",
+                            "description": "data version number",
+                            "type": "text",
+                            "unit": "none",
+                        },
+                        {
+                            "name": "residential_and_service_demand",
+                            "description": "annual heat demand",
+                            "type": "double precision",
+                            "unit": "MWh",
+                        },
+                        {
+                            "name": "geom_polygon",
+                            "description": "geo information of multipolygons",
+                            "type": "geometry(MULTIPOLYGON, 3035)",
+                            "unit": "none",
+                        },
+                    ],
+                    "primaryKey": ["id"],
+                    "foreignKeys": [
+                        {
+                            "fields": ["scenario"],
+                            "reference": {
+                                "resource": "scenario.egon_scenario_parameters",
+                                "fields": ["name"],
+                            },
+                        }
+                    ],
+                },
+                "dialect": {"delimiter": "none", "decimalSeparator": "."},
+            }
+        ],
+        "licenses": license_district_heating_areas,
+        "contributors": [
+            {
+                "title": "Eva, Clara",
+                "email": "",
+                "date": "2021-05-07",
+                "object": "",
+                "comment": "Processed data",
+            }
+        ],
+        "metaMetadata": {  # https://github.com/OpenEnergyPlatform/oemetadata
+            "metadataVersion": "OEP-1.4.0",
+            "metadataLicense": {
+                "name": "CC0-1.0",
+                "title": "Creative Commons Zero v1.0 Universal",
+                "path": ("https://creativecommons.org/publicdomain/zero/1.0/"),
+            },
+        },
+    }
+    meta_json = "'" + json.dumps(meta) + "'"
+
+    db.submit_comment(meta_json, "demand", "district_heating_areas")
+
+
+    # Metadata creation for "id mapping" table
+    meta = {
+        "name": "map_zensus_district_heating_areas_metadata",
+        "title": "district heating area ids assigned to zensus_population_ids",
+        "description": "Ids of scenario specific future district heating areas"
+        " for supply of residential and service-sector heat demands"
+        " assigned to zensus_population_ids",
+        "language": ["EN"],
+        "spatial": {
+            "location": "",
+            "extent": "Germany",
+            "resolution": "",
+        },
+        "temporal": {
+            "referenceDate": "scenario-specific",
+            "timeseries": {
+                "start": "",
+                "end": "",
+                "resolution": "",
+                "alignment": "",
+                "aggregationType": "",
+            },
+        },
+        "sources": [
+            {
+                # eGon scenario specific heat demand distribution based
+                # on Peta5_0_1, using vg250 boundaries
+                },
+            {
+                # Census gridded apartment data
+            },
+        ],
+
+
+    # Add the license for the map table
+
+        "resources": [
+            {
+                "profile": "tabular-data-resource",
+                "name": "map_zensus_district_heating_areas",
+                "path": "",
+                "format": "PostgreSQL",
+                "encoding": "UTF-8",
+                "schema": {
+                    "fields": [
+                        {
+                            "name": "id",
+                            "description": "Unique identifier",
+                            "type": "serial",
+                            "unit": "none",
+                        },
+                        {
+                            "name": "area_id",
+                            "description": "district heating area id",
+                            "type": "integer",
+                            "unit": "none",
+                        },
+                        {
+                            "name": "scenario",
+                            "description": "scenario name",
+                            "type": "text",
+                            "unit": "none",
+                        },
+                        {
+                            "name": "version",
+                            "description": "data version number",
+                            "type": "text",
+                            "unit": "none",
+                        },
+                    ],
+                    "primaryKey": ["id"],
+                    "foreignKeys": [
+                        {
+                            "fields": ["zensus_population_id"],
+                            "reference": {
+                                "resource": "society.destatis_zensus_population_per_ha",
+                                "fields": ["id"],
+                            },
+                        },
+                        {
+                            "fields": ["scenario"],
+                            "reference": {
+                                "resource": "scenario.egon_scenario_parameters",
+                                "fields": ["name"],
+                            },
+                        }
+                    ],
+                },
+                "dialect": {"delimiter": "none", "decimalSeparator": "."},
+            }
+        ],
+        "licenses": license_district_heating_areas,
+        "contributors": [
+            {
+                "title": "Eva, Clara",
+                "email": "",
+                "date": "2021-05-07",
+                "object": "",
+                "comment": "Processed data",
+            }
+        ],
+        "metaMetadata": {  # https://github.com/OpenEnergyPlatform/oemetadata
+            "metadataVersion": "OEP-1.4.0",
+            "metadataLicense": {
+                "name": "CC0-1.0",
+                "title": "Creative Commons Zero v1.0 Universal",
+                "path": ("https://creativecommons.org/publicdomain/zero/1.0/"),
+            },
+        },
+    }
+    meta_json = "'" + json.dumps(meta) + "'"
+
+    db.submit_comment(meta_json, "demand", "map_zensus_district_heating_areas")
+
+    return None
 
 
 def district_heating_areas_demarcation():

--- a/src/egon/data/processing/district_heating_areas/plot.py
+++ b/src/egon/data/processing/district_heating_areas/plot.py
@@ -11,17 +11,18 @@ import os
 from egon.data.importing.scenarios import get_sector_parameters
 import pandas as pd
 from matplotlib import pyplot as plt
-    # heat_denisty_per_scenario = {}
-    # heat_denisty_per_scenario['eGon2035'] = district_heating_areas(
-    #     'eGon2035', plotting = True)
-    # heat_denisty_per_scenario['eGon100RE'] = district_heating_areas(
-    #     'eGon100RE', plotting = True)
 
-    # if plotting:
+# heat_denisty_per_scenario = {}
+# heat_denisty_per_scenario['eGon2035'] = district_heating_areas(
+#     'eGon2035', plotting = True)
+# heat_denisty_per_scenario['eGon100RE'] = district_heating_areas(
+#     'eGon100RE', plotting = True)
 
-    #     from egon.data.processing.district_heating_areas.plot import (
-    #         plot_heat_density_sorted)
-    #     plot_heat_density_sorted({scenario_name:collection}, scenario_name )
+# if plotting:
+
+#     from egon.data.processing.district_heating_areas.plot import (
+#         plot_heat_density_sorted)
+#     plot_heat_density_sorted({scenario_name:collection}, scenario_name )
 def plot_heat_density_sorted(heat_denisty_per_scenario, scenario_name=None):
     """
     Create diagrams for visualisation, sorted by HDD
@@ -44,43 +45,51 @@ def plot_heat_density_sorted(heat_denisty_per_scenario, scenario_name=None):
     """
 
     # create directory to store files
-    results_path = 'district_heating_areas/'
+    results_path = "district_heating_areas/"
 
     if not os.path.exists(results_path):
         os.mkdir(results_path)
 
     fig, ax = plt.subplots(1, 1)
 
-    colors = pd.DataFrame(columns=['share', 'curve'],
-                          index = ['eGon2035', 'eGon100RE'])
+    colors = pd.DataFrame(
+        columns=["share", "curve"], index=["eGon2035", "eGon100RE"]
+    )
 
-    colors['share']['eGon2035'] = 'darkblue'
-    colors['curve']['eGon2035'] = 'blue'
-    colors['share']['eGon100RE'] = 'red'
-    colors['curve']['eGon100RE'] = 'orange'
+    colors["share"]["eGon2035"] = "darkblue"
+    colors["curve"]["eGon2035"] = "blue"
+    colors["share"]["eGon100RE"] = "red"
+    colors["curve"]["eGon100RE"] = "orange"
 
     for scenario in heat_denisty_per_scenario.keys():
 
-        heat_parameters = get_sector_parameters('heat', scenario=scenario)
+        heat_parameters = get_sector_parameters("heat", scenario=scenario)
 
-        district_heating_share = heat_parameters['DE_district_heating_share']
+        district_heating_share = heat_parameters["DE_district_heating_share"]
         collection = heat_denisty_per_scenario[scenario]
 
-        total_district_heat = (district_heating_share
-                               * collection.residential_and_service_demand.sum())
+        total_district_heat = (
+            district_heating_share
+            * collection.residential_and_service_demand.sum()
+        )
 
         # add the district heating share as a line
         procent = round(district_heating_share * 100, 0)
-        plt.axvline(x=total_district_heat / 1000000, ls = "--", lw = 0.5,
-                    label = (f'{scenario}: District Heating Share of {procent} %'),
-                    color = colors['share'][scenario])
+        plt.axvline(
+            x=total_district_heat / 1000000,
+            ls="--",
+            lw=0.5,
+            label=(f"{scenario}: District Heating Share of {procent} %"),
+            color=colors["share"][scenario],
+        )
         # add the sorted heat demand density curve
 
-
-        ax.plot(collection.Cumulative_Sum,
-                collection.residential_and_service_demand, label =
-                f"{scenario}: Heat demand densities, sorted",
-                color=colors['curve'][scenario])
+        ax.plot(
+            collection.Cumulative_Sum,
+            collection.residential_and_service_demand,
+            label=f"{scenario}: Heat demand densities, sorted",
+            color=colors["curve"][scenario],
+        )
 
         # annotations
         x1 = total_district_heat / 1000000 / 2
@@ -90,18 +99,35 @@ def plot_heat_density_sorted(heat_denisty_per_scenario, scenario_name=None):
         #     total_district_heat) / 2)) / 1000000
         y = collection.residential_and_service_demand.max() * 0.7
 
-        ax.text(x1, y, "District\nheat", ha="center", va="center", size=8,
-                bbox=dict(boxstyle="round, pad=0.5", fc="none",
-                          ec=colors['share'][scenario], # lw=2
-                          ))
-        ax.text(x2, y, "Individual\nheat supply", ha='center', va="center",
-                size=8,
-                bbox=dict(boxstyle="round, pad=0.5", fc="none",
-                          ec=colors['share'][scenario], # lw=2
-                          ))
+        ax.text(
+            x1,
+            y,
+            "District\nheat",
+            ha="center",
+            va="center",
+            size=8,
+            bbox=dict(
+                boxstyle="round, pad=0.5",
+                fc="none",
+                ec=colors["share"][scenario],  # lw=2
+            ),
+        )
+        ax.text(
+            x2,
+            y,
+            "Individual\nheat supply",
+            ha="center",
+            va="center",
+            size=8,
+            bbox=dict(
+                boxstyle="round, pad=0.5",
+                fc="none",
+                ec=colors["share"][scenario],  # lw=2
+            ),
+        )
 
     if scenario_name:
-        ax.set(title = ("Heat Sector in " + scenario_name))
+        ax.set(title=("Heat Sector in " + scenario_name))
     ax.set_xlabel("Cumulative Heat Demand [TWh / a]")
     ax.set_ylabel("Heat Demand Densities [MWh / (ha a)]")
 
@@ -114,7 +140,8 @@ def plot_heat_density_sorted(heat_denisty_per_scenario, scenario_name=None):
     ax.plot(0, 1, "^k", transform=ax.get_xaxis_transform(), clip_on=False)
     ax.legend()  # or: plt.legend()
     if scenario_name:
-        plt.savefig(results_path+
-                    f'HeatDemandDensities_Curve_{scenario_name}.png')
+        plt.savefig(
+            results_path + f"HeatDemandDensities_Curve_{scenario_name}.png"
+        )
     else:
-        plt.savefig(results_path+'HeatDemandDensities_Curves.png')
+        plt.savefig(results_path + "HeatDemandDensities_Curves.png")

--- a/src/egon/data/processing/district_heating_areas/plot.py
+++ b/src/egon/data/processing/district_heating_areas/plot.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+
+# This script is part of eGon-data.
+
+# license text - to be added.
+
+"""
+Module containing all code creating with plots of district heating areas
+"""
+from egon.data.importing.scenarios import get_sector_parameters
+import pandas as pd
+from matplotlib import pyplot as plt
+    # heat_denisty_per_scenario = {}
+    # heat_denisty_per_scenario['eGon2035'] = district_heating_areas(
+    #     'eGon2035', plotting = True)
+    # heat_denisty_per_scenario['eGon100RE'] = district_heating_areas(
+    #     'eGon100RE', plotting = True)
+
+    # if plotting:
+
+    #     from egon.data.processing.district_heating_areas.plot import (
+    #         plot_heat_density_sorted)
+    #     plot_heat_density_sorted({scenario_name:collection}, scenario_name )
+def plot_heat_density_sorted(heat_denisty_per_scenario, scenario_name=None):
+    """
+    Create diagrams for visualisation, sorted by HDD
+    sorted census dh first, sorted new areas, left overs, DH share
+    create one dataframe with all data: first the cells with existing,
+    then the cells with new district heating systems and in the end the
+    ones without
+
+    Parameters
+    ----------
+    scenario_name : TYPE
+        DESCRIPTION.
+    collection : TYPE
+        DESCRIPTION.
+
+    Returns
+    -------
+    None.
+
+    """
+
+    fig, ax = plt.subplots(1, 1)
+
+    colors = pd.DataFrame(columns=['share', 'curve'],
+                          index = ['eGon2035', 'eGon100RE'])
+
+    colors['share']['eGon2035'] = 'darkblue'
+    colors['curve']['eGon2035'] = 'blue'
+    colors['share']['eGon100RE'] = 'red'
+    colors['curve']['eGon100RE'] = 'orange'
+
+    for scenario in heat_denisty_per_scenario.keys():
+
+        heat_parameters = get_sector_parameters('heat', scenario=scenario)
+
+        district_heating_share = heat_parameters['DE_district_heating_share']
+        collection = heat_denisty_per_scenario[scenario]
+
+        total_district_heat = (district_heating_share
+                               * collection.residential_and_service_demand.sum())
+
+        # add the district heating share as a line
+        procent = round(district_heating_share * 100, 0)
+        plt.axvline(x=total_district_heat / 1000000, ls = "--", lw = 0.5,
+                    label = (f'{scenario}: District Heating Share of {procent} %'),
+                    color = colors['share'][scenario])
+        # add the sorted heat demand density curve
+
+
+        ax.plot(collection.Cumulative_Sum,
+                collection.residential_and_service_demand, label =
+                f"{scenario}: Heat demand densities, sorted",
+                color=colors['curve'][scenario])
+
+        # annotations
+        x1 = total_district_heat / 1000000 / 2
+        x2 = x1 * 4
+        # x2 = (total_district_heat + ((heat_demand_cells[
+        #     'residential_and_service_demand'].sum() -
+        #     total_district_heat) / 2)) / 1000000
+        y = collection.residential_and_service_demand.max() * 0.7
+
+        ax.text(x1, y, "District\nheat", ha="center", va="center", size=8,
+                bbox=dict(boxstyle="round, pad=0.5", fc="none",
+                          ec=colors['share'][scenario], # lw=2
+                          ))
+        ax.text(x2, y, "Individual\nheat supply", ha='center', va="center",
+                size=8,
+                bbox=dict(boxstyle="round, pad=0.5", fc="none",
+                          ec=colors['share'][scenario], # lw=2
+                          ))
+
+    if scenario_name:
+        ax.set(title = ("Heat Sector in " + scenario_name))
+    ax.set_xlabel("Cumulative Heat Demand [TWh / a]")
+    ax.set_ylabel("Heat Demand Densities [MWh / (ha a)]")
+
+    # remove empty space between axis and graph
+    ax.margins(x=0, y=0)
+    # axes style
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.plot(1, 0, ">k", transform=ax.get_yaxis_transform(), clip_on=False)
+    ax.plot(0, 1, "^k", transform=ax.get_xaxis_transform(), clip_on=False)
+    ax.legend()  # or: plt.legend()
+    if scenario_name:
+        plt.savefig(f'HeatDemandDensities_Curve_{scenario_name}.png')
+    else:
+        plt.savefig('HeatDemandDensities_Curves.png')

--- a/src/egon/data/processing/district_heating_areas/plot.py
+++ b/src/egon/data/processing/district_heating_areas/plot.py
@@ -7,6 +7,7 @@
 """
 Module containing all code creating with plots of district heating areas
 """
+import os
 from egon.data.importing.scenarios import get_sector_parameters
 import pandas as pd
 from matplotlib import pyplot as plt
@@ -41,6 +42,12 @@ def plot_heat_density_sorted(heat_denisty_per_scenario, scenario_name=None):
     None.
 
     """
+
+    # create directory to store files
+    results_path = 'district_heating_areas/'
+
+    if not os.path.exists(results_path):
+        os.mkdir(results_path)
 
     fig, ax = plt.subplots(1, 1)
 
@@ -107,6 +114,7 @@ def plot_heat_density_sorted(heat_denisty_per_scenario, scenario_name=None):
     ax.plot(0, 1, "^k", transform=ax.get_xaxis_transform(), clip_on=False)
     ax.legend()  # or: plt.legend()
     if scenario_name:
-        plt.savefig(f'HeatDemandDensities_Curve_{scenario_name}.png')
+        plt.savefig(results_path+
+                    f'HeatDemandDensities_Curve_{scenario_name}.png')
     else:
-        plt.savefig('HeatDemandDensities_Curves.png')
+        plt.savefig(results_path+'HeatDemandDensities_Curves.png')


### PR DESCRIPTION
Close #162 
Scenario specific District Heating areas are defined using the modelled heat demand densities while considering existing district heat supply in flats (according to census data) and scenario specific district heating shares.
Open TODO are the dataset version management (including numbering), the finalization of the metadata and minor nice-to-have improvements.