### PR TITLE
Fixes/#1487 next etrago id issues

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -80,6 +80,14 @@ Bug Fixes
   sources/targets; registration is now skipped with a warning when no
   database is available
   `#1435 <https://github.com/openego/eGon-data/issues/1435>`_
+* Fix eTraGo ID sequences getting out of sync with the IDs actually
+  written, which made concurrent inserts fail with ``duplicate key value
+  violates unique constraint``: ``h2_neighbours_egon2035`` derived a range
+  of IDs from a single reserved one, and foreign pumped hydro storages
+  drew their ``storage_id`` from the ``store`` sequence. ``next_etrago_id``
+  now ignores the case of the component name and always returns a list
+  when a count is given
+  `#1487 <https://github.com/openego/eGon-data/issues/1487>`_
 
 Version 2.0.0 (2025-08-20)
 ==========================

--- a/src/egon/data/datasets/DSM_cts_ind.py
+++ b/src/egon/data/datasets/DSM_cts_ind.py
@@ -1061,13 +1061,13 @@ def aggregate_components(df_dsm_buses, df_dsm_links, df_dsm_stores):
     df_dsm_stores["bus"] = bus_id
 
     # select new link_ids for aggregated links
-    link_id = db.next_etrago_id("Link", len(df_dsm_links.index))
+    link_id = db.next_etrago_id("link", len(df_dsm_links.index))
 
     df_dsm_links["link_id"] = link_id
 
     # select new store_ids to aggregated stores
 
-    store_id = db.next_etrago_id("Store", len(df_dsm_stores.index))
+    store_id = db.next_etrago_id("store", len(df_dsm_stores.index))
 
     df_dsm_stores["store_id"] = store_id
 

--- a/src/egon/data/datasets/electrical_neighbours.py
+++ b/src/egon/data/datasets/electrical_neighbours.py
@@ -1740,7 +1740,7 @@ def insert_storage_units_sq():
             "cyclic_state_of_charge"
         ]
 
-        sto_sq["storage_id"] = db.next_etrago_id("store", len(sto_sq))
+        sto_sq["storage_id"] = db.next_etrago_id("storage", len(sto_sq))
 
         # Delete entrances without any installed capacity
         sto_sq = sto_sq[sto_sq["p_nom"] > 0]
@@ -2181,7 +2181,7 @@ class ElectricalNeighbours(Dataset):
     #:
     name: str = "ElectricalNeighbours"
     #:
