### PR TITLE
Use random seed from CLI parameters for CHP and society prognosis

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -193,6 +193,8 @@ Changed
   `#391 <https://github.com/openego/eGon-data/issues/391>`_
 * Update version of zenodo download
   `#397 <https://github.com/openego/eGon-data/issues/397>`_
+* Use random seed from CLI parameters for CHP and society prognosis functions
+  `#351 <https://github.com/openego/eGon-data/issues/351>`_
 
 Bug fixes
 ---------

--- a/src/egon/data/datasets/chp/small_chp.py
+++ b/src/egon/data/datasets/chp/small_chp.py
@@ -141,7 +141,7 @@ def extension_to_areas(areas, additional_capacity, existing_chp, flh, EgonChp,
     """
     session = sessionmaker(bind=db.engine())()
 
-    np.random.seed(seed=123456)
+    np.random.seed(seed=config.settings()['egon-data']['--random-seed'])
 
     # n = 0
     # Add new CHP as long as the additional capacity is not reached

--- a/src/egon/data/datasets/society_prognosis.py
+++ b/src/egon/data/datasets/society_prognosis.py
@@ -28,7 +28,7 @@ class SocietyPrognosis(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="SocietyPrognosis",
-            version="0.0.0",
+            version="0.0.1",
             dependencies=dependencies,
             tasks=(create_tables,
                    zensus_population,
@@ -147,6 +147,10 @@ def household_prognosis_per_year(prognosis_nuts3, zensus, year):
     )
     prognosis["rounded"] = prognosis["quantity"].astype(int)
     prognosis["rest"] = prognosis["quantity"] - prognosis["rounded"]
+
+    # Set seed for reproducibility
+    np.random.seed(
+        seed=egon.data.config.settings()['egon-data']['--random-seed'])
 
     # Rounding process to meet exact values from demandregio on nuts3-level
     for name, group in prognosis.groupby(prognosis.nuts3):


### PR DESCRIPTION
Closes #351 

This branch uses the random seed from the configuration file in the CHP and society prognosis function. 