### PR TITLE
Fix github actions

### DIFF
--- a/src/egon/data/config.py
+++ b/src/egon/data/config.py
@@ -73,7 +73,8 @@ def settings() -> dict[str, dict[str, str]]:
                 "--jobs": 1,
                 "--random-seed": 42,
                 "--processes-per-task": 1,
-                "--scenarios": "status2023",
+                "--scenarios": ["status2019", "eGon2035"],
+                "--run-pypsa-eur": False,
             }
         }
     with open(files[0]) as f:


### PR DESCRIPTION
Fixes #1307 .

I had another look at this problem. There are different default values in cli.py and in config.py.
Sorry for my confusion!
The ones in config.py were not set correctly, and those are the ones used by the tox tests. This is fixed here.

