### PR TITLE
Features/#334 rename etrago tables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -160,6 +160,8 @@ Changed
   `#281 <https://github.com/openego/eGon-data/issues/281>`_
 * Migrate mastr, mv_grid_districts and re_potential_areas to datasets
   `#297 <https://github.com/openego/eGon-data/issues/297>`_
+* Rename etrago tables from e.g. egon_pf_hv_bus to egon_etrago bus etc. 
+  `#334 <https://github.com/openego/eGon-data/issues/334>`_
 
 Bug fixes
 ---------

--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -430,10 +430,10 @@ electrical_load_curves_cts:
   targets:
     pf_load:
       schema: 'grid'
-      table: 'egon_pf_hv_load'
+      table: 'egon_etrago_load'
     pf_load_timeseries:
       schema: 'grid'
-      table: 'egon_pf_hv_load_timeseries'
+      table: 'egon_etrago_load_timeseries'
 
 map_mvgrid_vg250:
   sources:
@@ -477,10 +477,10 @@ solar_rooftop:
   targets:
     generators:
       schema: 'grid'
-      table: 'egon_pf_hv_generator'
+      table: 'egon_etrago_generator'
     generator_timeseries:
       schema: 'grid'
-      table: 'egon_pf_hv_generator_timeseries'
+      table: 'egon_etrago_generator_timeseries'
 
 data-bundle:
   sources:
@@ -562,14 +562,14 @@ etrago_heat:
   targets:
     heat_buses:
       schema: 'grid'
-      table: 'egon_pf_hv_bus'
+      table: 'egon_etrago_bus'
     heat_generators:
       schema: 'grid'
-      table: 'egon_pf_hv_generator'
+      table: 'egon_etrago_generator'
     heat_generator_timeseries:
       schema: 'grid'
-      table: 'egon_pf_hv_generator_timeseries'
+      table: 'egon_etrago_generator_timeseries'
     heat_links:
       schema: 'grid'
-      table: 'egon_pf_hv_link'
+      table: 'egon_etrago_link'
 

--- a/src/egon/data/importing/etrago/__init__.py
+++ b/src/egon/data/importing/etrago/__init__.py
@@ -361,6 +361,64 @@ def create_tables():
     db.execute_sql(
         f"CREATE SCHEMA IF NOT EXISTS grid;")
     engine = db.engine()
+    
+    ##################### drop tables with old names #########################
+    db.execute_sql(
+        f"""
+        DROP TABLE IF EXISTS grid.egon_pf_hv_bus;""")
+    db.execute_sql(
+        f"""
+        DROP TABLE IF EXISTS grid.egon_pf_hv_bus_timeseries;""")
+    db.execute_sql(
+        f"""
+        DROP TABLE IF EXISTS grid.egon_pf_hv_carrier;""")    
+    db.execute_sql(
+        f"""
+        DROP TABLE IF EXISTS grid.egon_pf_hv_generator;""") 
+    db.execute_sql(
+        f"""
+        DROP TABLE IF EXISTS grid.egon_pf_hv_generator_timeseries;""")
+    db.execute_sql(
+        f"""
+        DROP TABLE IF EXISTS grid.egon_pf_hv_line;""")
+    db.execute_sql(
+        f"""
+        DROP TABLE IF EXISTS grid.egon_pf_hv_line_timeseries;""")
+    db.execute_sql(
+        f"""
+        DROP TABLE IF EXISTS grid.egon_pf_hv_link;""")
+    db.execute_sql(
+        f"""
+        DROP TABLE IF EXISTS grid.egon_pf_hv_link_timeseries;""")
+    db.execute_sql(
+        f"""
+        DROP TABLE IF EXISTS grid.egon_pf_hv_load;""")
+    db.execute_sql(
+        f"""
+        DROP TABLE IF EXISTS grid.egon_pf_hv_load_timeseries;""")     
+    db.execute_sql(
+        f"""
+        DROP TABLE IF EXISTS grid.egon_pf_hv_storage;""") 
+    db.execute_sql(
+        f"""
+        DROP TABLE IF EXISTS grid.egon_pf_hv_storage_timeseries;""") 
+    db.execute_sql(
+        f"""
+        DROP TABLE IF EXISTS grid.egon_pf_hv_store;""") 
+    db.execute_sql(
+        f"""
+        DROP TABLE IF EXISTS grid.egon_pf_hv_store_timeseries;""") 
+    db.execute_sql(
+        f"""
+        DROP TABLE IF EXISTS grid.egon_pf_hv_temp_resolution;""") 
+    db.execute_sql(
+        f"""
+        DROP TABLE IF EXISTS grid.egon_pf_hv_transformer;""")  
+    db.execute_sql(
+        f"""
+        DROP TABLE IF EXISTS grid.egon_pf_hv_transformer_timeseries;""")  
+    ##########################################################################
+        
     # Drop existing tables
     EgonPfHvBus.__table__.drop(bind=engine, checkfirst=True)
     EgonPfHvBusTimeseries.__table__.drop(bind=engine, checkfirst=True)

