### PR TITLE
Insert backup resitive heaters only if not empty

### DIFF
--- a/src/egon/data/datasets/heat_supply/__init__.py
+++ b/src/egon/data/datasets/heat_supply/__init__.py
@@ -129,11 +129,11 @@ def district_heating():
 
     if not backup_rh.empty:
         backup_rh.to_postgis(
-                targets["district_heating_supply"]["table"],
-                schema=targets["district_heating_supply"]["schema"],
-                con=db.engine(),
-                if_exists="append",
-            )
+            targets["district_heating_supply"]["table"],
+            schema=targets["district_heating_supply"]["schema"],
+            con=db.engine(),
+            if_exists="append",
+        )
 
 
 def individual_heating():

--- a/src/egon/data/datasets/heat_supply/__init__.py
+++ b/src/egon/data/datasets/heat_supply/__init__.py
@@ -171,7 +171,7 @@ class HeatSupply(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="HeatSupply",
-            version="0.0.6",
+            version="0.0.7",
             dependencies=dependencies,
             tasks=(
                 create_tables,

--- a/src/egon/data/datasets/heat_supply/__init__.py
+++ b/src/egon/data/datasets/heat_supply/__init__.py
@@ -127,12 +127,13 @@ def district_heating():
 
     backup_rh = backup_resistive_heaters("eGon2035")
 
-    backup_rh.to_postgis(
-        targets["district_heating_supply"]["table"],
-        schema=targets["district_heating_supply"]["schema"],
-        con=db.engine(),
-        if_exists="append",
-    )
+    if not backup_rh.empty:
+        backup_rh.to_postgis(
+                targets["district_heating_supply"]["table"],
+                schema=targets["district_heating_supply"]["schema"],
+                con=db.engine(),
+                if_exists="append",
+            )
 
 
 def individual_heating():


### PR DESCRIPTION
Fixes the bug described in https://github.com/openego/eGon-data/issues/377#issuecomment-1246292985

## Before merging into `dev`-branch, please make sure that

- [ ] the `CHANGELOG.rst` was updated.
- [x] new and adjusted code is formated using `black` and `isort`.
- [x] the `Dataset`-version is updated when existing datasets are adjusted.
- [x] the branch was merged into the
      `continuous-integration/run-everything-over-the-weekend`-branch.
- [x] the workflow is running successful in `test mode`.
- [x] the workflow is running successful in `Everything` mode.
