### PR TITLE
Features/#423 change schmidt industrial sites

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -191,6 +191,8 @@ Changed
   `#391 <https://github.com/openego/eGon-data/issues/391>`_
 * Update version of zenodo download
   `#397 <https://github.com/openego/eGon-data/issues/397>`_
+* Changed demand.egon_schmidt_industrial_sites - table and merged table (industrial_sites)
+  `#423 <https://github.com/openego/eGon-data/issues/423>`_
 
 Bug fixes
 ---------

--- a/src/egon/data/datasets/industrial_sites/__init__.py
+++ b/src/egon/data/datasets/industrial_sites/__init__.py
@@ -682,7 +682,7 @@ class MergeIndustrialSites(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="Merge_industrial_sites",
-            version="0.0.2.dev",
+            version="0.0.2",
             dependencies=dependencies,
             tasks=(download_import_industrial_sites, merge_inputs, map_nuts3),
         )

--- a/src/egon/data/datasets/industrial_sites/__init__.py
+++ b/src/egon/data/datasets/industrial_sites/__init__.py
@@ -680,7 +680,7 @@ class MergeIndustrialSites(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="Merge_industrial_sites",
-            version="0.0.2",
+            version="0.0.3",
             dependencies=dependencies,
             tasks=(download_import_industrial_sites, merge_inputs, map_nuts3),
         )

--- a/src/egon/data/datasets/industrial_sites/__init__.py
+++ b/src/egon/data/datasets/industrial_sites/__init__.py
@@ -653,18 +653,6 @@ def merge_inputs():
                     LOWER (SUBSTRING(s.companyname, 1, 3)));"""
     )
 
-    # Delete remaining duplicates
-
-    db.execute_sql(
-        f"""DELETE FROM
-                {sites_table} a
-                    USING {sites_table} b
-            WHERE a.id > b.id
-            AND a.geom = b.geom
-            AND a.wz = b.wz;"""
-    )
-
-
 def map_nuts3():
     """
     Match resulting industrial sites with nuts3 codes and fill column 'nuts3'
@@ -694,7 +682,7 @@ class MergeIndustrialSites(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="Merge_industrial_sites",
-            version="0.0.2",
+            version="0.0.2.dev",
             dependencies=dependencies,
             tasks=(download_import_industrial_sites, merge_inputs, map_nuts3),
         )


### PR DESCRIPTION
The industrial sites gathered by Danielle Schmidt's (https://zenodo.org/record/3613767#.YS9xcVtCS-p) are getting imported as they are, plants with different applications will no longer be dropped, because this information is important for the modelling of DSM.
Closes #423 