### PR TITLE
authentication method to md5 to keep working with old jbdc driver from osmosis

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -774,6 +774,8 @@ Bug Fixes
   `#343 <https://github.com/openego/powerd-data/issues/343>`_
 * Fix hard coded scenario name in CTS building generation
   `#1180 <https://github.com/openego/eGon-data/issues/1180>`_
+* Update postgresql version but assure compatibility with osmosis
+  `#1185 <https://github.com/openego/eGon-data/issues/1185>`_
 
 
 .. _PR #692: https://github.com/openego/eGon-data/pull/692

--- a/src/egon/data/airflow/Dockerfile.postgis
+++ b/src/egon/data/airflow/Dockerfile.postgis
@@ -1,8 +1,6 @@
-FROM postgres:12
+FROM postgres:16
 
 RUN apt-get update
-RUN apt-get install -y postgresql-12-postgis-3
+RUN apt-get install -y postgresql-16-postgis-3
 RUN apt-get update
-RUN apt-get install -y postgresql-12-pgrouting
-
-
+RUN apt-get install -y postgresql-16-pgrouting

--- a/src/egon/data/airflow/docker-compose.yml
+++ b/src/egon/data/airflow/docker-compose.yml
@@ -1,19 +1,21 @@
 version: '3'
 services:
   egon-data-local-database-service:
-    user: {uid}:{gid}
-    image: postgres:12-postgis
-    container_name: {--docker-container-name}
+    user: "{uid}:{gid}"
+    image: postgis/postgis:16-3
+    container_name: "{--docker-container-name}"
     restart: unless-stopped
     build:
       context: .
-      dockerfile: {airflow}/Dockerfile.postgis
+      dockerfile: "{airflow}/Dockerfile.postgis"
     ports:
-    - "{--database-host}:{--database-port}:5432"
+      - "{--database-host}:{--database-port}:5432"
     environment:
-      POSTGRES_DB: {--airflow-database-name}
-      POSTGRES_USER: {--database-user}
-      POSTGRES_PASSWORD: {--database-password}
+      POSTGRES_DB: "{--airflow-database-name}"
+      POSTGRES_USER: "{--database-user}"
+      POSTGRES_PASSWORD: "{--database-password}"
+      # Use md5 authentication because of old JDBC driver in osmosis
+      POSTGRES_INITDB_ARGS: "--auth=md5"
     volumes:
-    - ./database-data/:/var/lib/postgresql/data
-    - /dev/shm:/dev/shm
+      - ./database-data/:/var/lib/postgresql/data
+      - /dev/shm:/dev/shm


### PR DESCRIPTION
Fixes #1185 .

## Before merging into `dev`-branch, please make sure that

- [x] the `CHANGELOG.rst` was updated.
- [ ] ~new and adjusted code is formated using `black` and `isort`.~
- [ ] ~the `Dataset`-version is updated when existing datasets are adjusted.~
- [ ] ~the branch was merged into the
      `continuous-integration/run-everything-over-the-weekend`-branch.~
- [ ] ~the workflow is running successful in `test mode`.~
- [ ] ~the workflow is running successful in `Everything` mode.~
