### PR TITLE
Features/#514 catch unique violation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -191,6 +191,8 @@ Added
   etrago tables `#596 <https://github.com/openego/eGon-data/issues/596>`_
 * Add wind onshore farms for the eGon100RE scenario
   `#690 <https://github.com/openego/eGon-data/issues/690>`_
+* Provide wrapper to catch DB unique violation
+  `#514 <https://github.com/openego/eGon-data/issues/514>`_
 
 .. _PR #159: https://github.com/openego/eGon-data/pull/159
 

--- a/src/egon/data/db.py
+++ b/src/egon/data/db.py
@@ -1,15 +1,15 @@
+from contextlib import contextmanager
 import codecs
 import functools
-from contextlib import contextmanager
 
+from psycopg2.errors import UniqueViolation
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
 import geopandas as gpd
 import pandas as pd
-from egon.data import config
-from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker
 
-from sqlalchemy.exc import IntegrityError
-from psycopg2.errors import UniqueViolation
+from egon.data import config
 
 
 def credentials():
@@ -85,8 +85,10 @@ def submit_comment(json, schema, table):
     """
     prefix_str = "COMMENT ON TABLE {0}.{1} IS ".format(schema, table)
 
-    check_json_str = "SELECT obj_description('{0}.{1}'::regclass)::json".format(
-        schema, table
+    check_json_str = (
+        "SELECT obj_description('{0}.{1}'::regclass)::json".format(
+            schema, table
+        )
     )
 
     execute_sql(prefix_str + json + ";")
@@ -160,7 +162,7 @@ def session_scoped(function):
 
 
 def select_dataframe(sql, index_col=None):
-    """ Select data from local database as pandas.DataFrame
+    """Select data from local database as pandas.DataFrame
 
     Parameters
     ----------
@@ -185,7 +187,7 @@ def select_dataframe(sql, index_col=None):
 
 
 def select_geodataframe(sql, index_col=None, geom_col="geom", epsg=3035):
-    """ Select data from local database as geopandas.GeoDataFrame
+    """Select data from local database as geopandas.GeoDataFrame
 
     Parameters
     ----------
@@ -219,7 +221,7 @@ def select_geodataframe(sql, index_col=None, geom_col="geom", epsg=3035):
 
 
 def next_etrago_id(component):
-    """ Select next id value for components in etrago tables
+    """Select next id value for components in etrago tables
 
     Parameters
     ----------
@@ -237,10 +239,10 @@ def next_etrago_id(component):
     :func:`check_db_unique_violation` instead.
     """
 
-    if component=='transformer':
-        id_column = 'trafo_id'
+    if component == "transformer":
+        id_column = "trafo_id"
     else:
