### PR TITLE
Fixes/#901 component ids in dsm cts ind processing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -573,6 +573,8 @@ Bug Fixes
   `#852 <https://github.com/openego/eGon-data/issues/852>`_
 * Temporarily set upper version limit for pandas
   `#829 <https://github.com/openego/eGon-data/issues/829>`_
+* Fix model id issues in DSM potentials for CTS and industry
+  `#901 <https://github.com/openego/eGon-data/issues/901>`_
 
 .. _PR #692: https://github.com/openego/eGon-data/pull/692
 .. _#343: https://github.com/openego/eGon-data/issues/343

--- a/src/egon/data/datasets/DSM_cts_ind.py
+++ b/src/egon/data/datasets/DSM_cts_ind.py
@@ -1,11 +1,12 @@
-import egon.data.config
-from egon.data import db
+import geopandas as gpd
 import numpy as np
 import pandas as pd
-import geopandas as gpd
+
+from egon.data import db
+from egon.data.datasets import Dataset
 from egon.data.datasets.electricity_demand.temporal import calc_load_curve
 from egon.data.datasets.industry.temporal import identify_bus
-from egon.data.datasets import Dataset
+import egon.data.config
 
 
 class dsm_Potential(Dataset):
@@ -442,16 +443,18 @@ def dsm_cts_ind_processing():
         bus_id = pd.Series(index=dsm_buses.index, dtype=int)
 
         # Get number of DSM buses for both scenarios
-        rows_per_scenario = dsm_buses.groupby(
-            "scn_name").count().original_bus.to_dict()
+        rows_per_scenario = (
+            dsm_buses.groupby("scn_name").count().original_bus.to_dict()
+        )
 
         # Assignment of DSM ids
-        bus_id.iloc[0:rows_per_scenario["eGon2035"]] = range(
-            dsm_id, dsm_id + rows_per_scenario["eGon2035"])
+        bus_id.iloc[0 : rows_per_scenario["eGon2035"]] = range(
+            dsm_id, dsm_id + rows_per_scenario["eGon2035"]
+        )
         bus_id.iloc[
-            rows_per_scenario["eGon2035"]:rows_per_scenario["eGon2035"] +
-            rows_per_scenario["eGon100RE"]] = range(
-            dsm_id, dsm_id + rows_per_scenario["eGon100RE"])
+            rows_per_scenario["eGon2035"] : rows_per_scenario["eGon2035"]
+            + rows_per_scenario["eGon100RE"]
+        ] = range(dsm_id, dsm_id + rows_per_scenario["eGon100RE"])
 
         dsm_buses["bus_id"] = bus_id
 
@@ -475,12 +478,13 @@ def dsm_cts_ind_processing():
         link_id = pd.Series(index=dsm_buses.index, dtype=int)
 
         # Assignment of link ids
-        link_id.iloc[0:rows_per_scenario["eGon2035"]] = range(
-            dsm_id, dsm_id + rows_per_scenario["eGon2035"])
+        link_id.iloc[0 : rows_per_scenario["eGon2035"]] = range(
+            dsm_id, dsm_id + rows_per_scenario["eGon2035"]
+        )
         link_id.iloc[
-            rows_per_scenario["eGon2035"]:rows_per_scenario["eGon2035"] +
-            rows_per_scenario["eGon100RE"]] = range(
-            dsm_id, dsm_id + rows_per_scenario["eGon100RE"])
+            rows_per_scenario["eGon2035"] : rows_per_scenario["eGon2035"]
+            + rows_per_scenario["eGon100RE"]
+        ] = range(dsm_id, dsm_id + rows_per_scenario["eGon100RE"])
 
         dsm_links["link_id"] = link_id
 
@@ -511,12 +515,13 @@ def dsm_cts_ind_processing():
         store_id = pd.Series(index=dsm_buses.index, dtype=int)
 
         # Assignment of store ids
-        store_id.iloc[0:rows_per_scenario["eGon2035"]] = range(
-            dsm_id, dsm_id + rows_per_scenario["eGon2035"])
+        store_id.iloc[0 : rows_per_scenario["eGon2035"]] = range(
+            dsm_id, dsm_id + rows_per_scenario["eGon2035"]
+        )
         store_id.iloc[
-            rows_per_scenario["eGon2035"]:rows_per_scenario["eGon2035"] +
-            rows_per_scenario["eGon100RE"]] = range(
-            dsm_id, dsm_id + rows_per_scenario["eGon100RE"])
+            rows_per_scenario["eGon2035"] : rows_per_scenario["eGon2035"]
+            + rows_per_scenario["eGon100RE"]
+        ] = range(dsm_id, dsm_id + rows_per_scenario["eGon100RE"])
 
         dsm_stores["store_id"] = store_id
 
@@ -593,20 +598,20 @@ def dsm_cts_ind_processing():
         df_dsm_stores.sort_values("scn_name", inplace=True)
 
         # select new bus_ids for aggregated buses and add to links and stores
