### PR TITLE
Fix CTS el. demand for reGon2037

### DIFF
--- a/src/egon/data/datasets/scenario_parameters/parameters.py
+++ b/src/egon/data/datasets/scenario_parameters/parameters.py
@@ -571,7 +571,7 @@ def electricity(scenario):
         parameters["annual_demand"] = {
             "households": 83.0
             * 1e6,  # MWh source: NEP 2025 V.2; figure 6, Scenario C 2037
-            "CTS": 86.0
+            "CTS": 89.2
             * 1e6,  # MWh source: NEP 2025 V.2; figure 6, Scenario C 2037
             "industry": 309.1
             * 1e6,  # MWh source: NEP 2025 V.2; figure 6, Scenario C 2037


### PR DESCRIPTION
Small fix of CTS el. demand for reGon2037 - most likely a copy&paste error.
Introduced in #1427.

Cf. figure 6 in [NEP](https://www.netzentwicklungsplan.de/sites/default/files/2026-05/NEP_2037_2045_V2025_2_Entwurf_1.pdf)