--- a/src/egon/data/importing/etrago/__init__.py
+++ b/src/egon/data/importing/etrago/__init__.py
@@ -10,7 +10,7 @@ metadata = Base.metadata
 
 
 class EgonPfHvBus(Base):
-    __tablename__ = 'egon_pf_hv_bus'
+    __tablename__ = 'egon_etrago_bus'
     __table_args__ = {'schema': 'grid'}
 
     version = Column(Text, primary_key=True, nullable=False)
@@ -28,7 +28,7 @@ class EgonPfHvBus(Base):
 
 
 class EgonPfHvBusTimeseries(Base):
-    __tablename__ = 'egon_pf_hv_bus_timeseries'
+    __tablename__ = 'egon_etrago_bus_timeseries'
     __table_args__ = {'schema': 'grid'}
 
     version = Column(Text, primary_key=True, nullable=False)
@@ -37,7 +37,7 @@ class EgonPfHvBusTimeseries(Base):
     v_mag_pu_set = Column(ARRAY(Float(precision=53)))
 
 class EgonPfHvGenerator(Base):
-    __tablename__ = 'egon_pf_hv_generator'
+    __tablename__ = 'egon_etrago_generator'
     __table_args__ = {'schema': 'grid'}
 
     version = Column(Text, primary_key=True, nullable=False)
@@ -73,7 +73,7 @@ class EgonPfHvGenerator(Base):
 
 
 class EgonPfHvGeneratorTimeseries(Base):
-    __tablename__ = 'egon_pf_hv_generator_timeseries'
+    __tablename__ = 'egon_etrago_generator_timeseries'
     __table_args__ = {'schema': 'grid'}
 
     version = Column(Text, primary_key=True, nullable=False)
@@ -88,7 +88,7 @@ class EgonPfHvGeneratorTimeseries(Base):
 
 
 class EgonPfHvLine(Base):
-    __tablename__ = 'egon_pf_hv_line'
+    __tablename__ = 'egon_etrago_line'
     __table_args__ = {'schema': 'grid'}
 
     version = Column(Text, primary_key=True, nullable=False)
@@ -120,7 +120,7 @@ class EgonPfHvLine(Base):
 
 
 class EgonPfHvLineTimeseries(Base):
-    __tablename__ = 'egon_pf_hv_line_timeseries'
+    __tablename__ = 'egon_etrago_line_timeseries'
     __table_args__ = {'schema': 'grid'}
 
     version = version = Column(Text, primary_key=True, nullable=False)
@@ -131,7 +131,7 @@ class EgonPfHvLineTimeseries(Base):
 
 
 class EgonPfHvLink(Base):
-    __tablename__ = 'egon_pf_hv_link'
+    __tablename__ = 'egon_etrago_link'
     __table_args__ = {'schema': 'grid'}
 
     version = version = Column(Text, primary_key=True, nullable=False)
@@ -157,7 +157,7 @@ class EgonPfHvLink(Base):
     topo = Column(Geometry('LINESTRING', 4326))
 
 class EgonPfHvLinkTimeseries(Base):
-    __tablename__ = 'egon_pf_hv_link_timeseries'
+    __tablename__ = 'egon_etrago_link_timeseries'
     __table_args__ = {'schema': 'grid'}
 
     version = version = Column(Text, primary_key=True, nullable=False)
@@ -172,7 +172,7 @@ class EgonPfHvLinkTimeseries(Base):
 
 
 class EgonPfHvLoad(Base):
-    __tablename__ = 'egon_pf_hv_load'
+    __tablename__ = 'egon_etrago_load'
     __table_args__ = {'schema': 'grid'}
 
     version = Column(Text, primary_key=True, nullable=False)
