### PR TITLE
Pinned black versions to avoid dependeny and pre-commit issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,12 +14,12 @@ repos:
     rev: 5.8.0
     hooks:
       - id: isort
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        language_version: python3 # Should be a command that runs python3.6+
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.0
     hooks:
       - id: flake8
-  - repo: https://github.com/psf/black
-    rev: 20.8b1
-    hooks:
-      - id: black
-        language_version: python3 # Should be a command that runs python3.6+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -524,6 +524,10 @@ Bug Fixes
   `#748 <https://github.com/openego/eGon-data/issues/748>`_
 * Add missing dependency to heat_etrago
   `#771 <https://github.com/openego/eGon-data/issues/771>`_
+* Pinned and updated :code:`black` versions to avoid dependency
+  issues when installaing eGon-data and version issues when running
+  the pre-commit hooks
+  `#770 <https://github.com/openego/eGon-data/issues/770>`_
 
 .. _PR #692: https://github.com/openego/eGon-data/pull/692
 .. _#343: https://github.com/openego/eGon-data/issues/343

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,14 @@ setup(
         "xlrd",
     ],
     extras_require={
-        "dev": ["black", "flake8", "isort>=5", "pre-commit", "pytest", "tox"]
+        "dev": [
+            "black==21.12b0",
+            "flake8",
+            "isort>=5",
+            "pre-commit",
+            "pytest",
+            "tox",
+        ]
         # eg:
         #   'rst': ['docutils>=0.11'],
         #   ':python_version=="2.6"': ['argparse'],


### PR DESCRIPTION
Fixes #770 .

## Before merging into `dev`-branch, please make sure that

- [x] the `CHANGELOG.rst` was updated.
- [x] new and adjusted code is formated using `black` and `isort`.
- [ ] ~~the `Dataset`-version is updated when existing datasets are adjusted.~~
- [ ] ~~the branch was merged into the
      `continuous-integration/run-everything-over-the-weekend`-branch.~~
- [ ] ~~the workflow is running successful in `test mode`.~~
- [ ] ~~the workflow is running successful in `Everything` mode.~~
