### PR TITLE
Fix using datasets ending with parallel tasks as dependencies

### DIFF
--- a/src/egon/data/datasets/__init__.py
+++ b/src/egon/data/datasets/__init__.py
@@ -135,6 +135,7 @@ class Tasks(dict):
             self.first = {task for result in results for task in result.first}
             self.last = {task for result in results for task in result.last}
             self.update(reduce(lambda d1, d2: dict(d1, **d2), results, {}))
+            self.graph = set(tasks.graph for tasks in results)
         elif isinstance(graph, tuple):
             results = [Tasks(subtasks) for subtasks in graph]
             for (left, right) in zip(results[:-1], results[1:]):
@@ -144,6 +145,7 @@ class Tasks(dict):
             self.first = results[0].first
             self.last = results[-1].last
             self.update(reduce(lambda d1, d2: dict(d1, **d2), results, {}))
+            self.graph = tuple(tasks.graph for tasks in results)
         else:
             raise (
                 TypeError(

--- a/src/egon/data/datasets/__init__.py
+++ b/src/egon/data/datasets/__init__.py
@@ -101,6 +101,12 @@ Task = Union[Callable[[], None], Operator]
 TaskGraph = Union[Task, Set["TaskGraph"], Tuple["TaskGraph", ...]]
 
 
+def prefix(o):
+    module = o.__module__
+    parent = f"{__name__}."
+    return f"{module.replace(parent, '')}." if parent in module else ""
+
+
 @dataclass
 class Tasks(dict):
     first: Set[Task]
@@ -114,12 +120,7 @@ class Tasks(dict):
         """
         if isinstance(graph, Callable):
             graph = PythonOperator(
-                task_id=(
-                    f"{graph.__module__.replace('egon.data.datasets.', '')}."
-                    if "egon.data.datasets." in graph.__module__
-                    else ""
-                )
-                + graph.__name__.replace("_", "-"),
+                task_id=f"{prefix(graph)}{graph.__name__.replace('_', '-')}",
                 python_callable=graph,
             )
         self.graph = graph
@@ -229,8 +230,10 @@ class Dataset:
         if len(self.tasks.last) > 1:
             # Explicitly create single final task, because we can't know
             # which of the multiple tasks finishes last.
+            name = prefix(self)
+            name = name if name else f"{self.name}."
             update_version = PythonOperator(
-                task_id=f"update-{self.name}-version",
+                task_id=f"{name}update-version",
                 # Do nothing, because updating will be added later.
                 python_callable=lambda *xs, **ks: None,
             )

--- a/src/egon/data/datasets/demandregio/__init__.py
+++ b/src/egon/data/datasets/demandregio/__init__.py
@@ -24,18 +24,6 @@ except:
 # will be later imported from another file ###
 Base = declarative_base()
 
-# class DemandRegio(Dataset):
-#     def __init__(self, dependencies):
-#         super().__init__(
-#             name="DemandRegio",
-#             version="0.0.0",
-#             dependencies=dependencies,
-#             tasks=(clone_and_install, create_tables,
-#                    {insert_society_data, insert_household_demand,
-#                     insert_cts_ind_demands}),
-#         )
-
-# Avoid parallel tasks as long as the dependencies are not set correctly
 class DemandRegio(Dataset):
     def __init__(self, dependencies):
         super().__init__(
@@ -43,10 +31,9 @@ class DemandRegio(Dataset):
             version="0.0.1",
             dependencies=dependencies,
             tasks=(clone_and_install, create_tables,
-                   insert_society_data, insert_household_demand,
-                    insert_cts_ind_demands),
+                    {insert_society_data, insert_household_demand,
+                    insert_cts_ind_demands}),
         )
-
 
 class EgonDemandRegioHH(Base):
     __tablename__ = 'egon_demandregio_hh'

--- a/src/egon/data/datasets/heat_supply/__init__.py
+++ b/src/egon/data/datasets/heat_supply/__init__.py
@@ -136,6 +136,8 @@ class HeatSupply(Dataset):
             name="HeatSupply",
             version="0.0.1",
             dependencies=dependencies,
-            tasks=(create_tables,
-                district_heating, individual_heating, potential_germany),
+            tasks=(
+                create_tables,
+                {district_heating, individual_heating, potential_germany},
+            ),
         )

--- a/src/egon/data/datasets/heat_supply/__init__.py
+++ b/src/egon/data/datasets/heat_supply/__init__.py
@@ -2,44 +2,46 @@
 
 """
 
-from egon.data import db, config
-
-from egon.data.datasets.heat_supply.district_heating import (
-    cascade_heat_supply)
-from egon.data.datasets.heat_supply.individual_heating import (
-    cascade_heat_supply_indiv)
-from egon.data.datasets.heat_supply.geothermal import (
-    potential_germany)
-from egon.data.datasets.district_heating_areas import EgonDistrictHeatingAreas
-from sqlalchemy import Column, String, Float, Integer, ForeignKey
-from sqlalchemy.ext.declarative import declarative_base
 from geoalchemy2.types import Geometry
+from sqlalchemy import Column, Float, Integer, String
+from sqlalchemy.ext.declarative import declarative_base
+
+from egon.data import config, db
 from egon.data.datasets import Dataset
-### will be later imported from another file ###
+from egon.data.datasets.heat_supply.district_heating import cascade_heat_supply
+from egon.data.datasets.heat_supply.geothermal import potential_germany
+from egon.data.datasets.heat_supply.individual_heating import (
+    cascade_heat_supply_indiv,
+)
+
+# Will later be imported from another file.
 Base = declarative_base()
+
 
 # TODO: set district_heating_id as ForeignKey
 class EgonDistrictHeatingSupply(Base):
-    __tablename__ = 'egon_district_heating'
-    __table_args__ = {'schema': 'supply'}
+    __tablename__ = "egon_district_heating"
+    __table_args__ = {"schema": "supply"}
     index = Column(Integer, primary_key=True)
     district_heating_id = Column(Integer)
     carrier = Column(String(25))
     category = Column(String(25))
     capacity = Column(Float)
-    geometry = Column(Geometry('POINT', 3035))
+    geometry = Column(Geometry("POINT", 3035))
     scenario = Column(String(50))
 
+
 class EgonIndividualHeatingSupply(Base):
-    __tablename__ = 'egon_individual_heating'
-    __table_args__ = {'schema': 'supply'}
+    __tablename__ = "egon_individual_heating"
+    __table_args__ = {"schema": "supply"}
     index = Column(Integer, primary_key=True)
     mv_grid_id = Column(Integer)
     carrier = Column(String(25))
     category = Column(String(25))
     capacity = Column(Float)
-    geometry = Column(Geometry('POINT', 3035))
+    geometry = Column(Geometry("POINT", 3035))
     scenario = Column(String(50))
+
 
 def create_tables():
     """Create tables for district heating areas
@@ -57,30 +59,33 @@ def create_tables():
 
 
 def district_heating():
-    """ Insert supply for district heating areas
+    """Insert supply for district heating areas
 
     Returns
     -------
     None.
 
     """
-    sources = config.datasets()['heat_supply']['sources']
-    targets = config.datasets()['heat_supply']['targets']
+    sources = config.datasets()["heat_supply"]["sources"]
+    targets = config.datasets()["heat_supply"]["targets"]
 
     db.execute_sql(
         f"""
         DELETE FROM {targets['district_heating_supply']['schema']}.
         {targets['district_heating_supply']['table']}
-        """)
+        """
+    )
 
-    supply_2035 = cascade_heat_supply('eGon2035', plotting=False)
+    supply_2035 = cascade_heat_supply("eGon2035", plotting=False)
 
-    supply_2035['scenario'] = 'eGon2035'
+    supply_2035["scenario"] = "eGon2035"
 
     supply_2035.to_postgis(
-        targets['district_heating_supply']['table'],
-        schema=targets['district_heating_supply']['schema'],
-        con=db.engine(), if_exists='append')
+        targets["district_heating_supply"]["table"],
+        schema=targets["district_heating_supply"]["schema"],
+        con=db.engine(),
+        if_exists="append",
+    )
 
     # Compare target value with sum of distributed heat supply
     df_check = db.select_dataframe(
@@ -95,40 +100,46 @@ def district_heating():
         AND b.scenario_name = 'eGon2035'
         AND b.carrier = CONCAT('urban_central_', a.carrier)
         GROUP BY (a.carrier,  b.capacity);
-        """)
+        """
+    )
     # If the deviation is > 1%, throw an error
-    assert (df_check.deviation.abs().max() < 1), (
-        f"""Unexpected deviation between target value and distributed
+    assert (
+        df_check.deviation.abs().max() < 1
+    ), f"""Unexpected deviation between target value and distributed
         heat supply: {df_check}
         """
-        )
 
 
 def individual_heating():