-        id_column = f'{component}_id'
+        id_column = f"{component}_id"
 
     max_id = select_dataframe(
         f"""
@@ -314,6 +316,7 @@ def check_db_unique_violation(func):
     loop will not terminate until the error is resolved! In case of eTraGo
     tables you can use :func:`next_etrago_id`, see example above.
     """
+
     def commit(*args, **kwargs):
         unique_violation = True
         ret = None

--- a/src/egon/data/db.py
+++ b/src/egon/data/db.py
@@ -8,6 +8,9 @@ from egon.data import config
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
+from sqlalchemy.exc import IntegrityError
+from psycopg2.errors import UniqueViolation
+
 
 def credentials():
     """Return local database connection parameters.
@@ -221,13 +224,17 @@ def next_etrago_id(component):
     Parameters
     ----------
     component : str
-        Name of componenet
+        Name of component
 
     Returns
     -------
     next_id : int
         Next index value
 
+    Notes
+    -----
+    To catch concurrent DB commits, consider to use
+    :func:`check_db_unique_violation` instead.
     """
 
     if component=='transformer':
@@ -247,3 +254,84 @@ def next_etrago_id(component):
         next_id = 1
 
     return next_id
+
+
+def check_db_unique_violation(func):
+    """Wrapper to catch psycopg's UniqueViolation errors during concurrent DB
+    commits.
+
+    Preferrably used with :func:`next_etrago_id`. Retries DB operation 10
+    times before raising original exception.
+
+    Can be used as a decorator like this:
+
+    >>> @check_db_unique_violation
+    ... def commit_something_to_database():
+    ...     # commit something here
+    ...
+    >>> commit_something_to_database()
+
+    Examples
+    --------
+    Add new bus to eTraGo's bus table:
+
+    >>> from egon.data import db
+    ... from egon.data.datasets.etrago_setup import EgonPfHvBus
+    ...
+    ... @check_db_unique_violation
+    ... def add_etrago_bus():
+    ...     bus_id = db.next_etrago_id("bus")
+    ...     with db.session_scope() as session:
+    ...         emob_bus_id = db.next_etrago_id("bus")
+    ...         session.add(
+    ...             EgonPfHvBus(
+    ...                 scn_name="eGon2035",
+    ...                 bus_id=bus_id,
+    ...                 v_nom=1,
+    ...                 carrier="whatever",
+    ...                 x=52,
+    ...                 y=13,
+    ...                 geom="<some_geom>"
+    ...             )
+    ...         )
+    ...         session.commit()
+    ...
+    >>> add_etrago_bus()
+
+    Parameters
+    ----------
+
+    func: func
+        Function to wrap
+
+    Notes
+    -----
+    Background: using :func:`next_etrago_id` may cause trouble if tasks are
+    executed simultaneously, cf.
+    https://github.com/openego/eGon-data/issues/514
+
+    Important: your function requires a way to escape the violation as the
+    loop will not terminate until the error is resolved! In case of eTraGo
+    tables you can use :func:`next_etrago_id`, see example above.
+    """
+    def commit(*args, **kwargs):
+        unique_violation = True
+        ret = None
+        ctr = 0
+        while unique_violation:
+            try:
+                ret = func(*args, **kwargs)
+            except IntegrityError as e:
+                if isinstance(e.orig, UniqueViolation):
+                    print("Entry is not unique, retrying...")
+                    ctr += 1
+                    if ctr > 10:
+                        print("No success after 10 retries, exiting...")
+                        raise e
+                else:
+                    raise e
+            else:
+                unique_violation = False
+        return ret
+
+    return commit


### PR DESCRIPTION
Fixes #514 . 

As discussed in #514 `next_etrago_id()` might cause trouble, if tasks are executed simultaneously. In most cases when using bulk-write operations that's probably not an issue but when a task runs for a long time with periodic write operations, interferences with parallel tasks are more likely to occur.

Therefore, this PR introduces a new wrapper `db.check_db_unique_violation()` to catch UniqueViolation errors.

Details on usage see docstring of wrapper.

I'd appreciate if you could test it with the snippets below, one reviewer is sufficient.

## Example snippets for testing

**Header**

```python
import numpy as np
import pandas as pd
import geopandas as gpd

import egon.data.config
from egon.data import db
from egon.data.datasets.etrago_setup import EgonPfHvBus
from sqlalchemy import delete

engine = db.engine()

# ========== Register np datatypes with SQLA ==========
from psycopg2.extensions import register_adapter, AsIs

def adapt_numpy_float64(numpy_float64):
    return AsIs(numpy_float64)
def adapt_numpy_int64(numpy_int64):
    return AsIs(numpy_int64)

register_adapter(np.float64, adapt_numpy_float64)
register_adapter(np.int64, adapt_numpy_int64)
# =====================================================

bus_id = 1214
scenario_name = "eGon2035"
```

**Fail test**

```python
@db.check_db_unique_violation
def write_to_db() -> None:
    """Write model data to eTraGo tables"""
    with db.session_scope() as session:
        # Get eTraGo substation bus
        query = session.query(
            EgonPfHvBus.scn_name,
            EgonPfHvBus.bus_id,
            EgonPfHvBus.x,
            EgonPfHvBus.y,
            EgonPfHvBus.geom
        ).filter(
            EgonPfHvBus.scn_name == scenario_name,
            EgonPfHvBus.bus_id == bus_id,
        )
        etrago_bus = query.first()

        # eMob MIT bus
        emob_bus_id = 1   # <- ID ALREADY EXISTS
        session.add(
            EgonPfHvBus(
                scn_name=scenario_name,
                bus_id=emob_bus_id,
                v_nom=1,
                carrier="eMob MIT",
                x=etrago_bus.x,
                y=etrago_bus.y,
                geom=etrago_bus.geom
            )
        )
        session.commit()
        
write_to_db()
```

**Successful test**
(only differs in automatic obtainment of `emob_bus_id`)
```python
@db.check_db_unique_violation
def write_to_db() -> None:
    """Write model data to eTraGo tables"""
    with db.session_scope() as session:
        # Get eTraGo substation bus
        query = session.query(
            EgonPfHvBus.scn_name,
            EgonPfHvBus.bus_id,
            EgonPfHvBus.x,
            EgonPfHvBus.y,
            EgonPfHvBus.geom
        ).filter(
            EgonPfHvBus.scn_name == scenario_name,
            EgonPfHvBus.bus_id == bus_id,
        )
        etrago_bus = query.first()

        # eMob MIT bus
        emob_bus_id = db.next_etrago_id("bus")   # <- OBTAIN NEW ID
        session.add(
            EgonPfHvBus(
                scn_name=scenario_name,
                bus_id=emob_bus_id,
                v_nom=1,
                carrier="eMob MIT",
                x=etrago_bus.x,
                y=etrago_bus.y,
                geom=etrago_bus.geom
            )
        )
        session.commit()
        
    return emob_bus_id
        
id_of_created_bus = write_to_db()
```

**(Delete created entry)**
```python
with db.session_scope() as session:
    session.execute(delete(EgonPfHvBus).where(EgonPfHvBus.bus_id == id_of_created_bus))
```

## Before merging into `dev`-branch, please make sure that
- [x] the `CHANGELOG.rst` was updated.
- [x] new and adjusted code is formated using `black` and `isort`.
- [x] the branch was merged into the `continuous-integration/run-everything-over-the-weekend-v2`- branch.
