### PR TITLE
Fill missing household data for populated cells

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -295,6 +295,8 @@ Changed
   `#545 <https://github.com/openego/eGon-data/issues/545>`_
 * Integrate fuel and CO2 costs for eGon2035 to scenario parameters
   `#549 <https://github.com/openego/eGon-data/issues/549>`_
+* Fill missing household data for populated cells
+  `#549 <https://github.com/openego/eGon-data/issues/431>`_
 
 
 Bug fixes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -296,7 +296,7 @@ Changed
 * Integrate fuel and CO2 costs for eGon2035 to scenario parameters
   `#549 <https://github.com/openego/eGon-data/issues/549>`_
 * Fill missing household data for populated cells
-  `#549 <https://github.com/openego/eGon-data/issues/431>`_
+  `#431 <https://github.com/openego/eGon-data/issues/431>`_
 
 
 Bug fixes

--- a/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
@@ -872,9 +872,13 @@ def get_census_households_grid():
         right_on="grid_id",
         how="right",
     )
+    df_census_households_grid = df_census_households_grid.sort_values(
+        ["cell_id", "characteristics_code"]
+    )
 
     # fill cells with missing household distribution data but population
     # by distribution of random cell with same population value
+
     df_census_households_grid = fill_missing_hh_in_populated_cells(
         df_census_households_grid
     )

--- a/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
@@ -101,6 +101,10 @@ the number of categories of cell-level household data.
  attribute 'INSGESAMT'. As the profiles are scaled with demand-regio data at
  nuts3-level the impact at a higher aggregation level is negligible.
  For sake of simplicity, the data is not corrected.
+* There are cells without household data but a population. A randomly chosen
+ household distribution is taken from a subgroup of cells with same population value and
+ applied to all cells with missing household distribution and the specific
+ population value.
 
 Notes
 -----

--- a/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
@@ -715,17 +715,20 @@ def fill_missing_hh_in_populated_cells(df_census_households_grid):
     ].reset_index(drop=True)
 
     # iterate over unique population values
-    for i in df_wo_hh["population"].sort_values().unique():
+    for population in df_wo_hh["population"].sort_values().unique():
 
         # create fallback if no cell with specific population available
-        if i in df_w_hh["population"].unique():
-            last_i = i
+        if population in df_w_hh["population"].unique():
+            fallback_value = population
+            population_value = population
         # use fallback of last possible household distribution
         else:
-            i = last_i
+            population_value = fallback_value
 
         # get cells with specific population value from cells with household distribution
-        df_w_hh_population_i = df_w_hh.loc[df_w_hh["population"] == i]
+        df_w_hh_population_i = df_w_hh.loc[
+            df_w_hh["population"] == population_value
+        ]
         # choose random cell within this group
         rnd_cell_id_population_i = np.random.choice(
             df_w_hh_population_i["cell_id"].unique()
@@ -735,7 +738,9 @@ def fill_missing_hh_in_populated_cells(df_census_households_grid):
             df_w_hh_population_i["cell_id"] == rnd_cell_id_population_i
         ]
         # get cells with specific population value from cells without household distribution
-        df_wo_hh_population_i = df_wo_hh.loc[df_wo_hh["population"] == i]
+        df_wo_hh_population_i = df_wo_hh.loc[
+            df_wo_hh["population"] == population
+        ]
 
         # all cells will get the same random household distribution
 

--- a/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
@@ -173,7 +173,7 @@ class EgonEtragoElectricityHouseholds(Base):
 setup = partial(
     Dataset,
     name="HH Demand",
-    version="0.0.4",
+    version="0.0.5",
     dependencies=[],
     # Tasks are declared in pipeline as function is used multiple times with
     # different args.

--- a/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
@@ -774,16 +774,12 @@ def get_census_households_grid():
     amount of households per type deviates from the total number with attribute
     'INSGESAMT'. As the profiles are scaled with demand-regio data at
     nuts3-level the impact at a higher aggregation level is negligible. For sake
-    of simplicity, the data is not corrected. Secondly, cells without household
-    data but population value are covered. A randomly chosen household
-    distribution is taken from a group of cells with same population value and
-    applied to all cells with missing household distribution and the specific
-    population value.
+    of simplicity, the data is not corrected.
 
     Returns
     -------
     pd.DataFrame
-        zensus household data at 100x100m grid level"""
+        census household data at 100x100m grid level"""
 
     # Retrieve information about households for each census cell
     # Only use cell-data which quality (quantity_q<2) is acceptable
@@ -879,13 +875,6 @@ def get_census_households_grid():
     )
     df_census_households_grid = df_census_households_grid.sort_values(
         ["cell_id", "characteristics_code"]
-    )
-
-    # fill cells with missing household distribution data but population
-    # by distribution of random cell with same population value
-
-    df_census_households_grid = fill_missing_hh_in_populated_cells(
-        df_census_households_grid
     )
 
     return df_census_households_grid
@@ -1376,6 +1365,12 @@ def houseprofiles_in_census_cells():
 
     # Query census household grid data with family type
     df_census_households_grid = get_census_households_grid()
+
+    # fill cells with missing household distribution values but population
+    # by hh distribution value of random cell with same population value
+    df_census_households_grid = fill_missing_hh_in_populated_cells(
+        df_census_households_grid
+    )
 
     # Refine census household grid data with additional NUTS-1 level attributes
     df_census_households_grid_refined = refine_census_data_at_cell_level(

--- a/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
@@ -691,7 +691,7 @@ def process_nuts1_census_data(df_census_households_raw):
     return df_census_households
 
 
-def fill_missing_hh_in_populated_cells(df_census_households_grid):
+def impute_missing_hh_in_populated_cells(df_census_households_grid):
     """There are cells without household data but a population. A randomly
     chosen household distribution is taken from a subgroup of cells with same
     population value and applied to all cells with missing household
@@ -1368,7 +1368,7 @@ def houseprofiles_in_census_cells():
 
     # fill cells with missing household distribution values but population
     # by hh distribution value of random cell with same population value
-    df_census_households_grid = fill_missing_hh_in_populated_cells(
+    df_census_households_grid = impute_missing_hh_in_populated_cells(
         df_census_households_grid
     )
 


### PR DESCRIPTION
Fixes #431 . 

We decided to go for a random choice distribution within subgroups of specific population.
All cells which have a specific population value and no household distribution data, will get the same household distribution applied which is taken from a random cell with the same population value.

## Before merging into `dev`-branch, please make sure that

- [x] the `CHANGELOG.rst` was updated.
- [x] new and adjusted code is formated using `black` and `isort`.
- [x] the `Dataset`-version is updated when existing datasets are adjusted. 
- [x] the branch was merged into the `continuous-integration/run-everything-over-the-weekend`- branch.
- [x] the workflow is running successful in `test mode`.
- [x] the workflow is running successful in `Everything` mode.

