### PR TITLE
Fixes/#1190 profile building allocation wrong cells

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -780,6 +780,8 @@ Bug Fixes
   `#1187 <https://github.com/openego/eGon-data/issues/1187>`_
 * Fix DsmPotential dependency errors
   `#1157 <https://github.com/openego/eGon-data/issues/1157>`_
+* Fix household profile allocation to buildings
+  `#1190 <https://github.com/openego/eGon-data/issues/1190>`_
 
 
 .. _PR #692: https://github.com/openego/eGon-data/pull/692

--- a/src/egon/data/datasets/electricity_demand_timeseries/hh_buildings.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/hh_buildings.py
@@ -1200,7 +1200,7 @@ class setup(Dataset):
     #:
     name: str = "Demand_Building_Assignment"
     #:
-    version: str = "0.0.6"
+    version: str = "0.0.7"
     #:
     tasks = (
         map_houseprofiles_to_buildings,


### PR DESCRIPTION
Fixes #1190

### Bug

To reduce the number of cells with only synthetic buildings the use of building parts for profile allocation was introduced in https://github.com/openego/powerd-data/pull/358 . However, in cases when both building parts get a profile assigned in `map_houseprofiles_to_buildings()` both cell_ids are retained hence leading to duplicates in the table's PK.

### Solution

As before, building parts are taken into account when searching for cell buildings. I.e. cells that contain building parts (but not the main building = the part with centroid) are treated as building and can get profile(s) allocated. This led to multiple cell ids.

Now, profiles are reallocated to the main building as the building part is no independent building. This makes sense from a load perspective and fixes the error.

To avoid edge cases buildings whose centroid is not located in a populated cell are removed from allocation process.

## Before merging into `dev`-branch, please make sure that

- [x] the `CHANGELOG.rst` was updated.
- [ ] new and adjusted code is formated using `black` and `isort`.
- [x] the `Dataset`-version is updated when existing datasets are adjusted.
- [ ] the branch was merged into the
      `continuous-integration/run-everything-over-the-weekend`-branch.
- [x] the workflow is running successful in `test mode`.
- [x] the workflow is running successful in `Everything` mode.
