### PR TITLE
Distribute pv rooftop to buildings always based on status quo distribution

### DIFF
--- a/src/egon/data/datasets/power_plants/pv_rooftop_buildings.py
+++ b/src/egon/data/datasets/power_plants/pv_rooftop_buildings.py
@@ -2429,21 +2429,21 @@ def pv_rooftop_to_buildings():
         .set_geometry("geom")
     )
 
-    scenario_buildings_gdf = all_buildings_gdf.copy()
+    scenario_buildings_gdf_sq = all_buildings_gdf.copy()
 
     cap_per_bus_id_df = pd.DataFrame()
 
     for scenario in SCENARIOS:
         if scenario == status_quo:
-            continue
+            scenario_buildings_gdf = scenario_buildings_gdf_sq.copy()
         elif "status" in scenario:
             ts = pd.Timestamp(
                 config.datasets()["mastr_new"][f"{scenario}_date_max"], tz="UTC"
             )
 
-            scenario_buildings_gdf = scenario_buildings_gdf.loc[
+            scenario_buildings_gdf = scenario_buildings_gdf_sq.loc[
                 scenario_buildings_gdf.commissioning_date <= ts
-            ]
+            ].copy()
 
         else:
             logger.debug(f"Desaggregating scenario {scenario}.")
@@ -2454,7 +2454,7 @@ def pv_rooftop_to_buildings():
             ) = allocate_scenarios(  # noqa: F841
                 desagg_mastr_gdf,
                 desagg_buildings_gdf,
-                scenario_buildings_gdf,
+                scenario_buildings_gdf_sq,
                 scenario,
             )
 


### PR DESCRIPTION
Before, the distribution was done based on the previously created scenario. This resulted into errors when different scenarios were created (eGon2035 and eGon100RE).

Related to #1330 .

## Before merging into `dev`-branch, please make sure that

- [ ] the `CHANGELOG.rst` was updated.
- [x] new and adjusted code is formated using `black` and `isort`.
- [ ] the `Dataset`-version is updated when existing datasets are adjusted.
- [ ] the workflow is running successful in `test mode`.
- [x] the workflow is running successful in `Everything` mode.