-    """ Insert supply for individual heating
+    """Insert supply for individual heating
 
     Returns
     -------
     None.
 
     """
-    targets = config.datasets()['heat_supply']['targets']
+    targets = config.datasets()["heat_supply"]["targets"]
 
     db.execute_sql(
         f"""
         DELETE FROM {targets['individual_heating_supply']['schema']}.
         {targets['individual_heating_supply']['table']}
-        """)
+        """
+    )
 
     supply_2035 = cascade_heat_supply_indiv(
-        'eGon2035', distribution_level='federal_states', plotting=False)
+        "eGon2035", distribution_level="federal_states", plotting=False
+    )
 
-    supply_2035['scenario'] = 'eGon2035'
+    supply_2035["scenario"] = "eGon2035"
 
     supply_2035.to_postgis(
-        targets['individual_heating_supply']['table'],
-        schema=targets['individual_heating_supply']['schema'],
-        con=db.engine(), if_exists='append')
+        targets["individual_heating_supply"]["table"],
+        schema=targets["individual_heating_supply"]["schema"],
+        con=db.engine(),
+        if_exists="append",
+    )
+
 
 class HeatSupply(Dataset):
     def __init__(self, dependencies):

--- a/src/egon/data/datasets/osmtgmod/__init__.py
+++ b/src/egon/data/datasets/osmtgmod/__init__.py
@@ -657,14 +657,16 @@ class Osmtgmod(Dataset):
             tasks=(
                 import_osm_data,
                 run,
-                # {
-                PostgresOperator(
-                    task_id="osmtgmod_substation",
-                    sql=resources.read_text(__name__, "substation_otg.sql"),
-                    postgres_conn_id="egon_data",
-                    autocommit=True,
-                ),
-                to_pypsa
-                #  }
+                {
+                    PostgresOperator(
+                        task_id="osmtgmod_substation",
+                        sql=resources.read_text(
+                            __name__, "substation_otg.sql"
+                        ),
+                        postgres_conn_id="egon_data",
+                        autocommit=True,
+                    ),
+                    to_pypsa,
+                },
             ),
         )