-        bus_id = db.next_etrago_id("Bus") +  df_dsm_buses.index
+        bus_id = db.next_etrago_id("Bus") + df_dsm_buses.index
 
         df_dsm_buses["bus_id"] = bus_id
         df_dsm_links["dsm_bus"] = bus_id
         df_dsm_stores["bus"] = bus_id
 
         # select new link_ids for aggregated links
-        link_id = db.next_etrago_id("Link") +  df_dsm_links.index
+        link_id = db.next_etrago_id("Link") + df_dsm_links.index
 
         df_dsm_links["link_id"] = link_id
 
         # select new store_ids to aggregated stores
 
-        store_id = db.next_etrago_id("Store") +  df_dsm_stores.index
+        store_id = db.next_etrago_id("Store") + df_dsm_stores.index
 
         df_dsm_stores["store_id"] = store_id
 
@@ -747,7 +752,7 @@ def dsm_cts_ind_processing():
         # links
 
         sql = f"""DELETE FROM {targets["link_timeseries"]["schema"]}.{targets["link_timeseries"]["table"]} t
-        WHERE t.link_id IN 
+        WHERE t.link_id IN
                  (SELECT l.link_id FROM {targets["link"]["schema"]}.{targets["link"]["table"]} l
               WHERE l.carrier LIKE '{carrier}');"""
         db.execute_sql(sql)
@@ -758,7 +763,7 @@ def dsm_cts_ind_processing():
         # stores
 
         sql = f"""DELETE FROM {targets["store_timeseries"]["schema"]}.{targets["store_timeseries"]["table"]} t
-        WHERE t.store_id IN 
+        WHERE t.store_id IN
                  (SELECT s.store_id FROM {targets["store"]["schema"]}.{targets["store"]["table"]} s
               WHERE s.carrier LIKE '{carrier}');"""
         db.execute_sql(sql)

--- a/src/egon/data/datasets/DSM_cts_ind.py
+++ b/src/egon/data/datasets/DSM_cts_ind.py
@@ -448,13 +448,15 @@ def dsm_cts_ind_processing():
         )
 
         # Assignment of DSM ids
-        bus_id.iloc[0 : rows_per_scenario["eGon2035"]] = range(
-            dsm_id, dsm_id + rows_per_scenario["eGon2035"]
+        bus_id.iloc[0 : rows_per_scenario.get("eGon2035", 0)] = range(
+            dsm_id, dsm_id + rows_per_scenario.get("eGon2035", 0)
         )
         bus_id.iloc[
-            rows_per_scenario["eGon2035"] : rows_per_scenario["eGon2035"]
-            + rows_per_scenario["eGon100RE"]
-        ] = range(dsm_id, dsm_id + rows_per_scenario["eGon100RE"])
+            rows_per_scenario.get("eGon2035", 0) : rows_per_scenario.get(
+                "eGon2035", 0
+            )
+            + rows_per_scenario.get("eGon100RE", 0)
+        ] = range(dsm_id, dsm_id + rows_per_scenario.get("eGon100RE", 0))
 
         dsm_buses["bus_id"] = bus_id
 
@@ -478,13 +480,15 @@ def dsm_cts_ind_processing():
         link_id = pd.Series(index=dsm_buses.index, dtype=int)
 
         # Assignment of link ids
-        link_id.iloc[0 : rows_per_scenario["eGon2035"]] = range(
-            dsm_id, dsm_id + rows_per_scenario["eGon2035"]
+        link_id.iloc[0 : rows_per_scenario.get("eGon2035", 0)] = range(
+            dsm_id, dsm_id + rows_per_scenario.get("eGon2035", 0)
         )
         link_id.iloc[
-            rows_per_scenario["eGon2035"] : rows_per_scenario["eGon2035"]
-            + rows_per_scenario["eGon100RE"]
-        ] = range(dsm_id, dsm_id + rows_per_scenario["eGon100RE"])
+            rows_per_scenario.get("eGon2035", 0) : rows_per_scenario.get(
+                "eGon2035", 0
+            )
+            + rows_per_scenario.get("eGon100RE", 0)
+        ] = range(dsm_id, dsm_id + rows_per_scenario.get("eGon100RE", 0))
 
         dsm_links["link_id"] = link_id
 
@@ -515,13 +519,15 @@ def dsm_cts_ind_processing():
         store_id = pd.Series(index=dsm_buses.index, dtype=int)
 
         # Assignment of store ids
-        store_id.iloc[0 : rows_per_scenario["eGon2035"]] = range(
-            dsm_id, dsm_id + rows_per_scenario["eGon2035"]
+        store_id.iloc[0 : rows_per_scenario.get("eGon2035", 0)] = range(
+            dsm_id, dsm_id + rows_per_scenario.get("eGon2035", 0)
         )
         store_id.iloc[
-            rows_per_scenario["eGon2035"] : rows_per_scenario["eGon2035"]
-            + rows_per_scenario["eGon100RE"]
-        ] = range(dsm_id, dsm_id + rows_per_scenario["eGon100RE"])
+            rows_per_scenario.get("eGon2035", 0) : rows_per_scenario.get(
+                "eGon2035", 0
+            )
+            + rows_per_scenario.get("eGon100RE", 0)
+        ] = range(dsm_id, dsm_id + rows_per_scenario.get("eGon100RE", 0))
 
         dsm_stores["store_id"] = store_id
 

