### PR TITLE
Hotfix/tyndp url

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -672,6 +672,7 @@ Bug Fixes
   `#1058 <https://github.com/openego/eGon-data/issues/1058>`_
 * Fix aggregation of DSM-components
   `#1058 <https://github.com/openego/eGon-data/issues/1069>`_
+* Fix URL of TYNDP scenario dataset
 
 .. _PR #692: https://github.com/openego/eGon-data/pull/692
 .. _#343: https://github.com/openego/eGon-data/issues/343

--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -1057,7 +1057,7 @@ electrical_neighbours:
 
 tyndp:
   sources:
-      capacities: "https://www.entsos-tyndp2020-scenarios.eu/wp-content/uploads/2020/06/TYNDP-2020-Scenario-Datafile.xlsx.zip"
+      capacities: "https://2020.entsos-tyndp-scenarios.eu/wp-content/uploads/2020/06/TYNDP-2020-Scenario-Datafile.xlsx.zip"
       demand_2030: "https://eepublicdownloads.entsoe.eu/tyndp-documents/2020-data/Demand_TimeSeries_2030_DistributedEnergy.xlsx"
       demand_2040: "https://eepublicdownloads.entsoe.eu/tyndp-documents/2020-data/Demand_TimeSeries_2040_DistributedEnergy.xlsx"
   targets:

--- a/src/egon/data/datasets/tyndp.py
+++ b/src/egon/data/datasets/tyndp.py
@@ -11,7 +11,7 @@ class Tyndp(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="Tyndp",
-            version="0.0.0",
+            version="0.0.1",
             dependencies=dependencies,
             tasks=(download),
         )


### PR DESCRIPTION
Fixes broken URL to TYNDP scenario dataset.
Came up here: https://github.com/openego/eGon-data/issues/377#issuecomment-1385258766

I assign this to you @AmeliaNadal @ClaraBuettner @IlkaCu as I dunno who is responsible..

Over and out.

## Before merging into `dev`-branch, please make sure that

- [x] the `CHANGELOG.rst` was updated.
- [ ] new and adjusted code is formated using `black` and `isort`.
- [x] the `Dataset`-version is updated when existing datasets are adjusted.
- [ ] the branch was merged into the
      `continuous-integration/run-everything-over-the-weekend`-branch.
- [ ] the workflow is running successful in `test mode`.
- [ ] the workflow is running successful in `Everything` mode.
