### PR TITLE
Exclude version of google-re2 that can't be installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
         "geopandas>=0.10.0",
         "geopy",
         "geovoronoi",
+        "google-re2!=1.1.20250722",
         "importlib-resources<6.0",
         "loguru",
         "markupsafe",


### PR DESCRIPTION
Fixes the tox test within the github actions

## Before merging into `dev`-branch, please make sure that

- [ ] the `CHANGELOG.rst` was updated.
- [ ] new and adjusted code is formated using `black` and `isort`.
- [ ] the `Dataset`-version is updated when existing datasets are adjusted.
- [ ] the workflow is running successful in `test mode`.
- [ ] the workflow is running successful in `Everything` mode.
