### PR TITLE
Change order of demandregio tasks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -297,6 +297,8 @@ Bug fixes
   `#414 <https://github.com/openego/eGon-data/issues/414>`_
 * Exchange bus 0 and bus 1 in Power-to-H2 links
   `#458 <https://github.com/openego/eGon-data/issues/458>`_
+* Fix missing cts demands for eGon2035
+  `#511 <https://github.com/openego/eGon-data/issues/511>`_
 * Add `data_bundle` to `industrial_sites` task dependencies
   `#468 <https://github.com/openego/eGon-data/issues/468>`_
 

--- a/src/egon/data/datasets/demandregio/__init__.py
+++ b/src/egon/data/datasets/demandregio/__init__.py
@@ -33,14 +33,14 @@ class DemandRegio(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="DemandRegio",
-            version="0.0.1",
+            version="0.0.2",
             dependencies=dependencies,
             tasks=(
                 clone_and_install,
                 create_tables,
+                insert_household_demand,
                 {
                     insert_society_data,
-                    insert_household_demand,
                     insert_cts_ind_demands,
                 },
             ),


### PR DESCRIPTION
Temporary fixes #511 by running `demandregio.insert_household_demand` before  `demandregio.insert_cts_ind_demand` 