### PR TITLE
Fixes/#645 missing generators timeseries in etrago tables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -402,3 +402,5 @@ Bug fixes
   `#610 <https://github.com/openego/eGon-data/issues/610>`_
 * H2 steel tanks are removed again from saltcavern storage
   `#621 <https://github.com/openego/eGon-data/issues/621>`_
+* Timeseries not deleted from grid.etrago_generator_timeseries
+  `#645 <https://github.com/openego/eGon-data/issues/645>`_

--- a/src/egon/data/datasets/fill_etrago_gen.py
+++ b/src/egon/data/datasets/fill_etrago_gen.py
@@ -11,7 +11,7 @@ class Egon_etrago_gen(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="etrago_generators",
-            version="0.0.4",
+            version="0.0.5",
             dependencies=dependencies,
             tasks=(fill_etrago_generators,),
         )
@@ -23,7 +23,7 @@ def fill_etrago_generators():
     cfg = egon.data.config.datasets()["generators_etrago"]
 
     # Delete power plants from previous iterations of this script
-    delete_previuos_gen(cfg)
+    delete_previuos_gen(cfg, con)
 
     # Load required tables
     (
@@ -141,14 +141,7 @@ def fill_etrago_gen_time_table(
     etrago_pp_time = etrago_pp_time.drop(columns="generator_id")
     etrago_pp_time["p_max_pu"] = etrago_pp_time["p_max_pu"].apply(list)
     etrago_pp_time["temp_id"] = 1
-    '''
-    db.execute_sql(
-        f"""DELETE FROM 
-                   {cfg['targets']['etrago_gen_time']['schema']}.
-                   {cfg['targets']['etrago_gen_time']['table']}
-                   """
-    )
-    '''
+
     etrago_pp_time.to_sql(
         name=f"{cfg['targets']['etrago_gen_time']['table']}",
         schema=f"{cfg['targets']['etrago_gen_time']['schema']}",
@@ -232,7 +225,8 @@ def adjust_renew_feedin_table(renew_feedin, cfg):
     return renew_feedin
 
 
-def delete_previuos_gen(cfg):
+def delete_previuos_gen(cfg, con):
+    '''
     db.execute_sql(
         f"""DELETE FROM 
                    {cfg['targets']['etrago_generators']['schema']}.
@@ -247,7 +241,15 @@ def delete_previuos_gen(cfg):
                        AND carrier = 'AC')
                    """
     )
+    
 
+    db.execute_sql(
+        f"""DELETE FROM 
+                   {cfg['targets']['etrago_gen_time']['schema']}.
+                   {cfg['targets']['etrago_gen_time']['table']}
+                   """
+    )
+    '''
 
 def set_timeseries(power_plants, renew_feedin):
     def timeseries(pp):

--- a/src/egon/data/datasets/fill_etrago_gen.py
+++ b/src/egon/data/datasets/fill_etrago_gen.py
@@ -30,7 +30,7 @@ def fill_etrago_generators():
         etrago_gen_orig,
         pp_time,
     ) = load_tables(con, cfg)
-    
+
     # Delete power plants from previous iterations of this script
     delete_previuos_gen(cfg, con, etrago_gen_orig, power_plants)
 
@@ -225,14 +225,16 @@ def adjust_renew_feedin_table(renew_feedin, cfg):
     return renew_feedin
 
 
-def delete_previuos_gen(cfg, con, etrago_gen_orig, power_plants ):
+def delete_previuos_gen(cfg, con, etrago_gen_orig, power_plants):
     gen_to_delete = []
-    
+
     for i, gen in etrago_gen_orig.iterrows():
-        if ((power_plants['bus_id'] == gen['bus']) &
-        (power_plants['carrier'] == gen['carrier'])).any():
-            gen_to_delete.append(str(gen['generator_id']))
-        
+        if (
+            (power_plants["bus_id"] == gen["bus"])
+            & (power_plants["carrier"] == gen["carrier"])
+        ).any():
+            gen_to_delete.append(str(gen["generator_id"]))
+
     if gen_to_delete:
         db.execute_sql(
             f"""DELETE FROM 
@@ -246,7 +248,7 @@ def delete_previuos_gen(cfg, con, etrago_gen_orig, power_plants ):
                         AND carrier = 'AC')
                     """
         )
-        
+
         db.execute_sql(
             f"""DELETE FROM 
                     {cfg['targets']['etrago_gen_time']['schema']}.

--- a/src/egon/data/datasets/fill_etrago_gen.py
+++ b/src/egon/data/datasets/fill_etrago_gen.py
@@ -141,14 +141,14 @@ def fill_etrago_gen_time_table(
     etrago_pp_time = etrago_pp_time.drop(columns="generator_id")
     etrago_pp_time["p_max_pu"] = etrago_pp_time["p_max_pu"].apply(list)
     etrago_pp_time["temp_id"] = 1
-
+    '''
     db.execute_sql(
         f"""DELETE FROM 
                    {cfg['targets']['etrago_gen_time']['schema']}.
                    {cfg['targets']['etrago_gen_time']['table']}
                    """
     )
-
+    '''
     etrago_pp_time.to_sql(
         name=f"{cfg['targets']['etrago_gen_time']['table']}",
         schema=f"{cfg['targets']['etrago_gen_time']['schema']}",


### PR DESCRIPTION
Fixes # 645. 

## Before merging into `dev`-branch, please make sure that

- [X] the `CHANGELOG.rst` was updated.
- [X] new and adjusted code is formated using `black` and `isort`.
- [X] the `Dataset`-version is updated when existing datasets are adjusted. 
- [X] the branch was merged into the `continuous-integration/run-everything-over-the-weekend-v2`- branch.
- [X] the workflow is running successfully in `test mode`.
- [x] the workflow is running successfully in `Everything` mode.

