### PR TITLE
Fix function to get scaled hh profiles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -413,3 +413,5 @@ Bug fixes
   `#610 <https://github.com/openego/eGon-data/issues/610>`_
 * H2 steel tanks are removed again from saltcavern storage
   `#621 <https://github.com/openego/eGon-data/issues/621>`_
+* Fix function to get scaled hh profiles
+  `#674 <https://github.com/openego/eGon-data/issues/674>`_

--- a/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
@@ -1696,11 +1696,15 @@ def get_scaled_profiles_from_db(
          * 2050
 
     aggregate: bool
-        If True, all profiles are summed
+        If True, all profiles are summed. This uses a lot of RAM if a high
+        attribute level is chosen
 
     peak_load_only: bool
         If True, only peak load value is returned
 
+    Notes
+    -----
+    aggregate option can use a lot of RAM if many profiles are selected
 
     See Also
     --------

--- a/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
@@ -1554,10 +1554,6 @@ def get_houseprofiles_in_census_cells():
         census_profile_mapping = pd.read_sql(
             q.statement, q.session.bind, index_col="cell_id"
         )
-    # Cast profiles ids to tuple of type and int
-    # census_profile_mapping["cell_profile_ids"] = census_profile_mapping[
-    #     "cell_profile_ids"
-    # ].apply(lambda x: [(cat, int(profile_id)) for cat, profile_id in x])
 
     return census_profile_mapping
 
@@ -1637,10 +1633,6 @@ def get_cell_demand_metadata_from_db(attribute, list_of_identifiers):
     cell_demand_metadata = pd.read_sql(
         cells_query.statement, cells_query.session.bind, index_col="cell_id"
     )
-    # Cast profiles ids to tuple of type and int
-    # cell_demand_metadata["cell_profile_ids"] = cell_demand_metadata[
-    #     "cell_profile_ids"
-    # ].apply(lambda x: [(cat, int(profile_id)) for cat, profile_id in x])
     return cell_demand_metadata
 
 

--- a/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
@@ -1695,7 +1695,7 @@ def get_scaled_profiles_from_db(
     profile_ids = cell_demand_metadata.cell_profile_ids.sum()
 
     df_iee_profiles = get_hh_profiles_from_db(profile_ids)
-    df_iee_profiles = set_multiindex_to_profiles(df_iee_profiles)
+    # df_iee_profiles = set_multiindex_to_profiles(df_iee_profiles)
 
     scaled_profiles = get_load_timeseries(
         df_iee_profiles=df_iee_profiles,

--- a/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
@@ -102,9 +102,17 @@ the number of categories of cell-level household data.
  nuts3-level the impact at a higher aggregation level is negligible.
  For sake of simplicity, the data is not corrected.
 * There are cells without household data but a population. A randomly chosen
- household distribution is taken from a subgroup of cells with same population value and
- applied to all cells with missing household distribution and the specific
- population value.
+ household distribution is taken from a subgroup of cells with same population
+ value and applied to all cells with missing household distribution and the
+ specific population value.
+
+Helper functions
+----
+* To access the DB, select specific profiles at various aggregation levels
+use:func:`get_hh_profiles_from_db'
+* To access the DB, select specific profiles at various aggregation levels
+and scale profiles use :func:`get_scaled_profiles_from_db`
+
 
 Notes
 -----
@@ -1706,9 +1714,6 @@ def get_scaled_profiles_from_db(
     -----
     aggregate option can use a lot of RAM if many profiles are selected
 
-    See Also
-    --------
-    :func:`houseprofiles_in_census_cells`
 
     Returns
     -------

--- a/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
@@ -1319,6 +1319,7 @@ def get_load_timeseries(
     df_hh_profiles_in_census_cells,
     cell_ids,
     year,
+    aggregate=True,
     peak_load_only=False,
 ):
     """
@@ -1344,6 +1345,8 @@ def get_load_timeseries(
     year: int
         Scenario year. Is used to consider the scaling factor for aligning
         annual demand to NUTS-3 data.
+    aggregate: bool
+        If true, all profiles are aggregated
     peak_load_only: bool
         If true, only the peak load value is returned (the type of the return
         value is `float`). Defaults to False which returns the entire time
@@ -1356,9 +1359,12 @@ def get_load_timeseries(
         series in MWh.
     """
     timesteps = len(df_iee_profiles)
-    full_load = pd.Series(
-        data=np.zeros(timesteps), dtype=np.float64, index=range(timesteps)
-    )
+    if aggregate:
+        full_load = pd.Series(
+            data=np.zeros(timesteps), dtype=np.float64, index=range(timesteps)
+        )
+    else:
+        full_load = pd.DataFrame(index=range(timesteps))
     load_area_meta = df_hh_profiles_in_census_cells.loc[
         cell_ids, ["cell_profile_ids", "nuts3", f"factor_{year}"]
     ]
@@ -1367,12 +1373,24 @@ def get_load_timeseries(
     for (nuts3, factor), df in load_area_meta.groupby(
         by=["nuts3", f"factor_{year}"]
     ):
-        part_load = (
-            df_iee_profiles.loc[:, df["cell_profile_ids"].sum()].sum(axis=1)
-            * factor
-            / 1e6
-        )  # from Wh to MWh
-        full_load = full_load.add(part_load)
+        if aggregate:
+            part_load = (
+                df_iee_profiles.loc[:,
+                df["cell_profile_ids"].sum()].sum(axis=1)
+                * factor
+                / 1e6
+            )  # from Wh to MWh
+            full_load = full_load.add(part_load)
+        elif not aggregate:
+            part_load = (
+                df_iee_profiles.loc[:, df["cell_profile_ids"].sum()]
+                * factor
+                / 1e6
+            )  # from Wh to MWh
+            full_load = pd.concat(
+                [full_load, part_load], axis=1).dropna(axis=1)
+        else:
+            raise KeyError("Parameter 'aggregate' needs to be bool value!")
     if peak_load_only:
         full_load = full_load.max()
     return full_load
@@ -1656,7 +1674,7 @@ def get_hh_profiles_from_db(profile_ids):
 
 
 def get_scaled_profiles_from_db(
-    attribute, list_of_identifiers, year, peak_load_only=False
+    attribute, list_of_identifiers, year, aggregate=True, peak_load_only=False
 ):
     """Retrieve selection of scaled household electricity demand profiles
 
@@ -1673,11 +1691,16 @@ def get_scaled_profiles_from_db(
         nuts3/nuts1 need to be str
         cell_id need to be int
 
-     year: int
+    year: int
          * 2035
          * 2050
 
+    aggregate: bool
+        If True, all profiles are summed
+
     peak_load_only: bool
+        If True, only peak load value is returned
+
 
     See Also
     --------
@@ -1695,13 +1718,13 @@ def get_scaled_profiles_from_db(
     profile_ids = cell_demand_metadata.cell_profile_ids.sum()
 
     df_iee_profiles = get_hh_profiles_from_db(profile_ids)
-    # df_iee_profiles = set_multiindex_to_profiles(df_iee_profiles)
 
     scaled_profiles = get_load_timeseries(
         df_iee_profiles=df_iee_profiles,
         df_hh_profiles_in_census_cells=cell_demand_metadata,
         cell_ids=cell_demand_metadata.index.to_list(),
         year=year,
+        aggregate=aggregate,
         peak_load_only=peak_load_only,
     )
     return scaled_profiles

--- a/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/hh_profiles.py
@@ -1588,6 +1588,9 @@ def get_cell_demand_metadata_from_db(attribute, list_of_identifiers):
     if attribute not in attribute_options:
         raise ValueError(f"attribute has to be one of: {attribute_options}")
 
+    if not isinstance(list_of_identifiers, list):
+        raise KeyError("'list_of_identifiers' is not a list!")
+
     # Query profile ids and scaling factors for specific attributes
     with db.session_scope() as session:
         if attribute == "nuts3":
@@ -1704,7 +1707,7 @@ def get_scaled_profiles_from_db(
 
     Notes
     -----
-    aggregate option can use a lot of RAM if many profiles are selected
+    Aggregate == False option can use a lot of RAM if many profiles are selected
 
 
     Returns


### PR DESCRIPTION
Fixes #673  . 

The option to not aggregate the profiles is added.


This is not an active function which is used in any pipeline task. Therefore the workflow doesn't need to be tested

## Before merging into `dev`-branch, please make sure that

- [x] the `CHANGELOG.rst` was updated.
- [x] new and adjusted code is formated using `black` and `isort`.
- [ ] the `Dataset`-version is updated when existing datasets are adjusted. 
- [ ] the branch was merged into the `continuous-integration/run-everything-over-the-weekend-v2`- branch.
- [ ] the workflow is running successful in `test mode`.
- [ ] the workflow is running successful in `Everything` mode.

