### PR TITLE
Replace Centroid of industrial area with PointOnSurface

### DIFF
--- a/src/egon/data/datasets/chp/small_chp.py
+++ b/src/egon/data/datasets/chp/small_chp.py
@@ -467,7 +467,8 @@ def extension_industrial(federal_state, additional_capacity, flh_chp, EgonChp):
     industry_areas = db.select_geodataframe(
         f"""
         SELECT
-        SUM(demand) as demand, a.osm_id, ST_Centroid(b.geom) as geom, b.name
+        SUM(demand) as demand, a.osm_id,
+        ST_PointOnSurface(b.geom) as geom, b.name
         FROM
         {sources['industrial_demand_osm']['schema']}.
         {sources['industrial_demand_osm']['table']} a,

--- a/src/egon/data/datasets/chp_etrago.py
+++ b/src/egon/data/datasets/chp_etrago.py
@@ -206,6 +206,10 @@ def insert_scenario(scenario):
             electrical_bus_id, ch4_bus_id, a.carrier, c.bus_id)
         """
     )
+
+    chp_dh.loc[chp_dh[chp_dh.carrier=="gas extended"].index,
+                   "carrier"] = "gas"
+
     # Divide into biomass and gas CHP which are modelled differently
     chp_link_dh = chp_dh[chp_dh.carrier == "gas"].index
     chp_generator_dh = chp_dh[chp_dh.carrier != "gas"].index
@@ -345,6 +349,10 @@ def insert_scenario(scenario):
         GROUP BY (electrical_bus_id, ch4_bus_id, carrier)
         """
     )
+
+    chp_industry.loc[chp_industry[chp_industry.carrier=="gas extended"].index,
+                   "carrier"] = "gas"
+
     chp_link_ind = chp_industry[chp_industry.carrier == "gas"].index
 
     chp_generator_ind = chp_industry[chp_industry.carrier != "gas"].index

--- a/src/egon/data/datasets/heat_supply/individual_heating.py
+++ b/src/egon/data/datasets/heat_supply/individual_heating.py
@@ -656,6 +656,18 @@ def cascade_per_technology(
             {"bus_id": "mv_grid_id", "share": "capacity"}, axis=1, inplace=True
         )
 
+    elif (tech.index == "gas_boiler") & (scenario == "eGon2035"):
+        append_df = pd.DataFrame(
+            data={
+                "capacity": heat_per_mv.remaining_demand.div(
+                    tech.estimated_flh.values[0]
+                ),
+                "carrier": f"residential_rural_{tech.index}",
+                "mv_grid_id": heat_per_mv.index,
+                "scenario": scenario,
+            }
+        )
+
     elif tech.index in ("gas_boiler", "resistive_heater", "solar_thermal"):
         # Select target value for Germany
         target = db.select_dataframe(


### PR DESCRIPTION
Fixes #1308 .

There are a few edge cases where the Centroid of the area is not inside the area and may even be outside of the MV grid districts, for example, in the sea (at harbors). I stumbled over this one for example: 

<img width="722" height="677" alt="image" src="https://github.com/user-attachments/assets/9b0224b7-237e-4481-8706-5632d8fcd84e" />

In those cases, no bus_id can be assigned. To prevent these problems, a point on the surface is used instead.

## Before merging into `dev`-branch, please make sure that

- [ ] the `CHANGELOG.rst` was updated.
- [ ] new and adjusted code is formated using `black` and `isort`.
- [ ] the `Dataset`-version is updated when existing datasets are adjusted.
- [ ] the workflow is running successful in `test mode`.
- [ ] the workflow is running successful in `Everything` mode.
