### PR TITLE
Exclude breaking `openpyxl` version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
         # See: https://stackoverflow.com/a/73354885/12460232
         "oedialect==0.0.8",
         "omi",
-        "openpyxl",
+        "openpyxl!=3.1.1",  # 3.1.1 breaks "demandregio.insert-cts-ind-demands"
         "pandas>1.2.0,<1.4",  # pandas>=1.4 needs SQLAlchemy>=1.4
         "psycopg2",
         "pyaml",


### PR DESCRIPTION
TMP: Will modify and write more later.

[Apparently][0], this version [breaks][1] the

  ```python
  demandregio.insert-cts-ind-demands
  ```

task.

[0]: https://github.com/openego/eGon-data/issues/377#issuecomment-1436556686
[1]: https://github.com/openego/eGon-data/issues/1108

Fixes # .

## Before merging into `dev`-branch, please make sure that

- [ ] the `CHANGELOG.rst` was updated.
- [ ] new and adjusted code is formated using `black` and `isort`.
- [ ] the `Dataset`-version is updated when existing datasets are adjusted.
- [x] the branch was merged into the
      `continuous-integration/run-everything-over-the-weekend`-branch.
- [ ] the workflow is running successful in `test mode`.
- [x] the workflow is running successful in `Everything` mode.
