### PR TITLE
Add missing dependency in industrial_sites task

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -294,4 +294,6 @@ Bug fixes
   `#414 <https://github.com/openego/eGon-data/issues/414>`_
 * Exchange bus 0 and bus 1 in Power-to-H2 links
   `#458 <https://github.com/openego/eGon-data/issues/458>`_
+* Add `data_bundle` to `industrial_sites` task dependencies
+  `#468 <https://github.com/openego/eGon-data/issues/468>`_
 

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -418,7 +418,7 @@ with airflow.DAG(
     # Industry
 
     industrial_sites = MergeIndustrialSites(
-        dependencies=[setup, vg250_clean_and_prepare]
+        dependencies=[setup, vg250_clean_and_prepare, data_bundle]
     )
 
     demand_curves_industry = IndustrialDemandCurves(
@@ -480,7 +480,7 @@ with airflow.DAG(
 
     # Heat time Series
     heat_time_series = HeatTimeSeries(
-        dependencies = [data_bundle,demandregio,heat_demand_Germany, import_district_heating_areas,  
+        dependencies = [data_bundle,demandregio,heat_demand_Germany, import_district_heating_areas,
                         import_district_heating_areas,vg250,
                         map_zensus_grid_districts])
 


### PR DESCRIPTION
Resolve #468 

To test this, the workflow must be fully restarted.