-    version: str = "0.0.15"
+    version: str = "0.0.16"
 
     sources = DatasetSources(
         tables={

--- a/src/egon/data/datasets/pypsaeur/__init__.py
+++ b/src/egon/data/datasets/pypsaeur/__init__.py
@@ -53,7 +53,7 @@ class RunPypsaEur(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="SolvePypsaEur",
-            version="0.0.43",
+            version="0.0.44",
             dependencies=dependencies,
             tasks=(
                 prepare_network_2,
@@ -127,11 +127,7 @@ def h2_neighbours_egon2035():
         # Adjust dataframe to the database table format
         h2_bus["scn_name"] = "eGon2035"
 
-        bus_id = db.next_etrago_id("bus")  # will be change in PR1287
-        ### Delete when PR1287 is merged ###
-        bus_id = range(bus_id, bus_id + len(h2_bus.index))
-        ####################################
-        h2_bus["bus_id"] = bus_id
+        h2_bus["bus_id"] = db.next_etrago_id("bus", len(h2_bus.index))
 
         h2_bus.drop(
             columns=[

--- a/src/egon/data/db.py
+++ b/src/egon/data/db.py
@@ -227,34 +227,46 @@ def select_geodataframe(sql, index_col=None, geom_col="geom", epsg=3035):
     return gdf
 
 
-def next_etrago_id(component, count=1):
+def next_etrago_id(component, count=None):
     """
     Reserve one or more unique IDs from a PostgreSQL sequence specific to the
     given component.
 
+    Every ID written to an ``grid.egon_etrago_*`` table must be reserved
+    here, one call per ID. Deriving further IDs from a reserved one (e.g.
+    via :func:`range`) leaves the sequence behind the IDs actually
+    written, so the next IDs it hands out are already taken and inserts
+    fail with a unique violation, cf. `#1487
+    <https://github.com/openego/eGon-data/issues/1487>`_.
+
     Parameters
     ----------
     component : str
-        Name of the component (e.g., 'line', 'transformer', etc.).
+        Name of the component (e.g., 'line', 'transformer', etc.). Case is
+        ignored.
     count : int, optional
-        Number of IDs to reserve. Defaults to 1.
+        Number of IDs to reserve. If omitted, a single ID is returned as a
+        scalar.
 
     Returns
     -------
     int or list of int
-        A single ID (if count == 1) or a list of IDs.
+        A single ID if `count` is omitted, otherwise a list of `count`
+        IDs. Note that a list is returned even for ``count=1``, so the
+        result can be assigned to a DataFrame index regardless of length.
     """
 
-    sequence_name = f"grid.etrago_{component}_id_seq"
+    sequence_name = f"grid.etrago_{component.lower()}_id_seq"
 
     # Fetch the next `count` IDs from the sequence
     id_query = f"""
-        SELECT nextval('{sequence_name}') FROM generate_series(1, {count})
+        SELECT nextval('{sequence_name}')
+        FROM generate_series(1, {1 if count is None else count})
     """
     ids_df = select_dataframe(id_query)
     ids = ids_df["nextval"].tolist()
 
-    return ids[0] if count == 1 else ids
+    return ids[0] if count is None else ids
 
 
 def check_db_unique_violation(func):


### PR DESCRIPTION
Fixes #1487.
**Note:** This issue should be merged before #1485 to avoid etrago id conflicts!

Follow-up to #1287, whose mitigation was not applied thoroughly. Every ID
written to a `grid.egon_etrago_*` table must be reserved from the matching
sequence; three places did not do that, so the sequences drifted behind the
IDs actually present and concurrent inserts failed with `UniqueViolation`.

**Fixes**

- `pypsaeur.h2_neighbours_egon2035()` reserved one `bus_id` and derived a
  range of N from it. Now passes the count. This is the one that broke the
  MIT bunch tasks in #1485.
- `electrical_neighbours.insert_storage_units_sq()` drew `storage_id` for
  foreign pumped hydro from the `store` sequence instead of `storage`, so
  the `storage` sequence never advanced for those rows. Its sibling block
  for batteries 70 lines below already did it correctly.
- `DSM_cts_ind.aggregate_components()` asked for the `"Link"`/`"Store"`
  sequences. This only worked because PostgreSQL case-folds unquoted
  identifiers.

**`next_etrago_id()` hardening**

- Lower-cases the component name, so lookups no longer rely on that folding.
- Returns a list whenever a count is given, instead of a scalar for
  `count == 1`. Eight call sites assign the result to a DataFrame index and
  would have crashed with a `TypeError` on a single-row frame.
- Documents that IDs must be reserved one call per ID.

Dataset versions bumped: `SolvePypsaEur` 0.0.43 → 0.0.44,
`ElectricalNeighbours` 0.0.15 → 0.0.16. `DsmPotential` is unchanged, the
case fix alters no behaviour.

**Checked, no change needed:** all ~100 `next_etrago_id()` call sites were
reviewed. `motorized_individual_travel` is clean — it reserves exactly one
ID per row from the correct sequence in all four of its writes; it was the
victim here, not a cause, simply because it makes ~4 sequence draws per MV
grid district per scenario.

@CarlosEpia **Before re-running on an existing database,** the already desynchronised
sequences need realigning, otherwise the poisoned ID blocks remain:

```sql
SELECT setval('grid.etrago_bus_id_seq',     (SELECT MAX(bus_id)     FROM grid.egon_etrago_bus));
SELECT setval('grid.etrago_storage_id_seq', (SELECT MAX(storage_id) FROM grid.egon_etrago_storage));
```

## 🧑‍💻 Contributor Checklist

Before requesting a review, make sure you've completed all of the following:

- [x] All **tests pass** locally or via CI
      _(for more information on local test, check `tox` in the [Contributing section](https://egon-data.readthedocs.io/en/latest/contributing.html#))_
      _(CI tests are automatically executed when creating a PR, you can see the results of the checks below)_
- [x] Workflow has run at least once in **Test mode**
      _(optional if no dataset changes are involved)_
- [x] Relevant **documentation is updated** (API, new features, etc.)
- [x] Dataset-versions are updated when existing datasets are adjusted.
- [x] Added a note to `CHANGELOG.rst` about the changes
- [x] Added yourself to `AUTHORS.rst`

---

## 🔍 Reviewer Checklist

During your review, please check the following:

- [ ] **Is the code clean, readable, and efficient?** Are there any oddities or obvious inefficiencies?
- [ ] Does the code work as expected? _(should already be verified by contributor)_
- [ ] Do all tests pass? (see CI results)
- [ ] Is the documentation complete and up to date?
- [ ] Is `CHANGELOG.rst` updated accordingly?
- [ ] Is all necessary metadata complete and correct?
  - [ ] If metadata is pending: Is there an appropriate issue filed?
