### PR TITLE
Get zensus files from data-bundle

### DIFF
--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -141,14 +141,14 @@ with airflow.DAG(
     tyndp_data = Tyndp(dependencies=[setup])
 
     # Import zensus population
-    zensus_population = ZensusPopulation(dependencies=[setup, vg250])
+    zensus_population = ZensusPopulation(dependencies=[setup, vg250, data_bundle])
 
     # Combine zensus and VG250 data
     zensus_vg250 = ZensusVg250(dependencies=[vg250, zensus_population])
 
     # Download and import zensus data on households, buildings and apartments
     zensus_miscellaneous = ZensusMiscellaneous(
-        dependencies=[zensus_population, zensus_vg250]
+        dependencies=[zensus_population, zensus_vg250, data_bundle]
     )
 
     # Import DemandRegio data

--- a/src/egon/data/datasets/zensus/__init__.py
+++ b/src/egon/data/datasets/zensus/__init__.py
@@ -25,7 +25,6 @@ class ZensusPopulation(Dataset):
             version="0.0.2",
             dependencies=dependencies,
             tasks=(
-                download_zensus_pop,
                 create_zensus_pop_table,
                 population_to_postgres,
             ),
@@ -39,7 +38,6 @@ class ZensusMiscellaneous(Dataset):
             version="0.0.1",
             dependencies=dependencies,
             tasks=(
-                download_zensus_misc,
                 create_zensus_misc_tables,
                 zensus_misc_to_postgres,
             ),
@@ -80,6 +78,7 @@ def download_and_check(url, target_file, max_iteration=5):
 
 def download_zensus_pop():
     """Download Zensus csv file on population per hectare grid cell."""
+
     data_config = egon.data.config.datasets()
     zensus_population_config = data_config["zensus_population"][
         "original_data"
@@ -208,7 +207,8 @@ def target(source, dataset):
 
     """
     return Path(
-        os.path.join(Path("."), "zensus_population", source.stem)
+        os.path.join(Path("."), "data_bundle_egon_data", source.stem)
+        + "zensus_population"
         + "."
         + dataset
         + source.suffix
@@ -355,6 +355,7 @@ def population_to_postgres():
     zensus_population_processed = data_config["zensus_population"]["processed"]
     input_file = (
         Path(".")
+        / "data_bundle_egon_data"
         / "zensus_population"
         / zensus_population_orig["target"]["file"]
     )
@@ -427,7 +428,7 @@ def zensus_misc_to_postgres():
     data_config = egon.data.config.datasets()
     zensus_misc_processed = data_config["zensus_misc"]["processed"]
     zensus_population_processed = data_config["zensus_population"]["processed"]
-    file_path = Path(".") / "zensus_population"
+    file_path = Path(".") / "data_bundle_egon_data" / "zensus_population"
     dataset = settings()["egon-data"]["--dataset-boundary"]
 
     population_table = (


### PR DESCRIPTION
Zensus data from 2011 can not be downloaded as before. Until we switch to the new zensus data, the data is retrieved by the data bundle.

Related to #1318 

@CarlosEpia: Could you include this in your next run? I already tested the zensus tasks and they were working fine. 

## Before merging into `dev`-branch, please make sure that

- [ ] the `CHANGELOG.rst` was updated.
- [ ] new and adjusted code is formated using `black` and `isort`.
- [ ] the `Dataset`-version is updated when existing datasets are adjusted.
- [ ] the workflow is running successful in `test mode`.
- [ ] the workflow is running successful in `Everything` mode.
