### PR TITLE
Features/#359 zensus add combined bld apt pop table

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -128,6 +128,9 @@ Added
   `#321 <https://github.com/openego/eGon-data/issues/358>`_
 * Integrate existing CHP and extdended CHP > 10MW_el
   `#266 <https://github.com/openego/eGon-data/issues/266>`_
+* Extend zensus by a combined table with all cells where
+  there's either building, apartment or population data
+  `#359 <https://github.com/openego/eGon-data/issues/359>`_
 
 
 Changed

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -266,14 +266,14 @@ with airflow.DAG(
 
     gas_grid_insert_data  >> create_gas_polygons
     vg250_clean_and_prepare >> create_gas_polygons
-    
+
     # Gas prod import
     gas_production_insert_data = GasProduction(
         dependencies=[create_gas_polygons])
 
     # Insert industrial gas demand
-    industrial_gas_demand = IndustrialGasDemand( 
-     dependencies=[create_gas_polygons]) 
+    industrial_gas_demand = IndustrialGasDemand(
+        dependencies=[create_gas_polygons])
 
     # Extract landuse areas from osm data set
     create_landuse_table = PythonOperator(
@@ -325,7 +325,7 @@ with airflow.DAG(
     )
 
     map_zensus_grid_districts = tasks["zensus_mv_grid_districts.mapping"]
-    
+
     # Distribute electrical CTS demands to zensus grid
     cts_electricity_demand_annual = CtsElectricityDemand(
         dependencies=[

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -125,8 +125,9 @@ with airflow.DAG(
     # Combine Zensus and VG250 data
     zensus_vg250 = ZensusVg250(
         dependencies=[vg250, population_import])
+    zensus_vg250_inside_germany = tasks['zensus_vg250.inside-germany']
 
-    zensus_vg250 >> zensus_misc_import
+    zensus_vg250_inside_germany >> zensus_misc_import
 
     # DemandRegio data import
     demandregio = DemandRegio(dependencies=[

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -125,6 +125,9 @@ with airflow.DAG(
     # Combine Zensus and VG250 data
     zensus_vg250 = ZensusVg250(
         dependencies=[vg250, population_import])
+    zensus_inside_ger = tasks["zensus_vg250.inside-germany"]
+
+    zensus_inside_ger >> zensus_misc_import
 
     # DemandRegio data import
     demandregio = DemandRegio(dependencies=[

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -126,6 +126,8 @@ with airflow.DAG(
     zensus_vg250 = ZensusVg250(
         dependencies=[vg250, population_import])
 
+    zensus_vg250 >> zensus_misc_import
+
     # DemandRegio data import
     demandregio = DemandRegio(dependencies=[
         setup, vg250, scenario_parameters, data_bundle])

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -125,9 +125,8 @@ with airflow.DAG(
     # Combine Zensus and VG250 data
     zensus_vg250 = ZensusVg250(
         dependencies=[vg250, population_import])
-    zensus_vg250_inside_germany = tasks['zensus_vg250.inside-germany']
 
-    zensus_vg250_inside_germany >> zensus_misc_import
+    zensus_vg250 >> zensus_misc_import
 
     # DemandRegio data import
     demandregio = DemandRegio(dependencies=[

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -266,14 +266,14 @@ with airflow.DAG(
 
     gas_grid_insert_data  >> create_gas_polygons
     vg250_clean_and_prepare >> create_gas_polygons
-
+    
     # Gas prod import
     gas_production_insert_data = GasProduction(
         dependencies=[create_gas_polygons])
 
     # Insert industrial gas demand
-    industrial_gas_demand = IndustrialGasDemand(
-        dependencies=[create_gas_polygons])
+    industrial_gas_demand = IndustrialGasDemand( 
+     dependencies=[create_gas_polygons]) 
 
     # Extract landuse areas from osm data set
     create_landuse_table = PythonOperator(
@@ -325,7 +325,7 @@ with airflow.DAG(
     )
 
     map_zensus_grid_districts = tasks["zensus_mv_grid_districts.mapping"]
-
+    
     # Distribute electrical CTS demands to zensus grid
     cts_electricity_demand_annual = CtsElectricityDemand(
         dependencies=[

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -126,8 +126,6 @@ with airflow.DAG(
     zensus_vg250 = ZensusVg250(
         dependencies=[vg250, population_import])
 
-    zensus_vg250 >> zensus_misc_import
-
     # DemandRegio data import
     demandregio = DemandRegio(dependencies=[
         setup, vg250, scenario_parameters, data_bundle])

--- a/src/egon/data/importing/zensus/__init__.py
+++ b/src/egon/data/importing/zensus/__init__.py
@@ -429,7 +429,10 @@ def create_combined_zensus_table():
     If there's no data on buildings or apartments for a certain cell, the value
     for building_count resp. apartment_count contains NULL.
     """
-    sql_script = Path(".") / "create_combined_zensus_table.sql"
+    sql_script = os.path.join(
+        os.path.dirname(__file__),
+        "create_combined_zensus_table.sql"
+    )
     db.execute_sql_script(sql_script)
 
 

--- a/src/egon/data/importing/zensus/__init__.py
+++ b/src/egon/data/importing/zensus/__init__.py
@@ -411,8 +411,26 @@ def zensus_misc_to_postgres():
                     REFERENCES {population_table}(id);"""
         )
 
+    # Create combined table
+    create_combined_zensus_table()
+
     # Delete entries for unpopulated cells
     adjust_zensus_misc()
+
+
+def create_combined_zensus_table():
+    """Create combined table with buildings, apartments and population per cell
+
+    Only apartment and building data with acceptable data quality
+    (quantity_q<2) is used, all other data is dropped. For more details on data
+    quality see Zensus docs:
+    https://www.zensus2011.de/DE/Home/Aktuelles/DemografischeGrunddaten.html
+
+    If there's no data on buildings or apartments for a certain cell, the value
+    for building_count resp. apartment_count contains NULL.
+    """
+    sql_script = Path(".") / "create_combined_zensus_table.sql"
+    db.execute_sql_script(sql_script)
 
 
 def adjust_zensus_misc():

--- a/src/egon/data/importing/zensus/create_combined_zensus_table.sql
+++ b/src/egon/data/importing/zensus/create_combined_zensus_table.sql
@@ -1,45 +1,50 @@
 /*
-	Join building, apartment and population data from Zensus.
-	If there's no data on buildings or apartments for a certain cell,
-	the value for building_count resp. apartment_count contains NULL.
+    Join building, apartment and population data from Zensus.
+    If there's no data on buildings or apartments for a certain cell,
+    the value for building_count resp. apartment_count contains NULL.
 */
 
 DROP TABLE IF EXISTS society.egon_destatis_zensus_apartment_building_population_per_ha;
+
+-- Join tables and filter data
 CREATE TABLE society.egon_destatis_zensus_apartment_building_population_per_ha AS
-SELECT ze.grid_id,
+SELECT GREATEST(bld_apt.grid_id, ze.grid_id) AS grid_id,
        GREATEST(bld_apt.zensus_population_id, ze.gid) AS zensus_population_id,
        bld_apt.building_count,
-	   bld_apt.apartment_count,
-	   ze.population,
-	   ze.geom
-	FROM
-		(SELECT GREATEST(bld.zensus_population_id, apt.zensus_population_id) AS zensus_population_id,
-				GREATEST(bld.grid_id, apt.grid_id) AS grid_id,
-				bld.quantity as building_count,
+       bld_apt.apartment_count,
+       ze.population,
+       ze.geom
+    FROM
+        (SELECT GREATEST(bld.zensus_population_id, apt.zensus_population_id) AS zensus_population_id,
+                GREATEST(bld.grid_id, apt.grid_id) AS grid_id,
+                bld.quantity as building_count,
                 apt.quantity as apartment_count
             FROM
-				(SELECT *
-					FROM society.egon_destatis_zensus_building_per_ha
-					WHERE attribute = 'INSGESAMT' AND quantity_q < 2
-				) bld
-			FULL JOIN
-				(SELECT *
-					FROM society.egon_destatis_zensus_apartment_per_ha
-					WHERE attribute = 'INSGESAMT' AND quantity_q < 2
-				) apt
-			USING (grid_id)
-		) bld_apt
-	FULL JOIN
-		(SELECT *
-		 	FROM society.destatis_zensus_population_per_ha_inside_germany
-		) ze
-	USING (grid_id)
-	ORDER BY zensus_population_id;
+                (SELECT *
+                    FROM society.egon_destatis_zensus_building_per_ha
+                    WHERE attribute = 'INSGESAMT' AND quantity_q < 2
+                ) bld
+            FULL JOIN
+                (SELECT *
+                    FROM society.egon_destatis_zensus_apartment_per_ha
+                    WHERE attribute = 'INSGESAMT' AND quantity_q < 2
+                ) apt
+            USING (grid_id)
+        ) bld_apt
+    FULL JOIN
+        (SELECT *
+             FROM society.destatis_zensus_population_per_ha_inside_germany
+        ) ze
+    USING (grid_id)
+    ORDER BY zensus_population_id;
 
+-- Set empty geoms from raw Zensus dataset
+-- This is needed as table `society.destatis_zensus_population_per_ha_inside_germany`
+-- holds geoms on cells with population > 0
 UPDATE society.egon_destatis_zensus_apartment_building_population_per_ha AS t
-	SET geom = t2.geom
-	FROM
-	  society.destatis_zensus_population_per_ha AS t2
-	WHERE t.geom IS NULL AND t.grid_id = t2.grid_id;
+    SET geom = t2.geom
+    FROM society.destatis_zensus_population_per_ha AS t2
+    WHERE t.geom IS NULL AND t.grid_id = t2.grid_id;
 
+-- Create index
 CREATE INDEX ON society.egon_destatis_zensus_apartment_building_population_per_ha USING gist (geom);

--- a/src/egon/data/importing/zensus/create_combined_zensus_table.sql
+++ b/src/egon/data/importing/zensus/create_combined_zensus_table.sql
@@ -3,10 +3,12 @@
 	If there's no data on buildings or apartments for a certain cell,
 	the value for building_count resp. apartment_count contains NULL.
 */
+
 DROP TABLE IF EXISTS society.egon_destatis_zensus_apartment_building_population_per_ha;
 CREATE TABLE society.egon_destatis_zensus_apartment_building_population_per_ha AS
-SELECT GREATEST(bld_apt.zensus_population_id, ze.gid) AS zensus_population_id,
-	   bld_apt.building_count,
+SELECT ze.grid_id,
+       GREATEST(bld_apt.zensus_population_id, ze.gid) AS zensus_population_id,
+       bld_apt.building_count,
 	   bld_apt.apartment_count,
 	   ze.population,
 	   ze.geom
@@ -14,8 +16,8 @@ SELECT GREATEST(bld_apt.zensus_population_id, ze.gid) AS zensus_population_id,
 		(SELECT GREATEST(bld.zensus_population_id, apt.zensus_population_id) AS zensus_population_id,
 				GREATEST(bld.grid_id, apt.grid_id) AS grid_id,
 				bld.quantity as building_count,
-				apt.quantity as apartment_count
-			FROM
+                apt.quantity as apartment_count
+            FROM
 				(SELECT *
 					FROM society.egon_destatis_zensus_building_per_ha
 					WHERE attribute = 'INSGESAMT' AND quantity_q < 2
@@ -33,4 +35,11 @@ SELECT GREATEST(bld_apt.zensus_population_id, ze.gid) AS zensus_population_id,
 		) ze
 	USING (grid_id)
 	ORDER BY zensus_population_id;
+
+UPDATE society.egon_destatis_zensus_apartment_building_population_per_ha AS t
+	SET geom = t2.geom
+	FROM
+	  society.destatis_zensus_population_per_ha AS t2
+	WHERE t.geom IS NULL AND t.grid_id = t2.grid_id;
+
 CREATE INDEX ON society.egon_destatis_zensus_apartment_building_population_per_ha USING gist (geom);

--- a/src/egon/data/importing/zensus/create_combined_zensus_table.sql
+++ b/src/egon/data/importing/zensus/create_combined_zensus_table.sql
@@ -1,0 +1,36 @@
+/*
+	Join building, apartment and population data from Zensus.
+	If there's no data on buildings or apartments for a certain cell,
+	the value for building_count resp. apartment_count contains NULL.
+*/
+DROP TABLE IF EXISTS society.egon_destatis_zensus_apartment_building_population_per_ha;
+CREATE TABLE society.egon_destatis_zensus_apartment_building_population_per_ha AS
+SELECT GREATEST(bld_apt.zensus_population_id, ze.gid) AS zensus_population_id,
+	   bld_apt.building_count,
+	   bld_apt.apartment_count,
+	   ze.population,
+	   ze.geom
+	FROM
+		(SELECT GREATEST(bld.zensus_population_id, apt.zensus_population_id) AS zensus_population_id,
+				GREATEST(bld.grid_id, apt.grid_id) AS grid_id,
+				bld.quantity as building_count,
+				apt.quantity as apartment_count
+			FROM
+				(SELECT *
+					FROM society.egon_destatis_zensus_building_per_ha
+					WHERE attribute = 'INSGESAMT' AND quantity_q < 2
+				) bld
+			FULL JOIN
+				(SELECT *
+					FROM society.egon_destatis_zensus_apartment_per_ha
+					WHERE attribute = 'INSGESAMT' AND quantity_q < 2
+				) apt
+			USING (grid_id)
+		) bld_apt
+	FULL JOIN
+		(SELECT *
+		 	FROM society.destatis_zensus_population_per_ha_inside_germany
+		) ze
+	USING (grid_id)
+	ORDER BY zensus_population_id;
+CREATE INDEX ON society.egon_destatis_zensus_apartment_building_population_per_ha USING gist (geom);

--- a/src/egon/data/importing/zensus/create_combined_zensus_table.sql
+++ b/src/egon/data/importing/zensus/create_combined_zensus_table.sql
@@ -9,7 +9,7 @@ DROP TABLE IF EXISTS society.egon_destatis_zensus_apartment_building_population_
 -- Join tables and filter data
 CREATE TABLE society.egon_destatis_zensus_apartment_building_population_per_ha AS
 SELECT GREATEST(bld_apt.grid_id, ze.grid_id) AS grid_id,
-       GREATEST(bld_apt.zensus_population_id, ze.gid) AS zensus_population_id,
+       GREATEST(bld_apt.zensus_population_id, ze.id) AS zensus_population_id,
        bld_apt.building_count,
        bld_apt.apartment_count,
        ze.population,

--- a/src/egon/data/importing/zensus/create_combined_zensus_table.sql
+++ b/src/egon/data/importing/zensus/create_combined_zensus_table.sql
@@ -13,7 +13,8 @@ SELECT GREATEST(bld_apt.grid_id, ze.grid_id) AS grid_id,
        bld_apt.building_count,
        bld_apt.apartment_count,
        ze.population,
-       ze.geom
+       ze.geom,
+       ze.geom_point
     FROM
         (SELECT GREATEST(bld.zensus_population_id, apt.zensus_population_id) AS zensus_population_id,
                 GREATEST(bld.grid_id, apt.grid_id) AS grid_id,
@@ -42,7 +43,9 @@ SELECT GREATEST(bld_apt.grid_id, ze.grid_id) AS grid_id,
 -- This is needed as table `society.destatis_zensus_population_per_ha_inside_germany`
 -- holds geoms on cells with population > 0
 UPDATE society.egon_destatis_zensus_apartment_building_population_per_ha AS t
-    SET geom = t2.geom
+    SET
+        geom = t2.geom,
+        geom_point = t2.geom_point
     FROM society.destatis_zensus_population_per_ha AS t2
     WHERE t.geom IS NULL AND t.grid_id = t2.grid_id;
 


### PR DESCRIPTION
This task creates a new table `society.egon_destatis_zensus_apartment_building_population_per_ha` with buildings, apartments and population. Include cells where there's either building, apartment or population data -> different to the existing tables it contains data on all Zensus cells (also with pop = -1 or NULL).

Closes #359 