@@ -187,7 +187,7 @@ class EgonPfHvLoad(Base):
 
 
 class EgonPfHvLoadTimeseries(Base):
-    __tablename__ = 'egon_pf_hv_load_timeseries'
+    __tablename__ = 'egon_etrago_load_timeseries'
     __table_args__ = {'schema': 'grid'}
 
     version = Column(Text, primary_key=True, nullable=False)
@@ -199,7 +199,7 @@ class EgonPfHvLoadTimeseries(Base):
 
 
 class EgonPfHvCarrier(Base):
-    __tablename__ = 'egon_pf_hv_carrier'
+    __tablename__ = 'egon_etrago_carrier'
     __table_args__ = {'schema': 'grid'}
 
     version = Column(Text, primary_key=True, nullable=False)
@@ -211,7 +211,7 @@ class EgonPfHvCarrier(Base):
 
 
 class EgonPfHvStorage(Base):
-    __tablename__ = 'egon_pf_hv_storage'
+    __tablename__ = 'egon_etrago_storage'
     __table_args__ = {'schema': 'grid'}
 
     version = Column(Text, primary_key=True, nullable=False)
@@ -244,7 +244,7 @@ class EgonPfHvStorage(Base):
 
 
 class EgonPfHvStorageTimeseries(Base):
-    __tablename__ = 'egon_pf_hv_storage_timeseries'
+    __tablename__ = 'egon_etrago_storage_timeseries'
     __table_args__ = {'schema': 'grid'}
 
     version = Column(Text, primary_key=True, nullable=False)
@@ -260,7 +260,7 @@ class EgonPfHvStorageTimeseries(Base):
     marginal_cost = Column(ARRAY(Float(precision=53)))
 
 class EgonPfHvStore(Base):
-    __tablename__ = 'egon_pf_hv_store'
+    __tablename__ = 'egon_etrago_store'
     __table_args__ = {'schema': 'grid'}
 
     version = Column(Text, primary_key=True, nullable=False)
@@ -285,7 +285,7 @@ class EgonPfHvStore(Base):
     standing_loss = Column(Float(53))
 
 class EgonPfHvStoreTimeseries(Base):
-    __tablename__ = 'egon_pf_hv_store_timeseries'
+    __tablename__ = 'egon_etrago_store_timeseries'
     __table_args__ = {'schema': 'grid'}
 
     version = Column(Text, primary_key=True, nullable=False)
@@ -299,7 +299,7 @@ class EgonPfHvStoreTimeseries(Base):
     marginal_cost = Column(ARRAY(Float(precision=53)))
 
 class EgonPfHvTempResolution(Base):
-    __tablename__ = 'egon_pf_hv_temp_resolution'
+    __tablename__ = 'egon_etrago_temp_resolution'
     __table_args__ = {'schema': 'grid'}
 
     version = Column(Text, primary_key=True, nullable=False)
@@ -310,7 +310,7 @@ class EgonPfHvTempResolution(Base):
 
 
 class EgonPfHvTransformer(Base):
-    __tablename__ = 'egon_pf_hv_transformer'
+    __tablename__ = 'egon_etrago_transformer'
     __table_args__ = {'schema': 'grid'}
 
     version = Column(Text, primary_key=True, nullable=False)
@@ -342,7 +342,7 @@ class EgonPfHvTransformer(Base):
 
 
 class EgonPfHvTransformerTimeseries(Base):
-    __tablename__ = 'egon_pf_hv_transformer_timeseries'
+    __tablename__ = 'egon_etrago_transformer_timeseries'
     __table_args__ = {'schema': 'grid'}
 
     version = version = Column(Text, primary_key=True, nullable=False)
@@ -411,7 +411,7 @@ def insert_temp_resolution(version='0.0.0'):
 
     db.execute_sql(
         f"""
-        INSERT INTO grid.egon_pf_hv_temp_resolution
+        INSERT INTO grid.egon_etrago_temp_resolution
         (version, temp_id, timesteps, resolution, start_time)
         SELECT '{version}', 1, 8760, 'h', TIMESTAMP '2011-01-01 00:00:00';
         """)

--- a/src/egon/data/importing/gas_grid/__init__.py
+++ b/src/egon/data/importing/gas_grid/__init__.py
@@ -30,7 +30,7 @@ def next_id(component):
     """
     max_id = db.select_dataframe(
         f"""
