### PR TITLE
Fix constant p_set values for industrial sites load curves

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -260,3 +260,6 @@ Bug fixes
   `#349 <https://github.com/openego/eGon-data/issues/349>`_
 * Bump MV grid district version no
   `#432 <https://github.com/openego/eGon-data/issues/432>`_
+* Fix constant p_set values for industrial site load curves
+  `#429 <https://github.com/openego/eGon-data/issues/429>`_
+

--- a/src/egon/data/datasets/industry/__init__.py
+++ b/src/egon/data/datasets/industry/__init__.py
@@ -351,7 +351,7 @@ class IndustrialDemandCurves(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="Industrial_demand_curves",
-            version="0.0.3",
+            version="0.0.4",
             dependencies=dependencies,
             tasks=(
                 create_tables,

--- a/src/egon/data/datasets/industry/temporal.py
+++ b/src/egon/data/datasets/industry/temporal.py
@@ -110,7 +110,7 @@ def calc_load_curves_ind_osm(scenario):
         per substation id
 
     """
-
+    scenario = 'eGon2035'
     sources = egon.data.config.datasets()["electrical_load_curves_industry"][
         "sources"
     ]
@@ -165,7 +165,7 @@ def calc_load_curves_ind_osm(scenario):
     curves_da = identify_bus(load_curves, demand_area)
 
     # Group all load curves per bus
-    curves_bus = curves_da.drop(["id"], axis=1).groupby("subst_id").sum()
+    curves_bus = curves_da.drop(["id"], axis=1).fillna(0).groupby("subst_id").sum()
 
     # Initalize pandas.DataFrame for export to database
     load_ts_df = pd.DataFrame(index=curves_bus.index, columns=["p_set"])

--- a/src/egon/data/datasets/industry/temporal.py
+++ b/src/egon/data/datasets/industry/temporal.py
@@ -288,7 +288,7 @@ def calc_load_curves_ind_sites(scenario):
 
     # Group all load curves per bus and wz
     curves_bus = (
-        curves_da.groupby(["subst_id", "wz"]).sum().drop(["id"], axis=1)
+        curves_da.drop(["id"], axis=1).groupby(["subst_id", "wz"]).sum()
     )
 
     # Initalize pandas.DataFrame for pf table load timeseries


### PR DESCRIPTION
Fixes #429 

@KathiEsterl @hade9443 It seems like the order of one function call needed to be changed. I tested it in the script and it was working. I was not able to test it in a egon-data run. Could one of you maybe do this? 
You can also cherry-pick this commit to your dsm-branch and test it there. 