### PR TITLE
Improve `Dataset`s

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,14 @@ Added
   returns the current configuration settings. See `PR #159`_ for more
   details.
 
+* You can now use tasks which are not part of a ``Dataset``, i.e. which are
+  unversioned, as dependencies of a dataset. See `PR #318`_ for more
+  details.
+
+* You can now force the tasks of a ``Dataset`` to be always executed by
+  giving the version of the ``Dataset`` a ``".dev"`` suffix. See `PR
+  #318`_ for more details.
+
 * OSM data import as done in open_ego
   `#1 <https://github.com/openego/eGon-data/issues/1>`_
   which was updated to the latest long-term data set of the 2021-01-01 in

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ profile = black
 from_first = True
 line_length = 79
 known_first_party = egon, egon.data
+known_third_party = airflow
 default_section = THIRDPARTY
 skip = .tox,.eggs,ci/bootstrap.py,ci/templates,build,dist
 

--- a/src/egon/data/datasets/__init__.py
+++ b/src/egon/data/datasets/__init__.py
@@ -202,6 +202,8 @@ class Dataset:
                     [
                         (dataset.name, dataset.version)
                         for dependency in self.dependencies
+                        if isinstance(dependency, Dataset)
+                        or hasattr(dependency, "dataset")
                         for dataset in [
                             dependency.dataset
                             if isinstance(dependency, Operator)

--- a/src/egon/data/datasets/__init__.py
+++ b/src/egon/data/datasets/__init__.py
@@ -6,6 +6,7 @@ from collections import abc
 from dataclasses import dataclass
 from functools import reduce
 from typing import Callable, Iterable, Set, Tuple, Union
+import re
 
 from airflow import DAG
 from airflow.operators import BaseOperator as Operator
@@ -178,7 +179,9 @@ class Dataset:
         def skip_task(task, *xs, **ks):
             with db.session_scope() as session:
                 datasets = session.query(Model).filter_by(name=self.name).all()
-                if self.version in [ds.version for ds in datasets]:
+                if self.version in [
+                    ds.version for ds in datasets
+                ] and not re.search(r"\.dev$", self.version):
                     logger.info(
                         f"Dataset '{self.name}' version '{self.version}'"
                         f" already executed. Skipping."


### PR DESCRIPTION
 Allow unversioned tasks as dependencies and allow marking a `Dataset` to always run.