### PR TITLE
Create distrct heating profiles with census cells selected in annual demand

### DIFF
--- a/src/egon/data/datasets/heat_demand_timeseries/__init__.py
+++ b/src/egon/data/datasets/heat_demand_timeseries/__init__.py
@@ -309,6 +309,8 @@ def create_district_heating_profile_python_like(scenario="eGon2035"):
         index_col="zensus_population_id",
     )
 
+    # Assign zensus cells that are part of two district heating grids to
+    # one of them
     annual_demand = annual_demand[
         ~annual_demand.index.duplicated(keep="first")
     ]
@@ -346,6 +348,14 @@ def create_district_heating_profile_python_like(scenario="eGon2035"):
 
                 """
             )
+
+            # Exclude profiles of zensus cells that are in two district
+            # heating grids and added to the other one in the lines above
+            selected_profiles = selected_profiles[
+                selected_profiles.zensus_population_id.isin(
+                    annual_demand[annual_demand.area_id == area].index
+                )
+            ]
 
             if not selected_profiles.empty:
                 df = pd.merge(


### PR DESCRIPTION
A few cells are assigned to two district heating grids. This is a bug. To allow the correct creation of the profiles, the cells are signed to one of the grids. In the longer term, the creation of district heating areas needs to be fixed. When this is done, this commit can be reverted.

Deals with #1337 .

## Before merging into `dev`-branch, please make sure that

- [ ] the `CHANGELOG.rst` was updated.
- [ ] new and adjusted code is formated using `black` and `isort`.
- [ ] the `Dataset`-version is updated when existing datasets are adjusted.
- [ ] the workflow is running successful in `test mode`.
- [ ] the workflow is running successful in `Everything` mode.
