### PR TITLE
Add a method to prevent unique key errors

### DIFF
--- a/src/egon/data/datasets/ch4_storages.py
+++ b/src/egon/data/datasets/ch4_storages.py
@@ -148,16 +148,18 @@ def import_ch4_storages():
     )    
     
     # Select next id value
-    new_id = db.next_etrago_id('store')
-    
-    gas_storages_list = pd.concat([import_installed_ch4_storages(), import_ch4_grid_capacity()])
-    gas_storages_list['store_id'] = range(new_id, new_id + len(gas_storages_list))
-    
+    gas_storages_list = pd.concat(
+        [import_installed_ch4_storages(), import_ch4_grid_capacity()]
+    )
     gas_storages_list =  gas_storages_list.reset_index(drop=True)
    
     # Insert data to db
-    gas_storages_list.to_sql('egon_etrago_store',
-                              engine,
-                              schema ='grid',
-                              index = False,
-                              if_exists = 'append')
+    db.to_db(
+        gas_storages_list,
+        'store',
+        name='egon_etrago_store',
+        con=engine,
+        schema ='grid',
+        index = False,
+        if_exists = 'append'
+    )


### PR DESCRIPTION
Resolve #514

First try for method which solves the unique key problem with the next_etrago_id method (see #514). Example implementation in ch4_storages.py.

# ToDo:

- [ ] 1. Adapt all `to_postgis()` and `to_sql()` calls
- [ ] 2. (How to) handle insertion of the same ids in different scenario name(?)
- [ ] 3. Some insertions require predefined ids and should explicitly not assert new ones

## 1. 

## 2.
- Approach: search ids with scn_name as filter
- Maybe-Problem: This task might not even be required, as the same bus should have the same id throughout all scenarios(?)

## 3.
- Approach: Check if _id column data are available, only assert if not
- Maybe-Problem: For some data, the _id column is made the index column before writing to the db. Is this necessary? Needs discussion

# Reproduce issue

To reproduce the duplicated key issue, try checking out the #478 branch and clear the following tasks simultanously:

- insert_h2_to_ch4_to_h2
- insert power_to_h2_to_power

or clear the upstream task hydrogen_etrago.insert-hydrogen-buses. Both tasks write on the grid.egon_etrago_link table.