### PR TITLE
Increased shared memory size of docker container to 16 GB

### DIFF
--- a/src/egon/data/airflow/docker-compose.yml
+++ b/src/egon/data/airflow/docker-compose.yml
@@ -16,3 +16,4 @@ services:
       POSTGRES_PASSWORD: {--database-password}
     volumes:
     - ./database-data/:/var/lib/postgresql/data
+    shm_size: "16gb"


### PR DESCRIPTION
Fixes #267 

Note, you definitely need to stop and restart the container (`docker stop egon-data-local-database-container`). Eventually, the container needs to be deleted and re-created, use `docker rm egon-data-local-database-container`. 