### PR TITLE
Fixes/#344 set osmosis temp dir

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,4 +2,4 @@
 Authors
 =======
 
-* Guido Pleßmann, Ilka Cußman, Stephan Günther - https://github.com/openego/eGon-data
+* Guido Pleßmann, Ilka Cußman, Stephan Günther, Jonathan Amme - https://github.com/openego/eGon-data

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -192,3 +192,5 @@ Bug fixes
   `#258 <https://github.com/openego/eGon-data/issues/258>`_
 * Fix conflicting docker containers by setting a project name
   `#289 <https://github.com/openego/eGon-data/issues/289>`_
+* Set current working directory as java's temp dir when executing osmosis
+  `#344 <https://github.com/openego/eGon-data/issues/344>`_

--- a/README.rst
+++ b/README.rst
@@ -122,8 +122,11 @@ packages are required too. Right now these are:
 * To download ERA5 weather data you need to register at the CDS
   registration page and install the CDS API key as described
   `here <https://cds.climate.copernicus.eu/api-how-to>`_
-  You also have to agree on the `terms of use 
+  You also have to agree on the `terms of use
   <https://cds.climate.copernicus.eu/cdsapp/#!/terms/licence-to-use-copernicus-products>`_
+
+* Make sure you have enough free disk space (~300 GB) in your working
+  directory.
 
 Installation
 ============
@@ -188,6 +191,10 @@ solution.
    can't be run on laptop. Use the :ref:`test mode <Test mode>` for
    experimenting.
 
+.. warning::
+
+   A complete run of the workflow needs loads of free disk space (~300 GB) to
+   store (temporary) files.
 
 Test mode
 ---------
@@ -206,4 +213,4 @@ Data is reduced during execution of the workflow to represent only this area.
 Further Reading
 ===============
 
-You can find more in depth documentation at https://eGon-data.readthedocs.io.
+You can find more in-depth documentation at https://eGon-data.readthedocs.io.

--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ packages are required too. Right now these are:
   You also have to agree on the `terms of use
   <https://cds.climate.copernicus.eu/cdsapp/#!/terms/licence-to-use-copernicus-products>`_
 
-* Make sure you have enough free disk space (~300 GB) in your working
+* Make sure you have enough free disk space (~350 GB) in your working
   directory.
 
 Installation
@@ -193,7 +193,7 @@ solution.
 
 .. warning::
 
-   A complete run of the workflow needs loads of free disk space (~300 GB) to
+   A complete run of the workflow needs loads of free disk space (~350 GB) to
    store (temporary) files.
 
 Test mode

--- a/src/egon/data/processing/osmtgmod/__init__.py
+++ b/src/egon/data/processing/osmtgmod/__init__.py
@@ -142,11 +142,16 @@ def import_osm_data():
         {config['osm_data']['osmosis_path_to_binary']}"""
         )
 
+    # create directory to store osmosis' temp files
+    osmosis_temp_dir = Path('.') / "osmosis_temp/"
+    if not os.path.exists(osmosis_temp_dir):
+        os.mkdir(osmosis_temp_dir)
+
     subproc.run(
             "JAVACMD_OPTIONS='%s' %s --read-pbf %s --write-pgsql \
                 database=%s host=%s user=%s password=%s"
             % (
-                f"-Djava.io.tmpdir={Path('.')}",
+                f"-Djava.io.tmpdir={osmosis_temp_dir}",
                 os.path.join(egon.data.__path__[0],
                                  "processing/osmtgmod/osmTGmod/",
                                  config["osm_data"]["osmosis_path_to_binary"]),

--- a/src/egon/data/processing/osmtgmod/__init__.py
+++ b/src/egon/data/processing/osmtgmod/__init__.py
@@ -26,8 +26,7 @@ def run_osmtgmod():
         target_path = osm_config["target"]["path_testmode"]
 
     filtered_osm_pbf_path_to_file = os.path.join(
-        egon.data.__path__[0] + "/datasets" + "/osm/"
-        + target_path
+        egon.data.__path__[0], "datasets", "osm", target_path
     )
     docker_db_config = db.credentials()
 
@@ -75,8 +74,7 @@ def import_osm_data():
         target_path = osm_config["target"]["path_testmode"]
 
     filtered_osm_pbf_path_to_file = os.path.join(
-        egon.data.__path__[0] + "/datasets" + "/osm/"
-        + target_path
+        egon.data.__path__[0], "datasets", "osm", target_path
     )
 
     docker_db_config=db.credentials()
@@ -153,8 +151,8 @@ def import_osm_data():
             % (
                 f"-Djava.io.tmpdir={osmosis_temp_dir}",
                 os.path.join(egon.data.__path__[0],
-                                 "processing/osmtgmod/osmTGmod/",
-                                 config["osm_data"]["osmosis_path_to_binary"]),
+                             "processing/osmtgmod/osmTGmod/",
+                             config["osm_data"]["osmosis_path_to_binary"]),
                 filtered_osm_pbf_path_to_file,
                 config_database,
                 config["postgres_server"]["host"]

--- a/src/egon/data/processing/osmtgmod/__init__.py
+++ b/src/egon/data/processing/osmtgmod/__init__.py
@@ -53,7 +53,7 @@ def import_osm_data():
         )
 
     else:
-    	subproc.run(
+        subproc.run(
             [
                 "git",
                 "clone",
@@ -159,7 +159,6 @@ def import_osm_data():
             shell=True,
         )
     logging.info("Importing OSM-Data...")
-
 
     # After updating OSM-Data, power_tables (for editing)
     # have to be updated as well

--- a/src/egon/data/processing/osmtgmod/__init__.py
+++ b/src/egon/data/processing/osmtgmod/__init__.py
@@ -6,6 +6,7 @@ import csv
 import datetime
 import logging
 import codecs
+from pathlib import Path
 import egon.data.config
 from egon.data.config import settings
 import egon.data.subprocess as subproc
@@ -142,9 +143,10 @@ def import_osm_data():
         )
 
     subproc.run(
-            "%s --read-pbf %s --write-pgsql \
+            "JAVACMD_OPTIONS='%s' %s --read-pbf %s --write-pgsql \
                 database=%s host=%s user=%s password=%s"
             % (
+                f"-Djava.io.tmpdir={Path('.')}",
                 os.path.join(egon.data.__path__[0],
                                  "processing/osmtgmod/osmTGmod/",
                                  config["osm_data"]["osmosis_path_to_binary"]),


### PR DESCRIPTION
Sets the current working dir as location to store java's temp files (osmTGmod -> osmosis -> java).
Tested successfully in test and normal mode on RLI's infrastructure.

I also changed some fragile os.path joins but not touching the use of base path `egon.data.__path__[0]`.

Fixes #344

Could you give it a review @ClaraBuettner ? (if you decide to test, it's sufficient to use the test region)