### PR TITLE
neighbor lines get global scenario specific lifetime parameter

### DIFF
--- a/src/egon/data/datasets/pypsaeursec/__init__.py
+++ b/src/egon/data/datasets/pypsaeursec/__init__.py
@@ -18,6 +18,7 @@ from egon.data import __path__, db
 from egon.data.datasets import Dataset
 import egon.data.config
 import egon.data.subprocess as subproc
+from egon.data.datasets.scenario_parameters import get_sector_parameters
 
 
 def run_pypsa_eur_sec():
@@ -522,6 +523,10 @@ def neighbor_reduction():
             .rename_geometry("topo")
             .set_crs(4326)
         )
+        
+        neighbor_lines["lifetime"] = get_sector_parameters("electricity", scn)[
+            "lifetime"
+        ]        
 
         neighbor_lines.to_postgis(
             "egon_etrago_line",


### PR DESCRIPTION
Fixes # . 

## Before merging into `dev`-branch, please make sure that

- [ ] the `CHANGELOG.rst` was updated.
- [ ] new and adjusted code is formated using `black` and `isort`.
- [ ] the `Dataset`-version is updated when existing datasets are adjusted. 
- [ ] the branch was merged into the `continuous-integration/run-everything-over-the-weekend-v2`- branch.
- [ ] the workflow is running successful in `test mode`.
- [ ] the workflow is running successful in `Everything` mode.

@ClaraBuettner can you test it? - maybe after you added the eGon100RE values in the scenario parameter table (i.e.  #699 )- because like this it will throw an error for that scenario 