### PR TITLE
Share "/dev/shm" between host and container

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -190,8 +190,10 @@ Added
 * Add efficiency, capital_cost and marginal_cost to gas related data in
   etrago tables `#596 <https://github.com/openego/eGon-data/issues/596>`_
 
-
 .. _PR #159: https://github.com/openego/eGon-data/pull/159
+.. _PR #703: https://github.com/openego/eGon-data/pull/703
+.. _#702: https://github.com/openego/eGon-data/issues/702
+.. _#267: https://github.com/openego/eGon-data/issues/267
 
 
 Changed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -189,6 +189,15 @@ Added
   `#566 <https://github.com/openego/eGon-data/issues/566>`_
 * Add efficiency, capital_cost and marginal_cost to gas related data in
   etrago tables `#596 <https://github.com/openego/eGon-data/issues/596>`_
+* The shared memory under `"/dev/shm"` is now shared between host and
+  container. This was done because Docker has a rather tiny default for
+  the size of `"/dev/shm"` which caused random problems. Guessing what
+  size is correct is also not a good idea, so sharing between host and
+  container seems like the best option. This restricts using `egon-data`
+  with docker to Linux and MacOS, if the latter has `"/dev/shm"` but
+  seems like the best course of action for now. Done via `PR #703`_ and
+  hopefully prevents issues `#702`_ and `#267`_ from ever occurring
+  again.
 
 .. _PR #159: https://github.com/openego/eGon-data/pull/159
 .. _PR #703: https://github.com/openego/eGon-data/pull/703

--- a/src/egon/data/airflow/docker-compose.yml
+++ b/src/egon/data/airflow/docker-compose.yml
@@ -16,3 +16,4 @@ services:
       POSTGRES_PASSWORD: {--database-password}
     volumes:
     - ./database-data/:/var/lib/postgresql/data
+    - /dev/shm:/dev/shm


### PR DESCRIPTION
Make the Docker container use the host's "/dev/shm" by using a ["bind mount"][2] under the service's [`volumes`][3] key in the compose file.

[2]: https://docs.docker.com/storage/bind-mounts/
[3]: https://docs.docker.com/compose/compose-file/compose-file-v3/#volumes

Checking free space on the container for the weekend run using `docker exec weekend-run-container df -h`, we get

```
Filesystem                         Size  Used Avail Use% Mounted on
shm                                 64M   16K   64M   1% /dev/shm
```

without this fix applied and

```
Filesystem                         Size  Used Avail Use% Mounted on
tmpfs                              158G   32K  158G   1% /dev/shm
```

with the commit, so this looks like it fixes #702. It should also fix #267 .

## Before merging into `dev`, please make sure that:

- [x] The `CHANGELOG.rst` was updated.
- [x] New and adjusted code is formated using `black` and `isort`.
- [x] The `Dataset`-version is updated when existing datasets are adjusted. 
- [x] The branch was merged into the `continuous-integration/run-everything-over-the-weekend-v2`-branch.
- [x] The workflow is running successful in `Schleswig-Holstein` mode.
- [x] The workflow is running successful in `Everything` mode.

