### PR TITLE
Add colum 'temp_id' to all etrago-timeseries-tables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -135,7 +135,8 @@ Changed
 * Update installation of demandregio's disaggregator
   `#202 <https://github.com/openego/eGon-data/issues/202>`_
 * Update etrago tables
-  `#243 <https://github.com/openego/eGon-data/issues/243>`_
+  `#243 <https://github.com/openego/eGon-data/issues/243>`_ and 
+  `#285 <https://github.com/openego/eGon-data/issues/285>`_
 
 Bug fixes
 ---------

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -283,7 +283,7 @@ with airflow.DAG(
     # setting etrago input tables
     etrago_input_data = PythonOperator(
         task_id="setting-etrago-input-tables",
-        python_callable=etrago.create_tables,
+        python_callable=etrago.setup,
     )
     setup >> etrago_input_data
 

--- a/src/egon/data/importing/etrago/__init__.py
+++ b/src/egon/data/importing/etrago/__init__.py
@@ -26,7 +26,7 @@ class EgonPfHvBus(Base):
     y = Column(Float(53))
     geom = Column(Geometry('POINT', 4326), index=True)
 
-    
+
 class EgonPfHvBusTimeseries(Base):
     __tablename__ = 'egon_pf_hv_bus_timeseries'
     __table_args__ = {'schema': 'grid'}
@@ -64,8 +64,8 @@ class EgonPfHvGenerator(Base):
     shut_down_cost = Column(Float(53))
     min_up_time = Column(BigInteger)
     min_down_time = Column(BigInteger)
-    up_time_before = Column(BigInteger)    
-    down_time_before = Column(BigInteger)    
+    up_time_before = Column(BigInteger)
+    down_time_before = Column(BigInteger)
     ramp_limit_up = Column(Float(53))
     ramp_limit_down = Column(Float(53))
     ramp_limit_start_up = Column(Float(53))
@@ -79,7 +79,7 @@ class EgonPfHvGeneratorTimeseries(Base):
     version = Column(Text, primary_key=True, nullable=False)
     scn_name = Column(String, primary_key=True, nullable=False)
     generator_id = Column(Integer, primary_key=True, nullable=False)
-    temp_id = Column(Integer, nullable=False)
+    temp_id = Column(Integer, primary_key=True, nullable=False)
     p_set = Column(ARRAY(Float(precision=53)))
     q_set = Column(ARRAY(Float(precision=53)))
     p_min_pu = Column(ARRAY(Float(precision=53)))
@@ -97,7 +97,7 @@ class EgonPfHvLine(Base):
     bus0 = Column(BigInteger)
     bus1 = Column(BigInteger)
     type = Column(Text)
-    carrier = Column(Text)    
+    carrier = Column(Text)
     x = Column(Numeric)
     r = Column(Numeric)
     g = Column(Numeric)
@@ -126,6 +126,7 @@ class EgonPfHvLineTimeseries(Base):
     version = version = Column(Text, primary_key=True, nullable=False)
     scn_name = Column(String, primary_key=True, nullable=False)
     line_id = Column(BigInteger, primary_key=True, nullable=False)
+    temp_id = Column(Integer, primary_key=True, nullable=False)
     s_max_pu = Column(ARRAY(Float(precision=53)))
 
 
@@ -162,6 +163,7 @@ class EgonPfHvLinkTimeseries(Base):
     version = version = Column(Text, primary_key=True, nullable=False)
     scn_name = Column(String, primary_key=True, nullable=False)
     link_id = Column(BigInteger, primary_key=True, nullable=False)
+    temp_id = Column(Integer, primary_key=True, nullable=False)
     p_set = Column(ARRAY(Float(precision=53)))
     p_min_pu = Column(ARRAY(Float(precision=53)))
     p_max_pu = Column(ARRAY(Float(precision=53)))
@@ -191,7 +193,7 @@ class EgonPfHvLoadTimeseries(Base):
     version = Column(Text, primary_key=True, nullable=False)
     scn_name = Column(String, primary_key=True, nullable=False)
     load_id = Column(BigInteger, primary_key=True, nullable=False)
-    temp_id = Column(Integer, nullable=False)
+    temp_id = Column(Integer, primary_key=True, nullable=False)
     p_set = Column(ARRAY(Float(precision=53)))
     q_set = Column(ARRAY(Float(precision=53)))
 
@@ -238,7 +240,7 @@ class EgonPfHvStorage(Base):
     efficiency_dispatch = Column(Float(53))
     standing_loss = Column(Float(53))
     inflow_fixed = Column(Float(53))
-    
+
 
 
 class EgonPfHvStorageTimeseries(Base):
@@ -346,6 +348,7 @@ class EgonPfHvTransformerTimeseries(Base):
     version = version = Column(Text, primary_key=True, nullable=False)
     scn_name = Column(String, primary_key=True, nullable=False)
     trafo_id = Column(BigInteger, primary_key=True, nullable=False)
+    temp_id = Column(Integer, primary_key=True, nullable=False)
     s_max_pu = Column(ARRAY(Float(precision=53)))
 
 

--- a/src/egon/data/importing/etrago/__init__.py
+++ b/src/egon/data/importing/etrago/__init__.py
@@ -399,3 +399,30 @@ def create_tables():
     EgonPfHvTempResolution.__table__.create(bind=engine, checkfirst=True)
     EgonPfHvTransformer.__table__.create(bind=engine, checkfirst=True)
     EgonPfHvTransformerTimeseries.__table__.create(bind=engine, checkfirst=True)
+
+def insert_temp_resolution(version='0.0.0'):
+    """ Insert temporal resolution for etrago
+
+    Returns
+    -------
+    None.
+
+    """
+
+    db.execute_sql(
+        f"""
+        INSERT INTO grid.egon_pf_hv_temp_resolution
+        (version, temp_id, timesteps, resolution, start_time)
+        SELECT '{version}', 1, 8760, 'h', TIMESTAMP '2011-01-01 00:00:00';
+        """)
+
+def setup():
+    """ Set up table structure and temporal resolution for etrago
+
+    Returns
+    -------
+    None.
+
+    """
+    create_tables()
+    insert_temp_resolution()


### PR DESCRIPTION
Closes #285 
This branch adds the column 'temp_id' to all etrago-timeseries tables. The temp-resolution table is also filled. 
@KathiEsterl and @hade9443 could you please check out to this branch and test it? 
If it works fine, we can merge this into the dev branch and also into your branch. 