### PR TITLE
Fix/release v2.0.0 post merge cleanup kh

### DIFF
--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -563,10 +563,10 @@ with airflow.DAG(
             heat_time_series,
         ]
     )
-    
+
     # CHP to eTraGo
     chp_etrago = ChpEtrago(dependencies=[chp, heat_etrago])
-       
+
 
     # Storages to eTraGo
     storage_etrago = StorageEtrago(
@@ -612,15 +612,15 @@ with airflow.DAG(
             heat_etrago,
             heat_time_series,
             mv_grid_districts,
-            heat_pumps_2019,
+            heat_pumps_sq,
         ]
     )
-    
+
     # Power-to-H2-to-power chain installations with oxygen and waste_heat usage
     insert_power_to_h2_installations = HydrogenPowerLinkEtrago(
-        dependencies= [h2_infrastructure, mv_grid_districts, heat_etrago, substation_extraction, hts_etrago_table] 
+        dependencies= [h2_infrastructure, mv_grid_districts, heat_etrago, substation_extraction, hts_etrago_table]
     )
-    
+
     # Link between methane grid and respective hydrogen buses
     insert_h2_to_ch4_grid_links = HydrogenMethaneLinkEtrago(
         dependencies=[h2_infrastructure, insert_power_to_h2_installations]
@@ -719,6 +719,7 @@ with airflow.DAG(
         dependencies=[
             load_areas,
             cts_demand_buildings,
-            heat_pumps_2050
+            sanity_checks,
+            # heat_pumps_2050,
         ]
     )

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -56,7 +56,7 @@ from egon.data.datasets.heat_supply import (
 from egon.data.datasets.heat_supply.individual_heating import (
     HeatPumpsStatusQuo,
     HeatPumps2035,
-    #HeatPumps2050,
+    HeatPumps2050,
     HeatPumpsPypsaEur,
 )
 from egon.data.datasets.hydrogen_etrago import (
@@ -594,16 +594,16 @@ with airflow.DAG(
     )
 
     # Heat pump disaggregation for eGon2035
-    # heat_pumps_2035 = HeatPumps2035(
-    #     dependencies=[
-    #         cts_demand_buildings,
-    #         DistrictHeatingAreas,
-    #         heat_supply,
-    #         heat_time_series,
-    #         heat_pumps_pypsa_eur,
-    #         power_plants,
-    #     ]
-    # )
+    heat_pumps_2035 = HeatPumps2035(
+        dependencies=[
+            cts_demand_buildings,
+            DistrictHeatingAreas,
+            heat_supply,
+            heat_time_series,
+            heat_pumps_pypsa_eur,
+            power_plants,
+        ]
+    )
 
     # HTS to eTraGo table
     hts_etrago_table = HtsEtragoTable(
@@ -628,13 +628,13 @@ with airflow.DAG(
 
 
     # Heat pump disaggregation for eGon100RE
-    # heat_pumps_2050 = HeatPumps2050(
-    #     dependencies=[
-    #         run_pypsaeur,
-    #         heat_pumps_pypsa_eur,
-    #         heat_supply,
-    #     ]
-    # )
+    heat_pumps_2050 = HeatPumps2050(
+        dependencies=[
+            run_pypsaeur,
+            heat_pumps_pypsa_eur,
+            heat_supply,
+        ]
+    )
 
     # eMobility: motorized individual travel
     emobility_mit = MotorizedIndividualTravel(
@@ -720,6 +720,6 @@ with airflow.DAG(
             load_areas,
             cts_demand_buildings,
             sanity_checks,
-            # heat_pumps_2050,
+            heat_pumps_2050,
         ]
     )

--- a/src/egon/data/datasets/demandregio/__init__.py
+++ b/src/egon/data/datasets/demandregio/__init__.py
@@ -64,7 +64,7 @@ class DemandRegio(Dataset):
     #:
     name: str = "DemandRegio"
     #:
-    version: str = "0.0.10"
+    version: str = "0.0.11"
 
     def __init__(self, dependencies):
         super().__init__(
@@ -72,7 +72,7 @@ class DemandRegio(Dataset):
             version=self.version,
             dependencies=dependencies,
             tasks=(
-                # clone_and_install, demandregio must be previously installed
+                # clone_and_install,  # demandregio must be previously installed
                 get_cached_tables,  # adhoc workaround #180
                 create_tables,
                 {
@@ -552,7 +552,7 @@ def disagg_households_power(
     return df
 
 
-def write_demandregio_hh_profiles_to_db(hh_profiles, year):
+def write_demandregio_hh_profiles_to_db(hh_profiles):
     """Write HH demand profiles from demand regio into db. One row per
     year and nuts3. The annual load profile timeseries is an array.
 
@@ -564,7 +564,6 @@ def write_demandregio_hh_profiles_to_db(hh_profiles, year):
     Parameters
     ----------
     hh_profiles: pd.DataFrame
-    year: int
 
     Returns
     -------
@@ -580,7 +579,7 @@ def write_demandregio_hh_profiles_to_db(hh_profiles, year):
             :, hh_profiles.columns.str.contains("DEF0")
         ]
 
-    id = pd.read_sql_query(
+    idx = pd.read_sql_query(
         f"""
                            SELECT MAX(id)
                            FROM {DemandRegioLoadProfiles.__table__.schema}.
@@ -589,16 +588,16 @@ def write_demandregio_hh_profiles_to_db(hh_profiles, year):
         con=db.engine(),
     ).iat[0, 0]
 
-    if id is None:
-        id = 0
-    else:
-        id = id + 1
+    idx = 0 if idx is None else idx + 1
 
-    for nuts3 in hh_profiles.columns:
-        id += 1
-        df_to_db.at[id, "year"] = year
-        df_to_db.at[id, "nuts3"] = nuts3
-        df_to_db.at[id, "load_in_mwh"] = hh_profiles[nuts3].to_list()
+    for year in years:
+        df = hh_profiles[hh_profiles.index.year == year]
+
+        for nuts3 in hh_profiles.columns:
+            idx+=1
+            df_to_db.at[idx, "year"] = year
+            df_to_db.at[idx, "nuts3"] = nuts3
+            df_to_db.at[idx, "load_in_mwh"] = df[nuts3].to_list()
 
     df_to_db["year"] = df_to_db["year"].apply(int)
     df_to_db["nuts3"] = df_to_db["nuts3"].astype(str)
@@ -612,8 +611,6 @@ def write_demandregio_hh_profiles_to_db(hh_profiles, year):
         if_exists="append",
         index=-False,
     )
-
-    return
 
 
 def insert_hh_demand(scenario, year, engine):
@@ -686,7 +683,7 @@ def insert_hh_demand(scenario, year, engine):
 
             hh_load_timeseries.iloc[:24 * 7] = hh_load_timeseries.iloc[24 * 7:24 * 7 * 2].values
 
-    write_demandregio_hh_profiles_to_db(hh_load_timeseries, year)
+    write_demandregio_hh_profiles_to_db(hh_load_timeseries)
 
 
 def insert_cts_ind(scenario, year, engine, target_values):

--- a/src/egon/data/datasets/demandregio/__init__.py
+++ b/src/egon/data/datasets/demandregio/__init__.py
@@ -686,7 +686,7 @@ def insert_hh_demand(scenario, year, engine):
 
             hh_load_timeseries.iloc[:24 * 7] = hh_load_timeseries.iloc[24 * 7:24 * 7 * 2].values
 
-    write_demandregio_hh_profiles_to_db(hh_load_timeseries)
+    write_demandregio_hh_profiles_to_db(hh_load_timeseries, year)
 
 
 def insert_cts_ind(scenario, year, engine, target_values):

--- a/src/egon/data/datasets/heat_demand_timeseries/__init__.py
+++ b/src/egon/data/datasets/heat_demand_timeseries/__init__.py
@@ -366,13 +366,6 @@ def create_district_heating_profile_python_like(scenario="eGon2035"):
                     slice_df.zensus_population_id.isin(annual_demand.index)
                 ]
 
-                slice_df = pd.merge(
-                    df[df.area_id == area],
-                    idp_df,
-                    left_on="selected_idp",
-                    right_on="index",
-                )
-
                 for hour in range(24):
                     slice_df[hour] = (
                         slice_df.idp.str[hour]

--- a/src/egon/data/datasets/heat_demand_timeseries/__init__.py
+++ b/src/egon/data/datasets/heat_demand_timeseries/__init__.py
@@ -1232,7 +1232,7 @@ class HeatTimeSeries(Dataset):
     #:
     name: str = "HeatTimeSeries"
     #:
-    version: str = "0.0.12.dev"
+    version: str = "0.0.12"
 
     def __init__(self, dependencies):
         super().__init__(

--- a/src/egon/data/datasets/scenario_capacities.py
+++ b/src/egon/data/datasets/scenario_capacities.py
@@ -974,7 +974,7 @@ def add_metadata():
         EgonScenarioCapacities.__table__.name,
     )
 
-tasks = (create_table, insert_data_nep,)
+tasks = (create_table,)
 
 scenarios = config.settings()["egon-data"]["--scenarios"]
 

--- a/src/egon/data/datasets/storages/__init__.py
+++ b/src/egon/data/datasets/storages/__init__.py
@@ -96,8 +96,8 @@ class Storages(Dataset):
                 create_tables,
                 allocate_pumped_hydro_scn,
                 allocate_other_storage_units,
-                # allocate_pv_home_batteries_to_grids,
-                # allocate_home_batteries_to_buildings,
+                allocate_pv_home_batteries_to_grids,
+                allocate_home_batteries_to_buildings,
             ),
         )
 


### PR DESCRIPTION
**This PR fixes several minor merge issues introduced in https://github.com/openego/eGon-data/pull/1227.**
Tested pipeline: `eGon2035`

### ✅ Fixes included:

* Corrected indentation error in `src/egon/data/datasets/heat_demand_timeseries/__init__.py`
* Removed duplicate task from `src/egon/data/datasets/scenario_capacities.py`
* Fixed dataset naming and syntax issues for heat pump tasks in `src/egon/data/airflow/dags/pipeline.py`
* Reinstated support for multiple years in household profiles (lost during merge) in `src/egon/data/datasets/demandregio/__init__.py`

---

@CarlosEpia – the pipeline now runs up to `electrical_neighbours.grid` where it fails with a `FileNotFoundError` (as expected). I'll take a look at that tomorrow and try inserting your `.nc` file.

Could you please review this PR? Also, a few open questions:

### 🔍 Review & Questions:

* In `src/egon/data/airflow/dags/pipeline.py`, the heat pump tasks for 2035 and 2050 are commented out. I assume this is specific to `powerd` and should be reverted — can you confirm?
* Would it be possible to update or upload either the `powerd-data` or the new `regon-data` bundle soon? → https://github.com/openego/eGon-data/issues/1238
* I reverted a change in `write_demandregio_hh_profiles_to_db` (in `demandregio/__init__.py`) introduced by Julian during the merge. I believe the original version should be kept — feel free to double-check.
* While running the task `heat_demand_timeseries.district-heating`, I’m getting many warnings like this:

  ```text
  [2025-05-05, 12:55:19 UTC] {logging_mixin.py:190} INFO - WARNING: No data returned by statement: 
  ...
  FROM demand.egon_map_zensus_district_heating_areas
  WHERE scenario = 'eGon2035'
  AND area_id = '81'
  ...
  ```

  Do you know whether this is expected behavior?

---

@ClaraBuettner & @nesnoj – just FYI 🙂