### PR TITLE
Fixes/#1347 bast data url

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@ Changed
 Bug Fixes
 ---------
 
+* Fix URL of BASt traffic data
+  `#1347 <https://github.com/openego/eGon-data/issues/1347>`_
+
 
 Version 2.0.0 (2025-08-20)
 ==========================

--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -692,7 +692,7 @@ etrago_hydrogen:
       schema: 'grid'
       table: 'egon_etrago_link'
     H2_grid:
-      new_constructed_pipes:  
+      new_constructed_pipes:
         url: 'https://fnb-gas.de/wp-content/uploads/2024/07/2024_07_22_Anlage3_FNB_Massnahmenliste_Neubau.xlsx'
         path: "Anlage_3_Wasserstoffkernnetz_Neubau.xlsx"
       converted_ch4_pipes:
@@ -700,7 +700,7 @@ etrago_hydrogen:
         path: "Anlage_4_Wasserstoffkernnetz_Umstellung.xlsx"
       pipes_of_further_h2_grid_operators:
         url: 'https://fnb-gas.de/wp-content/uploads/2024/07/2024_07_22_Anlage2_Leitungsmeldungen_weiterer_potenzieller_Wasserstoffnetzbetreiber.xlsx'
-        path: "Anlage_2_Wasserstoffkernetz_weitere_Leitungen.xlsx"     
+        path: "Anlage_2_Wasserstoffkernetz_weitere_Leitungen.xlsx"
   targets:
     hydrogen_buses:
       schema: 'grid'
@@ -1291,7 +1291,7 @@ home_batteries:
     home_batteries:
       schema: 'supply'
       table: 'egon_home_batteries'
-      
+
 PtH2_waste_heat_O2:
   sources:
     ehv_substation:
@@ -1340,7 +1340,7 @@ PtH2_waste_heat_O2:
     buses:
       schema: 'grid'
       table: 'egon_etrago_bus'
-      
+
 
 scenario_path:
   sources:

--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -1231,7 +1231,7 @@ mobility_hgv:
     original_data:
       sources:
         BAST:
-          url: "https://www.bast.de/DE/Verkehrstechnik/Fachthemen/v2-verkehrszaehlung/Daten/2020_1/Jawe2020.csv?view=renderTcDataExportCSV&cms_strTyp=A"
+          url: "https://www.bast.de/DE/Themen/Digitales/HF_1/Massnahmen/verkehrszaehlung/Daten/2020_1/Jawe2020.csv?view=renderTcDataExportCSV&strTyp=A"
           file: "Jawe2020.csv"
           relevant_columns: ["DTV_SV_MobisSo_Q", "Koor_WGS84_E", "Koor_WGS84_N"]
           srid: 4326

--- a/src/egon/data/datasets/emobility/heavy_duty_transport/__init__.py
+++ b/src/egon/data/datasets/emobility/heavy_duty_transport/__init__.py
@@ -109,7 +109,7 @@ class HeavyDutyTransport(Dataset):
     #:
     name: str = "HeavyDutyTransport"
     #:
-    version: str = "0.0.2"
+    version: str = "0.0.3"
 
     def __init__(self, dependencies):
         super().__init__(


### PR DESCRIPTION
Fixes #1347 .

@CarlosEpia I updated the URL but did not test as I have no instance which is up to date. Would you mind to test it?

We could also update it to [latest 2023 data](https://mobilithek.info/offers/573280210227470336) data but as we're heading towards eTrucks in #1195 I wouldn't take the risk right now as the truck count locations slightly changed.

## Before merging into `dev`-branch, please make sure that

- [x] the `CHANGELOG.rst` was updated.
- [x] new and adjusted code is formated using `black` and `isort`.
- [x] the `Dataset`-version is updated when existing datasets are adjusted.
- [ ] the workflow is running successful in `test mode`.
- [ ] the workflow is running successful in `Everything` mode.