-        SELECT MAX({component}_id) FROM grid.egon_pf_hv_{component}
+        SELECT MAX({component}_id) FROM grid.egon_etrago_{component}
         """)['max'][0]
 
     if max_id:
@@ -144,7 +144,7 @@ def insert_gas_nodes_list(gas_nodes_list):
     gas_nodes_list = gas_nodes_list.drop(columns=['NUTS1', 'param', 'country_code' ])
 
     # Insert data to db    
-    gas_nodes_list.to_postgis('egon_pf_hv_bus',
+    gas_nodes_list.to_postgis('egon_etrago_bus',
                               engine,
                               schema ='grid',
                               index = False,
@@ -295,7 +295,7 @@ def insert_gas_pipeline_list(gas_nodes_list):
                                                           'max_transport_capacity_Gwh/d', 'lat', 'long'])
     
     # Insert data to db
-    gas_pipelines_list.to_postgis('egon_pf_hv_gas_link',
+    gas_pipelines_list.to_postgis('egon_etrago_gas_link',
                           engine,
                           schema = 'grid',
                           index = False,
@@ -304,16 +304,16 @@ def insert_gas_pipeline_list(gas_nodes_list):
     
     db.execute_sql(
         """
-    select UpdateGeometrySRID('grid', 'egon_pf_hv_gas_link', 'topo', 4326) ;
+    select UpdateGeometrySRID('grid', 'egon_etrago_gas_link', 'topo', 4326) ;
     
-    INSERT INTO grid.egon_pf_hv_link (version, scn_name, link_id, bus0,
+    INSERT INTO grid.egon_etrago_link (version, scn_name, link_id, bus0,
                                               bus1, p_nom, length,
                                               geom, topo, carrier)
     SELECT
     version, scn_name, link_id, bus0, bus1, p_nom, length, geom, topo, carrier
-    FROM grid.egon_pf_hv_gas_link;
+    FROM grid.egon_etrago_gas_link;
         
-    DROP TABLE grid.egon_pf_hv_gas_link;
+    DROP TABLE grid.egon_etrago_gas_link;
         """)
         
     

--- a/src/egon/data/processing/calculate_dlr.py
+++ b/src/egon/data/processing/calculate_dlr.py
@@ -38,7 +38,7 @@ def Calculate_DLR():
     # Connect to the data base
     con = db.engine()
 
-    sql = "SELECT version, scn_name, line_id, geom, s_nom FROM grid.egon_pf_hv_line"
+    sql = "SELECT version, scn_name, line_id, geom, s_nom FROM grid.egon_etrago_line"
     df = gpd.GeoDataFrame.from_postgis(sql, con, crs="EPSG:4326")
 
     trans_lines_R = {}
@@ -97,7 +97,7 @@ def Calculate_DLR():
     trans_lines["temp_id"] = 1
     # Insert into database
     trans_lines.to_sql(
-        "egon_pf_hv_line_timeseries",
+        "egon_etrago_line_timeseries",
         schema="grid",
         con=db.engine(),
         if_exists="append",

--- a/src/egon/data/processing/gas_areas/__init__.py
+++ b/src/egon/data/processing/gas_areas/__init__.py
@@ -22,7 +22,7 @@ def create_voronoi():
                 
         SELECT bus_id, bus_id as id, geom as point
         INTO grid.egon_gas_voronoi
-        FROM grid.egon_pf_hv_bus 
+        FROM grid.egon_etrago_bus 
         WHERE carrier = 'gas';
         
         ALTER TABLE grid.egon_gas_voronoi ADD geom Geometry('Multipolygon', 4326);     
@@ -31,7 +31,7 @@ def create_voronoi():
         
         SELECT bus_id, bus_id as id, geom as point 
         INTO grid.egon_gas_bus
-        FROM grid.egon_pf_hv_bus 
+        FROM grid.egon_etrago_bus 
         WHERE carrier = 'gas';
         """
                     )

--- a/src/egon/data/processing/osmtgmod/__init__.py
+++ b/src/egon/data/processing/osmtgmod/__init__.py
@@ -530,12 +530,12 @@ def osmtgmmod_to_pypsa(version="'0.0.0'"):
     db.execute_sql(
             f"""
             -- CLEAN UP OF TABLES
-            DELETE FROM grid.egon_pf_hv_bus
+            DELETE FROM grid.egon_etrago_bus
             WHERE version = {version}
             AND carrier = 'AC';
-            DELETE FROM grid.egon_pf_hv_line
+            DELETE FROM grid.egon_etrago_line
             WHERE version = {version};
-            DELETE FROM grid.egon_pf_hv_transformer
+            DELETE FROM grid.egon_etrago_transformer
             WHERE version = {version};
             """
             )
