### PR TITLE
Fix missing ehv hvmv voronoi

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -192,3 +192,5 @@ Bug fixes
   `#258 <https://github.com/openego/eGon-data/issues/258>`_
 * Fix conflicting docker containers by setting a project name
   `#289 <https://github.com/openego/eGon-data/issues/289>`_
+* Fix versioning conflict with mv_grid_districts
+  `#340 <https://github.com/openego/eGon-data/issues/340>`_

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -305,6 +305,7 @@ with airflow.DAG(
         autocommit=True,
     )
 
+
     osm_add_metadata >> substation_tables >> substation_functions
     substation_functions >> hvmv_substation_extraction
     substation_functions >> ehv_substation_extraction
@@ -341,8 +342,15 @@ with airflow.DAG(
     etrago_input_data >> osmtgmod_pypsa
     run_osmtgmod >> osmtgmod_substation
 
+    # create Voronoi for MV grid districts
+    create_voronoi_substation = PythonOperator(
+        task_id="create-voronoi-substations",
+        python_callable=substation.create_voronoi,
+    )
+    osmtgmod_substation >> create_voronoi_substation
+
     # MV grid districts
-    mv_grid_districts = mv_grid_districts_setup(dependencies=[osmtgmod_substation])
+    mv_grid_districts = mv_grid_districts_setup(dependencies=[create_voronoi_substation])
     mv_grid_districts.insert_into(pipeline)
     define_mv_grid_districts = tasks["mv_grid_districts.define-mv-grid-districts"]
 

--- a/src/egon/data/datasets/mv_grid_districts.py
+++ b/src/egon/data/datasets/mv_grid_districts.py
@@ -35,7 +35,6 @@ from egon.data.db import session_scope
 from egon.data.processing.substation import (
     EgonHvmvSubstation,
     EgonHvmvSubstationVoronoi,
-    create_voronoi,
 )
 
 Base = declarative_base()
@@ -775,5 +774,5 @@ mv_grid_districts_setup = partial(
     name="MvGridDistricts",
     version="0.0.0",
     dependencies=[],
-    tasks=(create_voronoi, define_mv_grid_districts),
+    tasks=(define_mv_grid_districts),
 )


### PR DESCRIPTION
This is a temporary fix for #340.
The create_voronoi function of the substation module was executed while creating the mv_grid_district dataest although it altered tables not directly related to the dataset itself. This lead to conflicts with the versioning module and further depending tasks.

To fix this, the function was excluded from the mv_grid_district dataset task and implemented as a separate task with the old dependency to osmtg_mod as mentioned [here](https://github.com/openego/eGon-data/issues/340#issuecomment-884861539). Also the dependency of mv_grid_districts was adapted to create_voronoi.
