### PR TITLE
Change name of postgres-connection type of database connection

### DIFF
--- a/src/egon/data/cli.py
+++ b/src/egon/data/cli.py
@@ -444,7 +444,7 @@ def egon_data(context, **kwargs):
     connection.host = options["--database-host"]
     connection.port = options["--database-port"]
     connection.schema = options["--database-name"]
-    connection.conn_type = "pgsql"
+    connection.conn_type = "postgres"
     airflow.add(connection)
     airflow.commit()
 


### PR DESCRIPTION
The previous "pgsql" was renamed to "postgres" in airflow version 2.10

This fixes the problem in the lowflex-scenario creation

## Before merging into `dev`-branch, please make sure that

- [x] new and adjusted code is formated using `black` and `isort`.
- [x] the workflow is running successful in `test mode`.
- [x] the workflow is running successful in `Everything` mode.