@@ -545,7 +545,7 @@ def osmtgmmod_to_pypsa(version="'0.0.0'"):
         db.execute_sql(
             f"""
             -- BUS DATA
-            INSERT INTO grid.egon_pf_hv_bus (version, scn_name, bus_id, v_nom,
+            INSERT INTO grid.egon_etrago_bus (version, scn_name, bus_id, v_nom,
                                              geom, x, y, carrier)
             SELECT
               {version},
@@ -561,7 +561,7 @@ def osmtgmmod_to_pypsa(version="'0.0.0'"):
 
 
             -- BRANCH DATA
-            INSERT INTO grid.egon_pf_hv_line (version, scn_name, line_id, bus0,
+            INSERT INTO grid.egon_etrago_line (version, scn_name, line_id, bus0,
                                               bus1, x, r, b, s_nom, cables, v_nom,
                                               geom, topo)
             SELECT
@@ -584,7 +584,7 @@ def osmtgmmod_to_pypsa(version="'0.0.0'"):
 
 
             -- TRANSFORMER DATA
-            INSERT INTO grid.egon_pf_hv_transformer (version, scn_name,
+            INSERT INTO grid.egon_etrago_transformer (version, scn_name,
                                                      trafo_id, bus0, bus1, x,
                                                      s_nom, tap_ratio,
                                                      phase_shift, geom, topo)
@@ -606,32 +606,32 @@ def osmtgmmod_to_pypsa(version="'0.0.0'"):
 
             -- per unit to absolute values
 
-            UPDATE grid.egon_pf_hv_line a
+            UPDATE grid.egon_etrago_line a
             SET
                  r = r * (((SELECT v_nom
-                            FROM grid.egon_pf_hv_bus b
+                            FROM grid.egon_etrago_bus b
                             WHERE bus_id=bus1
                             AND a.scn_name = b.scn_name
                             )*1000)^2 / (100 * 10^6)),
                  x = x * (((SELECT v_nom
-                            FROM grid.egon_pf_hv_bus b
+                            FROM grid.egon_etrago_bus b
                             WHERE bus_id=bus1
                             AND a.scn_name = b.scn_name
                             )*1000)^2 / (100 * 10^6)),
                  b = b * (((SELECT v_nom
-                            FROM grid.egon_pf_hv_bus b
+                            FROM grid.egon_etrago_bus b
                             WHERE bus_id=bus1
                             AND a.scn_name = b.scn_name
                             )*1000)^2 / (100 * 10^6));
 
             -- calculate line length (in km) from geoms
 
-            UPDATE grid.egon_pf_hv_line a
+            UPDATE grid.egon_etrago_line a
             SET
                  length = result.length
                  FROM
                  (SELECT b.line_id, st_length(b.geom,false)/1000 as length
-                  from grid.egon_pf_hv_line b)
+                  from grid.egon_etrago_line b)
                  as result
             WHERE a.line_id = result.line_id;
 
@@ -639,21 +639,21 @@ def osmtgmmod_to_pypsa(version="'0.0.0'"):
             -- delete buses without connection to AC grid and generation or
             -- load assigned
 
-            DELETE FROM grid.egon_pf_hv_bus
+            DELETE FROM grid.egon_etrago_bus
             WHERE scn_name={scenario_name}
             AND carrier = 'AC'
             AND version = {version}
             AND bus_id NOT IN
-            (SELECT bus0 FROM grid.egon_pf_hv_line WHERE
+            (SELECT bus0 FROM grid.egon_etrago_line WHERE
              scn_name={scenario_name})
             AND bus_id NOT IN
-            (SELECT bus1 FROM grid.egon_pf_hv_line WHERE
+            (SELECT bus1 FROM grid.egon_etrago_line WHERE
              scn_name={scenario_name})
             AND bus_id NOT IN
-            (SELECT bus0 FROM grid.egon_pf_hv_transformer
+            (SELECT bus0 FROM grid.egon_etrago_transformer
              WHERE scn_name={scenario_name})
             AND bus_id NOT IN
-            (SELECT bus1 FROM grid.egon_pf_hv_transformer
+            (SELECT bus1 FROM grid.egon_etrago_transformer
              WHERE scn_name={scenario_name});
                 """
         )