--- a/src/egon/data/datasets/DSM_cts_ind.py
+++ b/src/egon/data/datasets/DSM_cts_ind.py
@@ -440,12 +440,19 @@ def dsm_cts_ind_processing():
             max_id = 0
         dsm_id = max_id + 1
         bus_id = pd.Series(index=dsm_buses.index, dtype=int)
-        bus_id.iloc[0 : int((len(bus_id) / 2))] = range(
-            dsm_id, int((dsm_id + len(dsm_buses) / 2))
-        )
-        bus_id.iloc[int((len(bus_id) / 2)) : len(bus_id)] = range(
-            dsm_id, int((dsm_id + len(dsm_buses) / 2))
-        )
+
+        # Get number of DSM buses for both scenarios
+        rows_per_scenario = dsm_buses.groupby(
+            "scn_name").count().original_bus.to_dict()
+
+        # Assignment of DSM ids
+        bus_id.iloc[0:rows_per_scenario["eGon2035"]] = range(
+            dsm_id, dsm_id + rows_per_scenario["eGon2035"])
+        bus_id.iloc[
+            rows_per_scenario["eGon2035"]:rows_per_scenario["eGon2035"] +
+            rows_per_scenario["eGon100RE"]] = range(
+            dsm_id, dsm_id + rows_per_scenario["eGon100RE"])
+
         dsm_buses["bus_id"] = bus_id
 
         # add links from "orignal" buses to DSM-buses
@@ -466,12 +473,15 @@ def dsm_cts_ind_processing():
             max_id = 0
         dsm_id = max_id + 1
         link_id = pd.Series(index=dsm_buses.index, dtype=int)
-        link_id.iloc[0 : int((len(link_id) / 2))] = range(
-            dsm_id, int((dsm_id + len(dsm_links) / 2))
-        )
-        link_id.iloc[int((len(link_id) / 2)) : len(link_id)] = range(
-            dsm_id, int((dsm_id + len(dsm_links) / 2))
-        )
+
+        # Assignment of link ids
+        link_id.iloc[0:rows_per_scenario["eGon2035"]] = range(
+            dsm_id, dsm_id + rows_per_scenario["eGon2035"])
+        link_id.iloc[
+            rows_per_scenario["eGon2035"]:rows_per_scenario["eGon2035"] +
+            rows_per_scenario["eGon100RE"]] = range(
+            dsm_id, dsm_id + rows_per_scenario["eGon100RE"])
+
         dsm_links["link_id"] = link_id
 
         # add calculated timeseries to df to be returned
@@ -499,12 +509,15 @@ def dsm_cts_ind_processing():
             max_id = 0
         dsm_id = max_id + 1
         store_id = pd.Series(index=dsm_buses.index, dtype=int)
-        store_id.iloc[0 : int((len(store_id) / 2))] = range(
-            dsm_id, int((dsm_id + len(dsm_stores) / 2))
-        )
-        store_id.iloc[int((len(store_id) / 2)) : len(store_id)] = range(
-            dsm_id, int((dsm_id + len(dsm_stores) / 2))
-        )
+
+        # Assignment of store ids
+        store_id.iloc[0:rows_per_scenario["eGon2035"]] = range(
+            dsm_id, dsm_id + rows_per_scenario["eGon2035"])
+        store_id.iloc[
+            rows_per_scenario["eGon2035"]:rows_per_scenario["eGon2035"] +
+            rows_per_scenario["eGon100RE"]] = range(
+            dsm_id, dsm_id + rows_per_scenario["eGon100RE"])
+
         dsm_stores["store_id"] = store_id
 
         # add calculated timeseries to df to be returned

--- a/src/egon/data/datasets/DSM_cts_ind.py
+++ b/src/egon/data/datasets/DSM_cts_ind.py
@@ -12,7 +12,7 @@ class dsm_Potential(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="DSM_potentials",
-            version="0.0.2",
+            version="0.0.3",
             dependencies=dependencies,
             tasks=(dsm_cts_ind_processing),
         )


### PR DESCRIPTION
Fixes #901

Makes the ID allocation more failsafe. Tested in `dev` for DE.
(However, creating 3 DFs with the same content doesn't make much sense. If codacy will let you get away with this, I'll buy you a beer.)

Remaining question: why do the bus numbers in the 2 scenarios differ?
```
(Pdb) dsm_buses.groupby("scn_name").count()
           v_nom     x     y  geom  original_bus
scn_name                                        
eGon100RE   3260  3260  3260  3260          3260
eGon2035    3261  3261  3261  3261          3261
```

## Before merging into `dev`-branch, please make sure that

- [x] the `CHANGELOG.rst` was updated.
- [x] new and adjusted code is formated using `black` and `isort`.
- [x] the `Dataset`-version is updated when existing datasets are adjusted.
- [x] the branch was merged into the
      `continuous-integration/run-everything-over-the-weekend`-branch.
- [x] the workflow is running successful in `test mode`.
- [x] the workflow is running successful in `Everything` mode.
