### PR TITLE
Fix path to pbf file in osmtgmod_osm_file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -186,3 +186,5 @@ Bug fixes
   `#279 <https://github.com/openego/eGon-data/issues/279>`_
 * Fix import of hydro power plants
   `#270 <https://github.com/openego/eGon-data/issues/270>`_
+* Fix path to osm-file for osmtgmod_osm_import
+  `#258 <https://github.com/openego/eGon-data/issues/258>`_

--- a/src/egon/data/processing/osmtgmod/__init__.py
+++ b/src/egon/data/processing/osmtgmod/__init__.py
@@ -25,7 +25,7 @@ def run_osmtgmod():
         target_path = osm_config["target"]["path_testmode"]
 
     filtered_osm_pbf_path_to_file = os.path.join(
-        egon.data.__path__[0] + "/importing" + "/openstreetmap/"
+        egon.data.__path__[0] + "/datasets" + "/osm/"
         + target_path
     )
     docker_db_config = db.credentials()
@@ -74,7 +74,7 @@ def import_osm_data():
         target_path = osm_config["target"]["path_testmode"]
 
     filtered_osm_pbf_path_to_file = os.path.join(
-        egon.data.__path__[0] + "/importing" + "/openstreetmap/"
+        egon.data.__path__[0] + "/datasets" + "/osm/"
         + target_path
     )
 

--- a/src/egon/data/processing/osmtgmod/__init__.py
+++ b/src/egon/data/processing/osmtgmod/__init__.py
@@ -6,7 +6,6 @@ import csv
 import datetime
 import logging
 import codecs
-import subprocess
 import egon.data.config
 from egon.data.config import settings
 import egon.data.subprocess as subproc
@@ -142,9 +141,7 @@ def import_osm_data():
         {config['osm_data']['osmosis_path_to_binary']}"""
         )
 
-    # BUG: Python continues (and sets osm_metadata)
-    # even in case osmosis fails!!!
-    proc = subprocess.Popen(
+    subproc.run(
             "%s --read-pbf %s --write-pgsql \
                 database=%s host=%s user=%s password=%s"
             % (
@@ -162,7 +159,7 @@ def import_osm_data():
             shell=True,
         )
     logging.info("Importing OSM-Data...")
-    proc.wait()
+
 
     # After updating OSM-Data, power_tables (for editing)
     # have to be updated as well


### PR DESCRIPTION
Fixes #258
When the osm dataset was moved to the datasets-folder, the path to the pbf file was not adjusted in `osmtgmod_osm_import`. But the subprocess function didn't forwarded the error, so the function continued and the upcoming task `run_osmtgmod` failed.  

This branch updates the path to the osm-file. It also uses the subprocess function of egon-data to run osmosis which breaks the task when osmosis fails and forwards the log to airflow. 

@nesnoj Could you test this branch?