### PR TITLE
Distribute rural heat supply to residential and service demands

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -419,3 +419,5 @@ Bug fixes
   `#674 <https://github.com/openego/eGon-data/issues/674>`_
 * Change order of pypsa-eur-sec and scenario-capacities
   `#589 <https://github.com/openego/eGon-data/issues/589>`_
+* Distribute rural heat supply to residetntial and service demands
+  `#679 <https://github.com/openego/eGon-data/issues/679>`_

--- a/src/egon/data/datasets/heat_supply/__init__.py
+++ b/src/egon/data/datasets/heat_supply/__init__.py
@@ -160,7 +160,7 @@ class HeatSupply(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="HeatSupply",
-            version="0.0.4",
+            version="0.0.5",
             dependencies=dependencies,
             tasks=(
                 create_tables,

--- a/src/egon/data/datasets/heat_supply/individual_heating.py
+++ b/src/egon/data/datasets/heat_supply/individual_heating.py
@@ -166,7 +166,6 @@ def cascade_heat_supply_indiv(scenario, distribution_level, plotting=True):
         {sources['mv_grids']['table']} d
         ON d.bus_id = c.bus_id
         WHERE scenario = '{scenario}'
-        AND sector = 'residential'
         AND a.zensus_population_id NOT IN (
             SELECT zensus_population_id
             FROM {sources['map_dh']['schema']}.{sources['map_dh']['table']}


### PR DESCRIPTION
Fixes #679  . 

This branch fixes problem with isolated rural_heat buses (e.g. close to Brunsbüttel) which only have a service heat demand but no residential heat demand. 

## Before merging into `dev`-branch, please make sure that

- [x] the `CHANGELOG.rst` was updated.
- [x] new and adjusted code is formated using `black` and `isort`.
- [x] the `Dataset`-version is updated when existing datasets are adjusted. 
- [x] the branch was merged into the `continuous-integration/run-everything-over-the-weekend-v2`- branch.
- [x] the workflow is running successful in `test mode`.
- [x] the workflow is running successful in `Everything` mode.

