### PR TITLE
Add extendable battries only to buses representing a substation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -556,6 +556,8 @@ Bug Fixes
   `#849 <https://github.com/openego/eGon-data/issues/849>`_
 * Fix final demand of heat demand timeseries
   `#781 <https://github.com/openego/eGon-data/issues/781>`_
+* Add extendable batteries only to buses at substations
+  `#852 <https://github.com/openego/eGon-data/issues/852>`_
 
 .. _PR #692: https://github.com/openego/eGon-data/pull/692
 .. _#343: https://github.com/openego/eGon-data/issues/343

--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -939,6 +939,12 @@ storage_etrago:
     bus:
       table: 'egon_etrago_bus'
       schema: 'grid'
+    ehv-substation:
+      table: 'egon_ehv_substation'
+      schema: 'grid'
+    hv-substation:
+      table: 'egon_hvmv_substation'
+      schema: 'grid'
   targets:
     storage:
       schema: 'grid'

--- a/src/egon/data/datasets/storages_etrago/__init__.py
+++ b/src/egon/data/datasets/storages_etrago/__init__.py
@@ -17,7 +17,7 @@ class StorageEtrago(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="StorageEtrago",
-            version="0.0.6",
+            version="0.0.7",
             dependencies=dependencies,
             tasks=(insert_PHES, extendable_batteries),
         )
@@ -104,10 +104,11 @@ def extendable_batteries_per_scenario(scenario):
         {sources['bus']['table']}
         WHERE carrier = 'AC'
         AND scn_name = '{scenario}'
-        AND bus_id IN (SELECT bus_id
-                       FROM {sources['bus']['schema']}.{sources['bus']['table']}
-                       WHERE scn_name = '{scenario}'
-                       AND country = 'DE')
+        AND (bus_id IN (SELECT bus_id
+                       FROM {sources['ehv-substation']['schema']}.{sources['ehv-substation']['table']})
+        OR bus_id IN (SELECT bus_id
+                       FROM {sources['hv-substation']['schema']}.{sources['hv-substation']['table']}
+        ))
         """
     )
 


### PR DESCRIPTION
Fixes #852  .

## Before merging into `dev`-branch, please make sure that

- [x] the `CHANGELOG.rst` was updated.
- [x] new and adjusted code is formated using `black` and `isort`.
- [x] the `Dataset`-version is updated when existing datasets are adjusted.
- [x] the branch was merged into the
      `continuous-integration/run-everything-over-the-weekend`-branch.
- [x] the workflow is running successful in `test mode`.
- [x] the workflow is running successful in `Everything` mode.
