### PR TITLE
add random seed to config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -126,6 +126,8 @@ Added
   `#328 <https://github.com/openego/eGon-data/issues/328>`_
 * Integrate existing CHP and extdended CHP > 10MW_el
   `#266 <https://github.com/openego/eGon-data/issues/266>`_
+* Add random seed to CLI parameters
+  `#351 <https://github.com/openego/eGon-data/issues/351>`_
 
 .. _PR #159: https://github.com/openego/eGon-data/pull/159
 

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -142,6 +142,19 @@ import egon.data.config as config
     show_default=True,
 )
 
+@click.option(
+    "--random-seed",
+    default=42,
+    metavar="RANDOM_SEED",
+    help=(
+        "Random seed used by some tasks in the pipeline to ensure "
+        " deterministic behaviour. All published results in the eGon project "
+        " will be created with the default value so keep it if you want to "
+        " make sure to get the same results."
+    ),
+    show_default=True,
+)
+
 @click.version_option(version=egon.data.__version__)
 @click.pass_context
 def egon_data(context, **kwargs):

--- a/src/egon/data/config.py
+++ b/src/egon/data/config.py
@@ -10,12 +10,6 @@ from egon.data import logger
 import egon
 
 
-# Random seed to be used on init in any script that uses random
-# to ensure reproducibility. Take special care in multiprocessing
-# tasks! (cf. #351)
-RANDOM_SEED = 42
-
-
 def paths(pid=None):
     """Obtain configuration file paths.
 

--- a/src/egon/data/config.py
+++ b/src/egon/data/config.py
@@ -10,6 +10,12 @@ from egon.data import logger
 import egon
 
 
+# Random seed to be used on init in any script that uses random
+# to ensure reproducibility. Take special care in multiprocessing
+# tasks! (cf. #351)
+RANDOM_SEED = 42
+
+
 def paths(pid=None):
     """Obtain configuration file paths.
 


### PR DESCRIPTION
~I've added a predefined seed to `config.py`, do you agree with the location @gnn?
Simply use by `from egon.data.config import RANDOM_SEED`~

This PR adds the random seed to CLI parameters.

You can obtain the seed in your tasks by
```
from egon.data import config
SEED = config.settings()['egon-data']['--random-seed']
```

Subsequently, you may set the seed by `random.seed(SEED)` or `numpy.random.seed(SEED)` respectively.