--- a/src/egon/data/datasets/power_plants/__init__.py
+++ b/src/egon/data/datasets/power_plants/__init__.py
@@ -52,8 +52,8 @@ class PowerPlants(Dataset):
             dependencies=dependencies,
             tasks=(
                 create_tables,
+                insert_hydro_biomass,
                 {
-                    insert_hydro_biomass,
                     wind_onshore.insert,
                     pv_ground_mounted.insert,
                     pv_rooftop_per_mv_grid,

--- a/src/egon/data/datasets/power_plants/__init__.py
+++ b/src/egon/data/datasets/power_plants/__init__.py
@@ -52,10 +52,12 @@ class PowerPlants(Dataset):
             dependencies=dependencies,
             tasks=(
                 create_tables,
-                insert_hydro_biomass,
-                wind_onshore.insert,
-                pv_ground_mounted.insert,
-                pv_rooftop_per_mv_grid,
+                {
+                    insert_hydro_biomass,
+                    wind_onshore.insert,
+                    pv_ground_mounted.insert,
+                    pv_rooftop_per_mv_grid,
+                },
             ),
         )
 

--- a/src/egon/data/datasets/renewable_feedin.py
+++ b/src/egon/data/datasets/renewable_feedin.py
@@ -18,7 +18,7 @@ class RenewableFeedin(Dataset):
             name="RenewableFeedin",
             version="0.0.0",
             dependencies=dependencies,
-            tasks=(wind, pv, solar_thermal),
+            tasks={wind, pv, solar_thermal},
             )
 
 def weather_cells_in_germany(geom_column='geom'):

--- a/src/egon/data/datasets/society_prognosis.py
+++ b/src/egon/data/datasets/society_prognosis.py
@@ -12,18 +12,6 @@ from egon.data.datasets import Dataset
 # will be later imported from another file ###
 Base = declarative_base()
 
-# class SocietyPrognosis(Dataset):
-#     def __init__(self, dependencies):
-#         super().__init__(
-#             name="SocietyPrognosis",
-#             version="0.0.0",
-#             dependencies=dependencies,
-#             tasks=(create_tables,
-#                    {zensus_population,
-#                     zensus_household}),
-#         )
-
-# Avoid parallel tasks as long as the dependencies are not set correctly
 class SocietyPrognosis(Dataset):
     def __init__(self, dependencies):
         super().__init__(
@@ -31,8 +19,8 @@ class SocietyPrognosis(Dataset):
             version="0.0.0",
             dependencies=dependencies,
             tasks=(create_tables,
-                   zensus_population,
-                    zensus_household),
+                    {zensus_population,
+                    zensus_household}),
         )
 
 


### PR DESCRIPTION
This should fix #365. It's not tested in `continuous-integration/run-everything-over-the-weekend` yet, because I also didn't get around to run the test mode on it, yet. I hope I'll manage to do so before Friday, so the changes can be teste over the weekend. But you can already have  look and tell whether any of these changes look wrong.