### PR TITLE
Add missing packages to setup.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -233,4 +233,7 @@ Bug fixes
   `#387 <https://github.com/openego/eGon-data/issues/387>`_
 * Fix unnecessary columns in normal mode for inserting the gas production
   `#387 <https://github.com/openego/eGon-data/issues/390>`_
+* Add xlrd and openpyxl to installation setup
+  `#400 <https://github.com/openego/eGon-data/issues/400>`_
+
 

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ setup(
         "matplotlib",
         "netcdf4",
         "oedialect==0.0.8",
+        "openpyxl",
         "pandas>1.2.0,<1.3.0",
         "psycopg2",
         "pyaml",
@@ -99,6 +100,7 @@ setup(
         "rtree",
         "sqlalchemy<1.4",
         "xarray",
+        "xlrd",
         "rioxarray",
     ],
     extras_require={


### PR DESCRIPTION
Fixes #400 
This branch adds `xlrd `and `openpyxl` to the setup.py of egon-data. These packages were only installed in the task `demandregio.install_disaggregator.clone-and-install`which results in errors when other tasks run before this one (e.g. `insert-nep-data`). 