### PR TITLE
Add structure to unify setting sources and targets of Datasets

### DIFF
--- a/src/egon/data/datasets/__init__.py
+++ b/src/egon/data/datasets/__init__.py
@@ -443,13 +443,11 @@ def load_sources_and_targets(
     Parameters
     ----------
         name (str): Name of the dataset.
-        version (str): Version of the dataset.
 
     Returns
     -------
         Tuple[DatasetSources, DatasetTargets]
     """
-
     with db.session_scope() as session:
         dataset_entry = (
             session.query(Model)
@@ -457,13 +455,14 @@ def load_sources_and_targets(
             .first()
         )
 
-    if dataset_entry is None:
-        raise ValueError(f"Dataset '{name}' not found in the database.")
+        if dataset_entry is None:
+            raise ValueError(f"Dataset '{name}' not found in the database.")
 
-    raw_sources = dataset_entry.sources or {}
-    raw_targets = dataset_entry.targets or {}
+        # Extract raw JSON dicts within the session
+        raw_sources = dict(dataset_entry.sources or {})
+        raw_targets = dict(dataset_entry.targets or {})
 
-    # Recreate DatasetSources and DatasetTargets from dictionaries
+    # Recreate objects *outside the session* (now safe)
     sources = DatasetSources(**raw_sources)
     targets = DatasetTargets(**raw_targets)
 

--- a/src/egon/data/datasets/__init__.py
+++ b/src/egon/data/datasets/__init__.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 from collections import abc
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import partial, reduce, update_wrapper
-from typing import Callable, Iterable, Set, Tuple, Union
+from typing import Callable, Dict, Iterable, Set, Tuple, Union
 import re
 
 from airflow.models.baseoperator import BaseOperator as Operator
 from airflow.operators.python import PythonOperator
 from sqlalchemy import Column, ForeignKey, Integer, String, Table, orm, tuple_
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.dialects.postgresql import JSONB
 
 from egon.data import config, db, logger
 
@@ -87,6 +88,78 @@ class Model(Base):
         backref=orm.backref("dependents", cascade="all, delete"),
     )
 
+
+@dataclass
+class DatasetSources:
+    tables: Dict[str, str] = field(default_factory=dict)
+    files: Dict[str, str] = field(default_factory=dict)
+    urls: Dict[str, str] = field(default_factory=dict)
+
+    def empty(self):
+        return not (self.tables or self.files or self.urls)
+
+    def get_table_schema(self, key: str) -> str:
+        """Returns the schema of the table identified by key."""
+        try:
+            return self.tables[key].split(".", 1)[0]
+        except (KeyError, AttributeError, IndexError):
+            raise ValueError(f"Invalid table reference: {self.tables.get(key)}")
+
+    def get_table_name(self, key: str) -> str:
+        """Returns the table name of the table identified by key."""
+        try:
+            return self.tables[key].split(".", 1)[1]
+        except (KeyError, AttributeError, IndexError):
+            raise ValueError(f"Invalid table reference: {self.tables.get(key)}")
+
+    def to_dict(self):
+        return {
+            "tables": self.tables,
+            "urls": self.urls,
+            "files": self.files,
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            tables=data.get("tables", {}),
+            urls=data.get("urls", {}),
+            files=data.get("files", {}),
+        )
+
+@dataclass
+class DatasetTargets:
+    tables: Dict[str, str] = field(default_factory=dict)
+    files: Dict[str, str] = field(default_factory=dict)
+
+    def empty(self):
+        return not (self.tables or self.files)
+
+    def get_table_schema(self, key: str) -> str:
+        """Returns the schema of the table identified by key."""
+        try:
+            return self.tables[key].split(".", 1)[0]
+        except (KeyError, AttributeError, IndexError):
+            raise ValueError(f"Invalid table reference: {self.tables.get(key)}")
+
+    def get_table_name(self, key: str) -> str:
+        """Returns the table name of the table identified by key."""
+        try:
+            return self.tables[key].split(".", 1)[1]
+        except (KeyError, AttributeError, IndexError):
+            raise ValueError(f"Invalid table reference: {self.tables.get(key)}")
+
+    def to_dict(self):
+        return {
+            "tables": self.tables,
+            "files": self.files,
+        }
+
+    def from_dict(cls, data):
+        return cls(
+            tables=data.get("tables", {}),
+            files=data.get("files", {}),
+        )
 
 #: A :class:`Task` is an Airflow :class:`Operator` or any
 #: :class:`Callable <typing.Callable>` taking no arguments and returning
@@ -189,6 +262,12 @@ class Dataset:
     #: and a sequential number in case the data changes without the date
     #: or region changing, for example due to implementation changes.
     version: str
+    #: The sources used by the datasets.
+    #: Could be tables, files and urls
+    sources: DatasetSources = field(init=False)
+    #: The targets created by the datasets.
+    #: Could be tables and files
+    targets: DatasetTargets = field(init=False)
     #: The first task(s) of this :class:`Dataset` will be marked as
     #: downstream of any of the listed dependencies. In case of bare
     #: :class:`Task`, a direct link will be created whereas for a
@@ -258,6 +337,43 @@ class Dataset:
 
     def __post_init__(self):
         self.dependencies = list(self.dependencies)
+
+        class_sources = getattr(type(self), "sources", None)
+
+        if not isinstance(class_sources, DatasetSources):
+            logger.warning(
+                f"Dataset '{type(self).__name__}' has no valid class-level 'sources' attribute. "
+                "Defaulting to empty DatasetSources().",
+                stacklevel=2
+            )
+            self.sources = DatasetSources()
+        else:
+            self.sources = class_sources
+            if self.sources.empty():
+                logger.warning(
+                    f"Dataset '{type(self).__name__}' defines 'sources', but it is empty. "
+                    "Please check if this is intentional.",
+                    stacklevel=2
+                )
+
+
+        class_targets = getattr(type(self), "targets", None)
+
+        if not isinstance(class_targets, DatasetTargets):
+            logger.warning(
+                f"Dataset '{type(self).__name__}' has no valid class-level 'targets' attribute. "
+                "Defaulting to empty DatasetTargets().",
+                stacklevel=2
+            )
+            self.targets = DatasetTargets()
+        else:
+            self.targets = class_targets
+            if self.targets.empty():
+                logger.warning(
+                    f"Dataset '{type(self).__name__}' defines 'targets', but it is empty. "
+                    "Please check if this is intentional.",
+                    stacklevel=2
+                )
         if not isinstance(self.tasks, Tasks_):
             self.tasks = Tasks_(self.tasks)
         if len(self.tasks.last) > 1:
@@ -298,3 +414,16 @@ class Dataset:
         for p in predecessors:
             for first in self.tasks.first:
                 p.set_downstream(first)
+
+    def __init_subclass__(cls) -> None:
+        # Warn about missing or invalid class attributes
+        if not isinstance(getattr(cls, "sources", None), DatasetSources):
+            logger.warning(
+                f"Dataset '{cls.__name__}' does not define a valid class-level 'sources'.",
+                stacklevel=2
+            )
+        if not isinstance(getattr(cls, "targets", None), DatasetTargets):
+            logger.warning(
+                f"Dataset '{cls.__name__}' does not define a valid class-level 'targets'.",
+                stacklevel=2
+            )

--- a/src/egon/data/datasets/__init__.py
+++ b/src/egon/data/datasets/__init__.py
@@ -433,3 +433,38 @@ class Dataset:
                 f"Dataset '{cls.__name__}' does not define a valid class-level 'targets'.",
                 stacklevel=2
             )
+
+def load_sources_and_targets(
+    name: str,
+) -> tuple[DatasetSources, DatasetTargets]:
+    """
+    Load DatasetSources and DatasetTargets from the datasets table.
+
+    Parameters
+    ----------
+        name (str): Name of the dataset.
+        version (str): Version of the dataset.
+
+    Returns
+    -------
+        Tuple[DatasetSources, DatasetTargets]
+    """
+
+    with db.session_scope() as session:
+        dataset_entry = (
+            session.query(Model)
+            .filter_by(name=name)
+            .first()
+        )
+
+    if dataset_entry is None:
+        raise ValueError(f"Dataset '{name}' not found in the database.")
+
+    raw_sources = dataset_entry.sources or {}
+    raw_targets = dataset_entry.targets or {}
+
+    # Recreate DatasetSources and DatasetTargets from dictionaries
+    sources = DatasetSources(**raw_sources)
+    targets = DatasetTargets(**raw_targets)
+
+    return sources, targets

--- a/src/egon/data/datasets/__init__.py
+++ b/src/egon/data/datasets/__init__.py
@@ -80,6 +80,9 @@ class Model(Base):
     version = Column(String, nullable=False)
     epoch = Column(Integer, default=0)
     scenarios = Column(String, nullable=False)
+    sources = Column(JSONB, nullable=True)
+    targets = Column(JSONB, nullable=True)
+
     dependencies = orm.relationship(
         "Model",
         secondary=DependencyGraph,
@@ -312,7 +315,10 @@ class Dataset:
             name=self.name,
             version=self.version,
             scenarios=config.settings()["egon-data"]["--scenarios"],
+            sources=self.sources.to_dict() if hasattr(self.sources, "to_dict") else dict(self.sources),
+            targets=self.targets.to_dict() if hasattr(self.targets, "to_dict") else dict(self.targets),
         )
+
         dependencies = (
             session.query(Model)
             .filter(

--- a/src/egon/data/datasets/__init__.py
+++ b/src/egon/data/datasets/__init__.py
@@ -8,6 +8,8 @@ from functools import partial, reduce, update_wrapper
 from typing import Callable, Dict, Iterable, Set, Tuple, Union
 import re
 
+import json
+from pathlib import Path
 from airflow.models.baseoperator import BaseOperator as Operator
 from airflow.operators.python import PythonOperator
 from sqlalchemy import Column, ForeignKey, Integer, String, Table, orm, tuple_
@@ -485,3 +487,40 @@ def load_sources_and_targets(
     targets = DatasetTargets(**raw_targets)
 
     return sources, targets
+
+
+def export_dataset_io_to_json(
+    output_path: str = "dataset_io_overview.json",
+) -> None:
+    """
+    Export all sources and targets of datasets to a JSON file.
+
+    Parameters
+    ----------
+    output_path : str
+        Path to the output JSON file.
+    """
+
+    result = {}
+
+    with db.session_scope() as session:
+        datasets = session.query(Model).all()
+
+        for dataset in datasets:
+            name = dataset.name
+
+            try:
+                raw_sources = dict(dataset.sources or {})
+                raw_targets = dict(dataset.targets or {})
+
+                result[name] = {
+                    "sources": raw_sources,
+                    "targets": raw_targets,
+                }
+            except Exception as e:
+                print(f"⚠️ Could not process dataset '{name}': {e}")
+
+    # Save to JSON
+    output_file = Path(output_path)
+    output_file.write_text(json.dumps(result, indent=2, ensure_ascii=False))
+    print(f"✅ Dataset I/O overview written to {output_file.resolve()}")

--- a/src/egon/data/datasets/__init__.py
+++ b/src/egon/data/datasets/__init__.py
@@ -421,6 +421,8 @@ class Dataset:
             for first in self.tasks.first:
                 p.set_downstream(first)
 
+        self.register()
+
     def __init_subclass__(cls) -> None:
         # Warn about missing or invalid class attributes
         if not isinstance(getattr(cls, "sources", None), DatasetSources):
@@ -433,6 +435,22 @@ class Dataset:
                 f"Dataset '{cls.__name__}' does not define a valid class-level 'targets'.",
                 stacklevel=2
             )
+
+    def register(self):
+        with db.session_scope() as session:
+            existing = session.query(Model).filter_by(
+                name=self.name
+            ).first()
+
+            if not existing:
+                entry = Model(
+                    name=self.name,
+                    version="will be filled after execution",
+                    scenarios="{}",
+                    sources=self.sources.to_dict(),
+                    targets=self.targets.to_dict()
+                )
+                session.add(entry)
 
 def load_sources_and_targets(
     name: str,

--- a/src/egon/data/datasets/heat_supply/__init__.py
+++ b/src/egon/data/datasets/heat_supply/__init__.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.declarative import declarative_base
 import pandas as pd
 
 from egon.data import config, db
-from egon.data.datasets import Dataset
+from egon.data.datasets import Dataset, DatasetSources, DatasetTargets
 from egon.data.datasets.district_heating_areas import EgonDistrictHeatingAreas
 from egon.data.datasets.heat_supply.district_heating import (
     backup_gas_boilers,
@@ -85,13 +85,12 @@ def district_heating():
     None.
 
     """
-    sources = config.datasets()["heat_supply"]["sources"]
-    targets = config.datasets()["heat_supply"]["targets"]
+    sources = HeatSupply.sources
+    targets = HeatSupply.targets
 
     db.execute_sql(
         f"""
-        DELETE FROM {targets['district_heating_supply']['schema']}.
-        {targets['district_heating_supply']['table']}
+        DELETE FROM {HeatSupply.targets.tables["district_heating_supply"]}
         """
     )
 
@@ -101,12 +100,13 @@ def district_heating():
         supply["scenario"] = scenario
 
         supply.to_postgis(
-            targets["district_heating_supply"]["table"],
-            schema=targets["district_heating_supply"]["schema"],
+            HeatSupply.targets.get_table_name("district_heating_supply"),
+            schema=HeatSupply.targets.get_table_schema(
+                "district_heating_supply"
+            ),
             con=db.engine(),
             if_exists="append",
         )
-
 
         # Do not check data for status quo as is it not listed in the table
         if "status" not in scenario:
@@ -115,10 +115,8 @@ def district_heating():
                 f"""
                 SELECT a.carrier,
                 (SUM(a.capacity) - b.capacity) / SUM(a.capacity) as deviation
-                FROM {targets['district_heating_supply']['schema']}.
-                {targets['district_heating_supply']['table']} a,
-                {sources['scenario_capacities']['schema']}.
-                {sources['scenario_capacities']['table']} b
+                FROM {targets.tables['district_heating_supply']} a,
+                {sources.tables['scenario_capacities']} b
                 WHERE a.scenario = '{scenario}'
                 AND b.scenario_name = '{scenario}'
                 AND b.carrier = CONCAT('urban_central_', a.carrier)
@@ -136,12 +134,11 @@ def district_heating():
         backup = backup_gas_boilers(scenario)
 
         backup.to_postgis(
-            targets["district_heating_supply"]["table"],
-            schema=targets["district_heating_supply"]["schema"],
+            targets.get_table_name("district_heating_supply"),
+            schema=targets.get_table_schema("district_heating_supply"),
             con=db.engine(),
             if_exists="append",
         )
-
 
         # Insert resistive heaters which are not available in status quo
         if "status" not in scenario:
@@ -149,8 +146,8 @@ def district_heating():
 
             if not backup_rh.empty:
                 backup_rh.to_postgis(
-                    targets["district_heating_supply"]["table"],
-                    schema=targets["district_heating_supply"]["schema"],
+                    targets.get_table_name("district_heating_supply"),
+                    schema=targets.get_table_schema("district_heating_supply"),
                     con=db.engine(),
                     if_exists="append",
                 )
@@ -164,13 +161,12 @@ def individual_heating():
     None.
 
     """
-    targets = config.datasets()["heat_supply"]["targets"]
+    targets = HeatSupply.targets
 
     for scenario in config.settings()["egon-data"]["--scenarios"]:
         db.execute_sql(
             f"""
-            DELETE FROM {targets['individual_heating_supply']['schema']}.
-            {targets['individual_heating_supply']['table']}
+            DELETE FROM {targets.tables['individual_heating_supply']}
             WHERE scenario = '{scenario}'
             """
         )
@@ -186,8 +182,8 @@ def individual_heating():
         supply["scenario"] = scenario
 
         supply.to_postgis(
-            targets["individual_heating_supply"]["table"],
-            schema=targets["individual_heating_supply"]["schema"],
+            targets.get_table_name("individual_heating_supply"),
+            schema=targets.get_table_schema("individual_heating_supply"),
             con=db.engine(),
             if_exists="append",
         )
@@ -392,6 +388,28 @@ class HeatSupply(Dataset):
     name: str = "HeatSupply"
     #:
     version: str = "0.0.12"
+
+    sources = DatasetSources(
+        tables={
+            "scenario_capacities": "supply.egon_scenario_capacities",
+            "district_heating_areas": "demand.egon_district_heating_areas",
+            "chp": "supply.egon_chp_plants",
+            "federal_states": "boundaries.vg250_lan",
+            "heat_demand": "demand.egon_peta_heat",
+            "map_zensus_grid": "boundaries.egon_map_zensus_grid_districts",
+            "map_vg250_grid": "boundaries.egon_map_mvgriddistrict_vg250",
+            "mv_grids": "grid.egon_mv_grid_district",
+            "map_dh": "demand.egon_map_zensus_district_heating_areas",
+            "etrago_buses": "grid.egon_etrago_bus",
+        }
+    )
+
+    targets = DatasetTargets(
+        tables={
+            "district_heating_supply": "supply.egon_district_heating",
+            "individual_heating_supply": "supply.egon_individual_heating",
+        }
+    )
 
     def __init__(self, dependencies):
         super().__init__(

--- a/src/egon/data/datasets/heat_supply/district_heating.py
+++ b/src/egon/data/datasets/heat_supply/district_heating.py
@@ -2,10 +2,12 @@
 for district heating areas.
 
 """
+
 import geopandas as gpd
 import pandas as pd
 from egon.data import config, db
 from egon.data.datasets.heat_supply.geothermal import calc_geothermal_costs
+from egon.data.datasets import load_sources_and_targets
 
 
 def capacity_per_district_heating_category(district_heating_areas, scenario):
@@ -24,13 +26,12 @@ def capacity_per_district_heating_category(district_heating_areas, scenario):
         Installed capacities per technology and size category
 
     """
-    sources = config.datasets()["heat_supply"]["sources"]
+    sources, targets = load_sources_and_targets("HeatSupply")
 
     target_values = db.select_dataframe(
         f"""
         SELECT capacity, split_part(carrier, 'urban_central_', 2) as technology
-        FROM {sources['scenario_capacities']['schema']}.
-        {sources['scenario_capacities']['table']}
+        FROM {sources.tables['scenario_capacities']}
         WHERE carrier IN (
             'urban_central_heat_pump',
             'urban_central_resistive_heater',
@@ -123,7 +124,7 @@ def select_district_heating_areas(scenario):
 
     """
 
-    sources = config.datasets()["heat_supply"]["sources"]
+    sources, targets = load_sources_and_targets("HeatSupply")
 
     max_demand_medium_district_heating = 96000
 
@@ -134,8 +135,7 @@ def select_district_heating_areas(scenario):
          SELECT id as district_heating_id,
          residential_and_service_demand as demand,
          geom_polygon as geom
-         FROM {sources['district_heating_areas']['schema']}.
-        {sources['district_heating_areas']['table']}
+         FROM {sources.tables['district_heating_areas']}
          WHERE scenario = '{scenario}'
          """,
         index_col="district_heating_id",
@@ -193,7 +193,7 @@ def cascade_per_technology(
         List of plants per district heating grid for the selected technology
 
     """
-    sources = config.datasets()["heat_supply"]["sources"]
+    sources, targets = load_sources_and_targets("HeatSupply")
 
     tech = technologies[technologies.priority == technologies.priority.max()]
 
@@ -203,10 +203,8 @@ def cascade_per_technology(
         # Select chp plants from database
         gdf_chp = db.select_geodataframe(
             f"""SELECT a.geom, th_capacity as capacity, c.area_id
-            FROM {sources['chp']['schema']}.
-            {sources['chp']['table']} a,
-            {sources['district_heating_areas']['schema']}.
-            {sources['district_heating_areas']['table']} c
+            FROM {sources.tables['chp']} a,
+            {sources.tables['district_heating_areas']} c
             WHERE a.district_heating = True
             AND a.district_heating_area_id = c.area_id
             AND a.scenario = '{scenario}'
@@ -429,6 +427,8 @@ def backup_resistive_heaters(scenario):
 
     """
 
+    sources, targets = load_sources_and_targets("HeatSupply")
+
     # Select district heating areas from database
     district_heating_areas = select_district_heating_areas(scenario)
 
@@ -436,7 +436,7 @@ def backup_resistive_heaters(scenario):
     target_value = db.select_dataframe(
         f"""
         SELECT capacity
-        FROM supply.egon_scenario_capacities
+        FROM {sources.tables['scenario_capacities']}
         WHERE carrier = 'urban_central_resistive_heater'
         AND scenario_name = '{scenario}'
         """
@@ -445,7 +445,7 @@ def backup_resistive_heaters(scenario):
     distributed = db.select_dataframe(
         f"""
         SELECT SUM(capacity) as capacity
-        FROM supply.egon_district_heating
+        FROM {targets.tables['district_heating_supply']}
         WHERE carrier = 'resistive_heater'
         AND scenario = '{scenario}'
         """

--- a/src/egon/data/datasets/heat_supply/individual_heating.py
+++ b/src/egon/data/datasets/heat_supply/individual_heating.py
@@ -50,6 +50,8 @@ from egon.data.datasets.heat_demand_timeseries.idp_pool import (
 # get zensus cells with district heating
 from egon.data.datasets.zensus_mv_grid_districts import MapZensusGridDistricts
 
+from egon.data.datasets import load_sources_and_targets
+
 engine = db.engine()
 Base = declarative_base()
 
@@ -594,7 +596,7 @@ def cascade_per_technology(
         List of plants per mv grid for the selected technology
 
     """
-    sources = config.datasets()["heat_supply"]["sources"]
+    sources, targets = load_sources_and_targets("HeatSupply")
 
     tech = technologies[technologies.priority == technologies.priority.max()]
 
@@ -605,10 +607,8 @@ def cascade_per_technology(
             target = db.select_dataframe(
                 f"""
                     SELECT DISTINCT ON (gen) gen as state, capacity
-                    FROM {sources['scenario_capacities']['schema']}.
-                    {sources['scenario_capacities']['table']} a
-                    JOIN {sources['federal_states']['schema']}.
-                    {sources['federal_states']['table']} b
+                    FROM {sources.tables['scenario_capacities']} a
+                    JOIN {sources.tables['federal_states']} b
                     ON a.nuts = b.nuts
                     WHERE scenario_name = '{scenario}'
                     AND carrier = 'residential_rural_heat_pump'
@@ -630,8 +630,7 @@ def cascade_per_technology(
             target = db.select_dataframe(
                 f"""
                     SELECT SUM(capacity) AS capacity
-                    FROM {sources['scenario_capacities']['schema']}.
-                    {sources['scenario_capacities']['table']} a
+                    FROM {sources.tables['scenario_capacities']} a
                     WHERE scenario_name = '{scenario}'
                     AND carrier = 'rural_heat_pump'
                     """
@@ -661,8 +660,7 @@ def cascade_per_technology(
         target = db.select_dataframe(
             f"""
                 SELECT SUM(capacity) AS capacity
-                FROM {sources['scenario_capacities']['schema']}.
-                {sources['scenario_capacities']['table']} a
+                FROM {sources.tables['scenario_capacities']} a
                 WHERE scenario_name = '{scenario}'
                 AND carrier = 'rural_{tech.index[0]}'
                 """
@@ -734,28 +732,24 @@ def cascade_heat_supply_indiv(scenario, distribution_level, plotting=True):
 
     """
 
-    sources = config.datasets()["heat_supply"]["sources"]
+    sources, targets = load_sources_and_targets("HeatSupply")
 
     # Select residential heat demand per mv grid district and federal state
     heat_per_mv = db.select_geodataframe(
         f"""
         SELECT d.bus_id as bus_id, SUM(demand) as demand,
         c.vg250_lan as state, d.geom
-        FROM {sources['heat_demand']['schema']}.
-        {sources['heat_demand']['table']} a
-        JOIN {sources['map_zensus_grid']['schema']}.
-        {sources['map_zensus_grid']['table']} b
+        FROM {sources.tables['heat_demand']} a
+        JOIN {sources.tables['map_zensus_grid']} b
         ON a.zensus_population_id = b.zensus_population_id
-        JOIN {sources['map_vg250_grid']['schema']}.
-        {sources['map_vg250_grid']['table']} c
+        JOIN {sources.tables['map_vg250_grid']} c
         ON b.bus_id = c.bus_id
-        JOIN {sources['mv_grids']['schema']}.
-        {sources['mv_grids']['table']} d
+        JOIN {sources.tables['mv_grids']} d
         ON d.bus_id = c.bus_id
         WHERE scenario = '{scenario}'
         AND a.zensus_population_id NOT IN (
             SELECT zensus_population_id
-            FROM {sources['map_dh']['schema']}.{sources['map_dh']['table']}
+            FROM {sources.tables['map_dh']}
             WHERE scenario = '{scenario}')
         GROUP BY d.bus_id, vg250_lan, geom
         """,

--- a/src/egon/data/datasets/zensus/__init__.py
+++ b/src/egon/data/datasets/zensus/__init__.py
@@ -20,13 +20,21 @@ from egon.data.datasets import Dataset, DatasetSources, DatasetTargets
 class ZensusPopulation(Dataset):
     sources = DatasetSources(
         urls={
-            "original_data":
-                "https://www.zensus2011.de/SharedDocs/Downloads/DE/Pressemitteilung/DemografischeGrunddaten/csv_Bevoelkerung_100m_Gitter.zip?__blob=publicationFile&v=3"}
+            "original_data": (
+                "https://www.zensus2011.de/SharedDocs/Downloads/DE/"
+                "Pressemitteilung/DemografischeGrunddaten/"
+                "csv_Bevoelkerung_100m_Gitter.zip?__blob=publicationFile&v=3"
+                ),
+            }
     )
 
     targets = DatasetTargets(
-        files = {"zensus_population": "zensus_population/csv_Bevoelkerung_100m_Gitter.zip"},
-        tables= {"zensus_population": "society.destatis_zensus_population_per_ha"}
+        files = {
+            "zensus_population":
+                "zensus_population/csv_Bevoelkerung_100m_Gitter.zip"},
+        tables= {
+            "zensus_population":
+                "society.destatis_zensus_population_per_ha"}
         )
 
     def __init__(self, dependencies):
@@ -45,13 +53,23 @@ class ZensusPopulation(Dataset):
 class ZensusMiscellaneous(Dataset):
     sources = DatasetSources(
         urls={
-            "zensus_households":
-                'https://www.zensus2011.de/SharedDocs/Downloads/DE/Pressemitteilung/DemografischeGrunddaten/csv_Haushalte_100m_Gitter.zip?__blob=publicationFile&v=2',
-            "zensus_buildings":
-                'https://www.zensus2011.de/SharedDocs/Downloads/DE/Pressemitteilung/DemografischeGrunddaten/csv_Gebaeude_100m_Gitter.zip?__blob=publicationFile&v=2',
-            "zensus_apartments":
-                'https://www.zensus2011.de/SharedDocs/Downloads/DE/Pressemitteilung/DemografischeGrunddaten/csv_Wohnungen_100m_Gitter.zip?__blob=publicationFile&v=5'
-            })
+            "zensus_households": (
+                "https://www.zensus2011.de/SharedDocs/Downloads/DE/"
+                "Pressemitteilung/DemografischeGrunddaten/"
+                "csv_Haushalte_100m_Gitter.zip?__blob=publicationFile&v=2"
+            ),
+            "zensus_buildings": (
+                "https://www.zensus2011.de/SharedDocs/Downloads/DE/"
+                "Pressemitteilung/DemografischeGrunddaten/"
+                "csv_Gebaeude_100m_Gitter.zip?__blob=publicationFile&v=2"
+            ),
+            "zensus_apartments": (
+                "https://www.zensus2011.de/SharedDocs/Downloads/DE/"
+                "Pressemitteilung/DemografischeGrunddaten/"
+                "csv_Wohnungen_100m_Gitter.zip?__blob=publicationFile&v=5"
+            ),
+        }
+    )
     targets = DatasetTargets(
         files = {
             "zensus_households":

--- a/src/egon/data/datasets/zensus/__init__.py
+++ b/src/egon/data/datasets/zensus/__init__.py
@@ -14,11 +14,22 @@ import pandas as pd
 
 from egon.data import db, subprocess
 from egon.data.config import settings
-from egon.data.datasets import Dataset
+from egon.data.datasets import Dataset, DatasetSources, DatasetTargets
 import egon.data.config
 
 
 class ZensusPopulation(Dataset):
+    sources = DatasetSources(
+        urls={
+            "original_data":
+                "https://www.zensus2011.de/SharedDocs/Downloads/DE/Pressemitteilung/DemografischeGrunddaten/csv_Bevoelkerung_100m_Gitter.zip?__blob=publicationFile&v=3"}
+    )
+
+    targets = DatasetTargets(
+        files = {"zensus_population": "zensus_population/csv_Bevoelkerung_100m_Gitter.zip"},
+        tables= {"zensus_population": "society.destatis_zensus_population_per_ha"}
+        )
+
     def __init__(self, dependencies):
         super().__init__(
             name="ZensusPopulation",
@@ -28,11 +39,38 @@ class ZensusPopulation(Dataset):
                 download_zensus_pop,
                 create_zensus_pop_table,
                 population_to_postgres,
-            ),
+            )
         )
 
 
 class ZensusMiscellaneous(Dataset):
+    sources = DatasetSources(
+        urls={
+            "zensus_households":
+                'https://www.zensus2011.de/SharedDocs/Downloads/DE/Pressemitteilung/DemografischeGrunddaten/csv_Haushalte_100m_Gitter.zip?__blob=publicationFile&v=2',
+            "zensus_buildings":
+                'https://www.zensus2011.de/SharedDocs/Downloads/DE/Pressemitteilung/DemografischeGrunddaten/csv_Gebaeude_100m_Gitter.zip?__blob=publicationFile&v=2',
+            "zensus_apartments":
+                'https://www.zensus2011.de/SharedDocs/Downloads/DE/Pressemitteilung/DemografischeGrunddaten/csv_Wohnungen_100m_Gitter.zip?__blob=publicationFile&v=5'
+            })
+    targets = DatasetTargets(
+        files = {
+            "zensus_households":
+                "zensus_population/csv_Haushalte_100m_Gitter.zip",
+            "zensus_buildings":
+                "zensus_population/csv_Gebaeude_100m_Gitter.zip",
+            "zensus_apartments":
+                "zensus_population/csv_Wohnungen_100m_Gitter.zip"
+            },
+        tables = {
+            "zensus_households":
+                "society.egon_destatis_zensus_household_per_ha",
+            "zensus_buildings":
+                "society.egon_destatis_zensus_building_per_ha",
+            "zensus_apartments":
+                "society.egon_destatis_zensus_apartment_per_ha",
+            }
+        )
     def __init__(self, dependencies):
         super().__init__(
             name="ZensusMiscellaneous",

--- a/src/egon/data/datasets/zensus/__init__.py
+++ b/src/egon/data/datasets/zensus/__init__.py
@@ -15,7 +15,6 @@ import pandas as pd
 from egon.data import db, subprocess
 from egon.data.config import settings
 from egon.data.datasets import Dataset, DatasetSources, DatasetTargets
-import egon.data.config
 
 
 class ZensusPopulation(Dataset):
@@ -118,62 +117,48 @@ def download_and_check(url, target_file, max_iteration=5):
 
 def download_zensus_pop():
     """Download Zensus csv file on population per hectare grid cell."""
-    data_config = egon.data.config.datasets()
-    zensus_population_config = data_config["zensus_population"][
-        "original_data"
-    ]
-    download_directory = Path(".") / "zensus_population"
+
+    download_directory = Path(".") / ZensusPopulation.targets.files["zensus_population"]
     # Create the folder, if it does not exist already
     if not os.path.exists(download_directory):
         os.mkdir(download_directory)
 
-    target_file = (
-        download_directory / zensus_population_config["target"]["file"]
-    )
-
-    url = zensus_population_config["source"]["url"]
-    download_and_check(url, target_file, max_iteration=5)
+    download_and_check(
+        ZensusPopulation.sources.urls["original_data"],
+        ZensusPopulation.targets.files["zensus_population"],
+        max_iteration=5)
 
 
 def download_zensus_misc():
     """Download Zensus csv files on data per hectare grid cell."""
 
     # Get data config
-    data_config = egon.data.config.datasets()
-    download_directory = Path(".") / "zensus_population"
+    download_directory = Path(".") / ZensusMiscellaneous.targets.files["zensus_buildings"]
     # Create the folder, if it does not exist already
     if not os.path.exists(download_directory):
         os.mkdir(download_directory)
     # Download remaining zensus data set on households, buildings, apartments
+    for key in ZensusMiscellaneous.sources.urls:
+       download_and_check(
+           ZensusMiscellaneous.sources.urls[key],
+           ZensusMiscellaneous.targets.files[key],
+           max_iteration=5)
 
-    zensus_config = data_config["zensus_misc"]["original_data"]
-    zensus_misc_processed = data_config["zensus_misc"]["processed"]
-    zensus_url = zensus_config["source"]["url"]
-    zensus_files = zensus_misc_processed["file_table_map"].keys()
-    url_path_map = list(zip(zensus_url, zensus_files))
-
-    for url, path in url_path_map:
-        target_file_misc = download_directory / path
-
-        download_and_check(url, target_file_misc, max_iteration=5)
 
 
 def create_zensus_pop_table():
     """Create tables for zensus data in postgres database"""
 
-    # Get information from data configuration file
-    data_config = egon.data.config.datasets()
-    zensus_population_processed = data_config["zensus_population"]["processed"]
+    # Create table for population data
+    population_table = ZensusPopulation.targets.tables["zensus_population"]
+
 
     # Create target schema
     db.execute_sql(
-        f"CREATE SCHEMA IF NOT EXISTS {zensus_population_processed['schema']};"
-    )
-
-    # Create table for population data
-    population_table = (
-        f"{zensus_population_processed['schema']}"
-        f".{zensus_population_processed['table']}"
+        f"""
+        CREATE SCHEMA IF NOT EXISTS
+        {ZensusPopulation.targets.get_table_schema("zensus_population")};
+        """
     )
 
     db.execute_sql(f"DROP TABLE IF EXISTS {population_table} CASCADE;")
@@ -187,7 +172,7 @@ def create_zensus_pop_table():
               population smallint,
               geom_point geometry(Point,3035),
               geom geometry (Polygon, 3035),
-              CONSTRAINT {zensus_population_processed['table']}_pkey
+              CONSTRAINT {population_table.split('.')[1]}_pkey
               PRIMARY KEY (id)
         );
         """
@@ -197,22 +182,17 @@ def create_zensus_pop_table():
 def create_zensus_misc_tables():
     """Create tables for zensus data in postgres database"""
 
-    # Get information from data configuration file
-    data_config = egon.data.config.datasets()
-    zensus_misc_processed = data_config["zensus_misc"]["processed"]
-
-    # Create target schema
-    db.execute_sql(
-        f"CREATE SCHEMA IF NOT EXISTS {zensus_misc_processed['schema']};"
-    )
-
     # Create tables for household, apartment and building
-    for table in zensus_misc_processed["file_table_map"].values():
-        misc_table = f"{zensus_misc_processed['schema']}.{table}"
-
-        db.execute_sql(f"DROP TABLE IF EXISTS {misc_table} CASCADE;")
+    for table in ZensusMiscellaneous.targets.tables:
+        table_name = ZensusMiscellaneous.targets.tables[table]
+        # Create target schema
         db.execute_sql(
-            f"CREATE TABLE {misc_table}"
+            f"CREATE SCHEMA IF NOT EXISTS {table_name.split('.')[0]};"
+        )
+
+        db.execute_sql(f"DROP TABLE IF EXISTS {table_name} CASCADE;")
+        db.execute_sql(
+            f"CREATE TABLE {table_name}"
             f""" (id                 SERIAL,
                   grid_id            VARCHAR(50),
                   grid_id_new        VARCHAR (50),
@@ -222,7 +202,7 @@ def create_zensus_misc_tables():
                   quantity           smallint,
                   quantity_q         smallint,
                   zensus_population_id int,
-                  CONSTRAINT {table}_pkey PRIMARY KEY (id)
+                  CONSTRAINT {table_name.split('.')[1]}_pkey PRIMARY KEY (id)
             );
             """
         )
@@ -388,23 +368,13 @@ def filter_zensus_misc(filename, dataset):
 def population_to_postgres():
     """Import Zensus population data to postgres database"""
     # Get information from data configuration file
-    data_config = egon.data.config.datasets()
-    zensus_population_orig = data_config["zensus_population"]["original_data"]
-    zensus_population_processed = data_config["zensus_population"]["processed"]
-    input_file = (
-        Path(".")
-        / "zensus_population"
-        / zensus_population_orig["target"]["file"]
-    )
+    input_file = ZensusPopulation.targets.files["zensus_population"]
     dataset = settings()["egon-data"]["--dataset-boundary"]
 
     # Read database configuration from docker-compose.yml
     docker_db_config = db.credentials()
 
-    population_table = (
-        f"{zensus_population_processed['schema']}"
-        f".{zensus_population_processed['table']}"
-    )
+    population_table = ZensusPopulation.targets.tables["zensus_population"]
 
     with zipfile.ZipFile(input_file) as zf:
         for filename in zf.namelist():
@@ -447,13 +417,13 @@ def population_to_postgres():
     )
 
     db.execute_sql(
-        f"CREATE INDEX {zensus_population_processed['table']}_geom_idx ON"
+        f"CREATE INDEX {population_table.split('.')[1]}_geom_idx ON"
         f" {population_table} USING gist (geom);"
     )
 
     db.execute_sql(
         f"CREATE INDEX"
-        f" {zensus_population_processed['table']}_geom_point_idx"
+        f" {population_table.split('.')[1]}_geom_point_idx"
         f" ON  {population_table} USING gist (geom_point);"
     )
 
@@ -461,23 +431,16 @@ def population_to_postgres():
 def zensus_misc_to_postgres():
     """Import data on buildings, households and apartments to postgres db"""
 
-    # Get information from data configuration file
-    data_config = egon.data.config.datasets()
-    zensus_misc_processed = data_config["zensus_misc"]["processed"]
-    zensus_population_processed = data_config["zensus_population"]["processed"]
-    file_path = Path(".") / "zensus_population"
     dataset = settings()["egon-data"]["--dataset-boundary"]
 
-    population_table = (
-        f"{zensus_population_processed['schema']}"
-        f".{zensus_population_processed['table']}"
-    )
+    population_table = ZensusPopulation.targets.tables["zensus_population"]
 
     # Read database configuration from docker-compose.yml
     docker_db_config = db.credentials()
 
-    for input_file, table in zensus_misc_processed["file_table_map"].items():
-        with zipfile.ZipFile(file_path / input_file) as zf:
+    for key in ZensusMiscellaneous.sources.urls:
+
+        with zipfile.ZipFile(ZensusMiscellaneous.targets.files[key]) as zf:
             csvfiles = [n for n in zf.namelist() if n.lower()[-3:] == "csv"]
             for filename in csvfiles:
                 zf.extract(filename)
@@ -493,7 +456,7 @@ def zensus_misc_to_postgres():
                 user = ["-U", f"{docker_db_config['POSTGRES_USER']}"]
                 command = [
                     "-c",
-                    rf"\copy {zensus_population_processed['schema']}.{table}"
+                    rf"\copy {ZensusMiscellaneous.targets.tables[key]}"
                     f"""(grid_id,
                         grid_id_new,
                         attribute,
@@ -513,15 +476,16 @@ def zensus_misc_to_postgres():
             os.remove(filename)
 
         db.execute_sql(
-            f"""UPDATE {zensus_population_processed['schema']}.{table} as b
+            f"""UPDATE {ZensusMiscellaneous.targets.tables[key]} as b
                     SET zensus_population_id = zs.id
                     FROM {population_table} zs
                     WHERE b.grid_id = zs.grid_id;"""
         )
 
         db.execute_sql(
-            f"""ALTER TABLE {zensus_population_processed['schema']}.{table}
-                    ADD CONSTRAINT {table}_fkey
+            f"""ALTER TABLE {ZensusMiscellaneous.targets.tables[key]}
+                    ADD CONSTRAINT
+                    {ZensusMiscellaneous.targets.get_table_name(key)}_fkey
                     FOREIGN KEY (zensus_population_id)
                     REFERENCES {population_table}(id);"""
         )
@@ -568,21 +532,13 @@ def adjust_zensus_misc():
     None.
 
     """
-    # Get information from data configuration file
-    data_config = egon.data.config.datasets()
-    zensus_population_processed = data_config["zensus_population"]["processed"]
-    zensus_misc_processed = data_config["zensus_misc"]["processed"]
 
-    population_table = (
-        f"{zensus_population_processed['schema']}"
-        f".{zensus_population_processed['table']}"
-    )
-
-    for input_file, table in zensus_misc_processed["file_table_map"].items():
+    for table in ZensusMiscellaneous.targets.tables:
         db.execute_sql(
             f"""
-             DELETE FROM {zensus_population_processed['schema']}.{table} as b
+             DELETE FROM {ZensusMiscellaneous.targets.tables[table]} as b
              WHERE b.zensus_population_id IN (
-                 SELECT id FROM {population_table}
+                 SELECT id FROM {
+                     ZensusPopulation.targets.tables["zensus_population"]}
                  WHERE population < 0);"""
         )


### PR DESCRIPTION
Deals with #1283

I implemented a first draft to add the attributes `sources` and `targets` to all `Datasets`. 
The attributes are added to every `Dataset`, but remain empty as long as they are not filled in the initialization.
There are also some functions added to `DatasetSources` and `DatasetTargets`, e.g. to easily get the schema of a specific table. 

The `sources` and `targets` are written into new columns of the table `metadata.datasets`. Submodules of the datasets can access the attributes from there to avoid importing the datasets class into the submodules (which always leads to a lot of problems with circular imports). In addition, this allows to get a quick overview of the `sources` and `targets` of all datasets. 

To be able to access the entries of `metadata.datasets` before all tasks of the dataset are executed, each dataset is first registered in the table, meaning that the information on the sources and targets is added. The version is still added after the execution of all tasks, in order to keep the versioning feature running. 

I tried the new structure for the datasets `ZensusPopulation`, `ZensusMiscellaneous` and `HeatSupply`. 
We will extend the usage in the future; those three are just meant to be examples. 

If you have any questions or comments, feel free to ask. I'm happy about any feedback! 
