### PR TITLE
Fix incorrect handling of --scenarios

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -780,7 +780,8 @@ Bug Fixes
   `#1187 <https://github.com/openego/eGon-data/issues/1187>`_
 * Fix DsmPotential dependency errors
   `#1157 <https://github.com/openego/eGon-data/issues/1157>`_
-
+* Fix incorrect handling of `--scenarios` CLI option by converting tuple to list
+  `#1192 <https://github.com/openego/eGon-data/issues/1192>`_
 
 .. _PR #692: https://github.com/openego/eGon-data/pull/692
 .. _#343: https://github.com/openego/eGon-data/issues/343

--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -266,6 +266,10 @@ def egon_data(context, **kwargs):
         "defaults": options(lambda o: o.default),
     }
 
+    # Fix: Convert 'scenarios' to list if it exists
+    if "scenarios" in options["cli"]:
+        options["cli"]["scenarios"] = list(options["cli"]["scenarios"])
+
     combined = merge(options["defaults"], options["cli"])
     if not config.paths()[0].exists():
         with open(config.paths()[0], "w") as f:

--- a/src/egon/data/datasets/demandregio/__init__.py
+++ b/src/egon/data/datasets/demandregio/__init__.py
@@ -39,7 +39,7 @@ class DemandRegio(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="DemandRegio",
-            version="0.0.10",
+            version="0.0.10.dev",
             dependencies=dependencies,
             tasks=(
                 clone_and_install, # demandregio must be previously installed

--- a/src/egon/data/datasets/demandregio/__init__.py
+++ b/src/egon/data/datasets/demandregio/__init__.py
@@ -39,7 +39,7 @@ class DemandRegio(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="DemandRegio",
-            version="0.0.10.dev",
+            version="0.0.10",
             dependencies=dependencies,
             tasks=(
                 clone_and_install, # demandregio must be previously installed


### PR DESCRIPTION
CLI option Convert scenarios option from tuple to list after parsing to ensure correct comparison with default values and proper writing to configuration file.

Closes #1192

## Before merging into `dev`-branch, please make sure that

- [x] the `CHANGELOG.rst` was updated.