--- a/src/egon/data/processing/power_plants/pv_rooftop.py
+++ b/src/egon/data/processing/power_plants/pv_rooftop.py
@@ -17,7 +17,7 @@ def next_id(component):
     """
     max_id = db.select_dataframe(
         f"""
-        SELECT MAX({component}_id) FROM grid.egon_pf_hv_{component}
+        SELECT MAX({component}_id) FROM grid.egon_etrago_{component}
         """)['max'][0]
 
     if max_id:
@@ -70,7 +70,7 @@ def pv_rooftop_per_mv_grid(version='0.0.0', scenario='eGon2035',
         WHERE scn_name = '{scenario}'
         AND generator_id NOT IN (
             SELECT generator_id FROM
-            grid.egon_pf_hv_generator
+            grid.egon_etrago_generator
             WHERE version = '{version}'
             AND scn_name = '{scenario}')
         """)

--- a/src/egon/data/processing/pv_ground_mounted.py
+++ b/src/egon/data/processing/pv_ground_mounted.py
@@ -1086,6 +1086,7 @@ def regio_of_pv_ground_mounted():
 
         # copy relevant columns from pv_parks
         insert_pv_parks = pv_parks[["el_capacity", "voltage_level", "geometry"]]
+        insert_pv_parks = insert_pv_parks.set_geometry('geometry')
 
         # set static column values
         insert_pv_parks["carrier"] = "solar"
@@ -1097,7 +1098,7 @@ def regio_of_pv_ground_mounted():
         insert_pv_parks = (
             insert_pv_parks.rename({"geometry": "geom"}, axis=1)
             .set_geometry("geom")
-            .to_crs(4326)
+            .set_crs(4326)
         )
 
         # reset index

--- a/src/egon/data/processing/pv_ground_mounted.py
+++ b/src/egon/data/processing/pv_ground_mounted.py
@@ -839,7 +839,7 @@ def regio_of_pv_ground_mounted():
             rora_i_hv = rora_i[rora_i["voltage_level"] == 4]
             agri_i_mv = agri_i[agri_i["voltage_level"] == 5]
             agri_i_hv = agri_i[agri_i["voltage_level"] == 4]
-            print("Untersuchung der Spannungslevel pro Bundesland:")
+            print("eGon2035: Untersuchung der Spannungslevel pro Bundesland:")
             print("a) PVs auf Potentialflächen Road & Railway: ")
             print(
                 "Insgesamt installierte Leistung: "
@@ -1135,7 +1135,7 @@ def regio_of_pv_ground_mounted():
     pv_agri_hv = pv_agri[pv_agri["voltage_level"] == 4]
 
     print(" ")
-    print("Untersuchung der Spannungslevel (gesamt):")
+    print("eGon2035: Untersuchung der Spannungslevel (gesamt):")
     print("a) PVs auf Potentialflächen Road & Railway: ")
     print(
         "Insgesamt installierte Leistung: "

--- a/src/egon/data/processing/pv_ground_mounted.py
+++ b/src/egon/data/processing/pv_ground_mounted.py
@@ -1006,6 +1006,13 @@ def regio_of_pv_ground_mounted():
                 },
             )
             plt.savefig("pv_per_distr_map_eGon100RE.png", dpi=300)
+        
+        pv_rora = pv_rora[pv_rora['installed capacity in kW']>0]
+        pv_agri = pv_agri[pv_agri['installed capacity in kW']>0]
+        pv_per_distr = pv_per_distr[pv_per_distr['installed capacity in kW']>0]
+        pv_rora_100RE = pv_rora_100RE[pv_rora_100RE['installed capacity in kW']>0]
+        pv_agri_100RE = pv_agri_100RE[pv_agri_100RE['installed capacity in kW']>0]
+        pv_per_distr_100RE = pv_per_distr_100RE[pv_per_distr_100RE['installed capacity in kW']>0]
 
         return (
             pv_rora,


### PR DESCRIPTION
With this branch I implemented the renaming of the etrago-tables from e.g. **_egon_pf_hv_bus_** to _**egon_etrago_bus**_.

During working on this branch, I solved an error occuring in _pv_ground_mounted_: I updated this task, it should be working now.

I had some more problems with other tasks while testing the changes, but I do not think, those are related to the changing of the name. I will submit issues for those. 

