### PR TITLE
Fix missing cts demands from demandregio

### DIFF
--- a/src/egon/data/datasets/demandregio/__init__.py
+++ b/src/egon/data/datasets/demandregio/__init__.py
@@ -33,13 +33,13 @@ class DemandRegio(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="DemandRegio",
-            version="0.0.2",
+            version="0.0.3",
             dependencies=dependencies,
             tasks=(
                 clone_and_install,
                 create_tables,
-                insert_household_demand,
                 {
+                    insert_household_demand,
                     insert_society_data,
                     insert_cts_ind_demands,
                 },


### PR DESCRIPTION
Closes #511
The problem was fixed in demandregio's disaggregator tool (see https://github.com/openego/disaggregator/commit/7881c90e9abaaa93185073172b64cc3d5402818d), so the demandregio tasks in eGon-data can run in parallel again. 

Here is some more information about the problem: 
As described in https://github.com/openego/eGon-data/issues/511#issue-1051705426 the issue occurred only in the first function call of `spatial.disagg_CTS_industry()` after a new installation. 
Only in the first access of the function mapping the nuts3 region codes to the number of 'Landkreise', the data is queried from the database. A cached csv-file is used in the upcoming runs. 
When the data is selected from the database, the data types are adjusted according to the config.yaml. 
This included the dtype `str` for `ags_lk`, but these values are integer values. Due to the type conversion, e.g. `1001` was transformed to `'01001'`, but the dataframe which should get the nuts3 names still had the integer values, so mapping was not possible. I updated the data type in the configuration file to `int` here:
https://github.com/openego/disaggregator/blob/7881c90e9abaaa93185073172b64cc3d5402818d/disaggregator/config.yaml#L157-L160
When the cached csv file was used, the data types were set automatically correctly which is why the problem only occurred in the first run of the function. 
