### PR TITLE
1475 feature rework status2024 demand data rerun generation independently instead of proxying egon2035 and verify hp capacity placeholder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,16 @@ develop-eggs
 lib
 lib64
 venv*/
+.venv*/
 pyvenv*/
 pip-wheel-metadata/
+
+# Local runtime config (contains DB credentials) and scratch/test scripts
+egon-data.configuration.yaml
+scratch/
+
+# Session planning docs (local use only, not project documentation)
+STATUS2024_HP_IMPLEMENTATION_PLAN.md
 
 # Installer logs
 pip-log.txt

--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -1199,14 +1199,20 @@ demand_timeseries_mvgd:
   parallel_tasks: 10
 
 heat_pumps_status_quo:
-  # Status-quo-type scenarios (e.g. status2024) don't yet have their own
-  # demand/PV data. Maps each such scenario to the existing scenario whose
-  # data is read as a stand-in. Update here (not in code) once real data for
-  # a status-quo scenario is inserted.
+  # Maps a status-quo scenario to the scenario whose demand/PV data is read.
+  # These existed because status-quo scenarios originally had no data of their
+  # own and proxied eGon2035. Both now resolve to themselves: real status2024
+  # data is present in egon_peta_heat, egon_map_zensus_district_heating_areas
+  # and egon_power_plants_pv_roof_building.
+  #
+  # Only point a mapping at another scenario if this database genuinely lacks
+  # the data, and never at a scenario absent from the target table: the lookup
+  # then matches nothing and fails silently (see pv_source_scenario history --
+  # "status_quo" matched no rows, so PV weighting had no effect at all).
   demand_source_scenario:
-    status2024: "eGon2035"
+    status2024: "status2024"
   pv_source_scenario:
-    status2024: "status_quo"
+    status2024: "status2024"
 
 charging_infrastructure:
   original_data:

--- a/src/egon/data/datasets.yml
+++ b/src/egon/data/datasets.yml
@@ -1198,6 +1198,16 @@ emobility_mit:
 demand_timeseries_mvgd:
   parallel_tasks: 10
 
+heat_pumps_status_quo:
+  # Status-quo-type scenarios (e.g. status2024) don't yet have their own
+  # demand/PV data. Maps each such scenario to the existing scenario whose
+  # data is read as a stand-in. Update here (not in code) once real data for
+  # a status-quo scenario is inserted.
+  demand_source_scenario:
+    status2024: "eGon2035"
+  pv_source_scenario:
+    status2024: "status_quo"
+
 charging_infrastructure:
   original_data:
     sources:

--- a/src/egon/data/datasets/electricity_demand_timeseries/cts_buildings.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/cts_buildings.py
@@ -43,6 +43,7 @@ from egon.data.datasets.electricity_demand_timeseries.tools import (
     write_table_to_postgres,
 )
 from egon.data.datasets.heat_demand import EgonPetaHeat
+from egon.data.datasets.scenario_parameters import demand_source_scenario
 from egon.data.datasets.heat_demand_timeseries import EgonEtragoHeatCts
 from egon.data.datasets.zensus_mv_grid_districts import MapZensusGridDistricts
 from egon.data.datasets.zensus_vg250 import DestatisZensusPopulationPerHa
@@ -1076,13 +1077,21 @@ def calc_cts_building_profiles(
         # df_cts_profiles = calc_load_curves_cts(scenario)
 
     elif sector == "heat":
+        # Status-quo-type scenarios don't yet have their own heat demand
+        # data; read from the configured source scenario instead (see
+        # scenario_parameters.demand_source_scenario).
+        demand_scenario = demand_source_scenario(scenario)
+
         # Get cts building heat demand share of selected buildings
         with db.session_scope() as session:
             cells_query = (
                 session.query(
                     EgonCtsHeatDemandBuildingShare,
                 )
-                .filter(EgonCtsHeatDemandBuildingShare.scenario == scenario)
+                .filter(
+                    EgonCtsHeatDemandBuildingShare.scenario
+                    == demand_scenario
+                )
                 .filter(EgonCtsHeatDemandBuildingShare.bus_id.in_(bus_ids))
             )
 
@@ -1097,7 +1106,7 @@ def calc_cts_building_profiles(
         with db.session_scope() as session:
             cells_query = (
                 session.query(EgonEtragoHeatCts).filter(
-                    EgonEtragoHeatCts.scn_name == scenario
+                    EgonEtragoHeatCts.scn_name == demand_scenario
                 )
             ).filter(EgonEtragoHeatCts.bus_id.in_(bus_ids))
 
@@ -1112,7 +1121,7 @@ def calc_cts_building_profiles(
         for bus_id in bus_ids:
             if bus_id in df_cts_substation_profiles.index:
                 # get peta demand to scale load profile to
-                peta_cts_demand = get_peta_demand(bus_id, scenario)
+                peta_cts_demand = get_peta_demand(bus_id, demand_scenario)
                 scaling_factor = (
                     peta_cts_demand.demand.sum()
                     / df_cts_substation_profiles.loc[bus_id, :].sum()

--- a/src/egon/data/datasets/electricity_demand_timeseries/cts_buildings.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/cts_buildings.py
@@ -43,7 +43,6 @@ from egon.data.datasets.electricity_demand_timeseries.tools import (
     write_table_to_postgres,
 )
 from egon.data.datasets.heat_demand import EgonPetaHeat
-from egon.data.datasets.scenario_parameters import demand_source_scenario
 from egon.data.datasets.heat_demand_timeseries import EgonEtragoHeatCts
 from egon.data.datasets.zensus_mv_grid_districts import MapZensusGridDistricts
 from egon.data.datasets.zensus_vg250 import DestatisZensusPopulationPerHa
@@ -1077,21 +1076,13 @@ def calc_cts_building_profiles(
         # df_cts_profiles = calc_load_curves_cts(scenario)
 
     elif sector == "heat":
-        # Status-quo-type scenarios don't yet have their own heat demand
-        # data; read from the configured source scenario instead (see
-        # scenario_parameters.demand_source_scenario).
-        demand_scenario = demand_source_scenario(scenario)
-
         # Get cts building heat demand share of selected buildings
         with db.session_scope() as session:
             cells_query = (
                 session.query(
                     EgonCtsHeatDemandBuildingShare,
                 )
-                .filter(
-                    EgonCtsHeatDemandBuildingShare.scenario
-                    == demand_scenario
-                )
+                .filter(EgonCtsHeatDemandBuildingShare.scenario == scenario)
                 .filter(EgonCtsHeatDemandBuildingShare.bus_id.in_(bus_ids))
             )
 
@@ -1106,7 +1097,7 @@ def calc_cts_building_profiles(
         with db.session_scope() as session:
             cells_query = (
                 session.query(EgonEtragoHeatCts).filter(
-                    EgonEtragoHeatCts.scn_name == demand_scenario
+                    EgonEtragoHeatCts.scn_name == scenario
                 )
             ).filter(EgonEtragoHeatCts.bus_id.in_(bus_ids))
 
@@ -1121,7 +1112,7 @@ def calc_cts_building_profiles(
         for bus_id in bus_ids:
             if bus_id in df_cts_substation_profiles.index:
                 # get peta demand to scale load profile to
-                peta_cts_demand = get_peta_demand(bus_id, demand_scenario)
+                peta_cts_demand = get_peta_demand(bus_id, scenario)
                 scaling_factor = (
                     peta_cts_demand.demand.sum()
                     / df_cts_substation_profiles.loc[bus_id, :].sum()

--- a/src/egon/data/datasets/heat_supply/__init__.py
+++ b/src/egon/data/datasets/heat_supply/__init__.py
@@ -379,7 +379,7 @@ class HeatSupply(Dataset):
     #:
     name: str = "HeatSupply"
     #:
-    version: str = "0.0.18"
+    version: str = "0.0.19"
 
     sources = DatasetSources(
         tables={

--- a/src/egon/data/datasets/heat_supply/individual_heating.py
+++ b/src/egon/data/datasets/heat_supply/individual_heating.py
@@ -50,6 +50,10 @@ from egon.data.datasets.heat_demand_timeseries.daily import (
 from egon.data.datasets.heat_demand_timeseries.idp_pool import (
     EgonHeatTimeseries,
 )
+from egon.data.datasets.scenario_parameters import (
+    demand_source_scenario,
+    pv_source_scenario,
+)
 
 # get zensus cells with district heating
 from egon.data.datasets.zensus_mv_grid_districts import MapZensusGridDistricts
@@ -756,6 +760,8 @@ def cascade_heat_supply_indiv(scenario, distribution_level, plotting=True):
 
     sources, targets = load_sources_and_targets("HeatSupply")
 
+    demand_scenario = demand_source_scenario(scenario)
+
     # Select residential heat demand per mv grid district and federal state
     heat_per_mv = db.select_geodataframe(
         f"""
@@ -768,11 +774,11 @@ def cascade_heat_supply_indiv(scenario, distribution_level, plotting=True):
         ON b.bus_id = c.bus_id
         JOIN {sources.tables['mv_grids']} d
         ON d.bus_id = c.bus_id
-        WHERE scenario = '{scenario}'
+        WHERE scenario = '{demand_scenario}'
         AND a.zensus_population_id NOT IN (
             SELECT zensus_population_id
             FROM {sources.tables['map_dh']}
-            WHERE scenario = '{scenario}')
+            WHERE scenario = '{demand_scenario}')
         GROUP BY d.bus_id, vg250_lan, geom
         """,
         index_col="bus_id",
@@ -1046,7 +1052,7 @@ def calc_residential_heat_profiles_per_mvgd(mvgd, scenario):
         "demand_ts",
     ]
 
-    df_peta_demand = get_peta_demand(mvgd, scenario)
+    df_peta_demand = get_peta_demand(mvgd, demand_source_scenario(scenario))
     df_peta_demand = reduce_mem_usage(df_peta_demand)
 
     # TODO maybe return empty dataframe
@@ -1188,7 +1194,8 @@ def get_zensus_cells_with_decentral_heat_demand_in_mv_grid(
         query = session.query(
             MapZensusDistrictHeatingAreas.zensus_population_id,
         ).filter(
-            MapZensusDistrictHeatingAreas.scenario == scenario,
+            MapZensusDistrictHeatingAreas.scenario
+            == demand_source_scenario(scenario),
             MapZensusDistrictHeatingAreas.zensus_population_id.in_(
                 zensus_population_ids
             ),
@@ -1447,7 +1454,7 @@ def determine_minimum_hp_capacity_per_building(
 
 
 def determine_buildings_with_hp_in_mv_grid(
-    hp_cap_mv_grid, min_hp_cap_per_building
+    hp_cap_mv_grid, min_hp_cap_per_building, scenario="eGon2035"
 ):
     """
     Distributes given total heat pump capacity to buildings based on their peak
@@ -1460,6 +1467,10 @@ def determine_buildings_with_hp_in_mv_grid(
     min_hp_cap_per_building : pd.Series
         Pandas series with minimum required heat pump capacity per building
          in MW.
+    scenario : str
+        Name of the scenario. Determines which scenario's PV rooftop data is
+        used to weight buildings (via
+        :func:`~.scenario_parameters.pv_source_scenario`).
 
     Returns
     -------
@@ -1479,7 +1490,8 @@ def determine_buildings_with_hp_in_mv_grid(
             egon_power_plants_pv_roof_building.building_id
         ).filter(
             egon_power_plants_pv_roof_building.building_id.in_(building_ids),
-            egon_power_plants_pv_roof_building.scenario == "eGon2035",
+            egon_power_plants_pv_roof_building.scenario
+            == pv_source_scenario(scenario),
         )
 
         buildings_with_pv = pd.read_sql(
@@ -1650,7 +1662,7 @@ def determine_hp_cap_buildings_pvbased_per_mvgd(
 
         # select buildings that will have a heat pump
         buildings_with_hp = determine_buildings_with_hp_in_mv_grid(
-            hp_cap_grid, min_hp_cap_buildings
+            hp_cap_grid, min_hp_cap_buildings, scenario=scenario
         )
 
         # distribute total heat pump capacity to all buildings with HP

--- a/src/egon/data/datasets/heat_supply/individual_heating.py
+++ b/src/egon/data/datasets/heat_supply/individual_heating.py
@@ -312,7 +312,7 @@ class HeatPumpsStatusQuo(Dataset):
 
         super().__init__(
             name="HeatPumpsStatusQuo",
-            version="0.0.5",
+            version="0.0.6",
             dependencies=dependencies,
             tasks=tasks,
         )
@@ -652,11 +652,11 @@ def cascade_per_technology(
             if not target.capacity[0]:
                 target.capacity[0] = 0
 
-            if (
-                config.settings()["egon-data"]["--dataset-boundary"]
-                == "Schleswig-Holstein"
-            ):
-                target.capacity[0] /= 16
+            # No testmode scaling here: the 'rural_heat_pump' target is already
+            # reduced to the dataset boundary by population_share() when it is
+            # inserted in scenario_capacities.insert_capacities_status_quo().
+            # Dividing by 16 again applied the boundary reduction twice and made
+            # the distributed capacity ~16x too low.
 
             heat_per_mv["share"] = (
                 heat_per_mv.remaining_demand
@@ -1494,9 +1494,12 @@ def determine_buildings_with_hp_in_mv_grid(
             == pv_source_scenario(scenario),
         )
 
-        buildings_with_pv = pd.read_sql(
-            query.statement, query.session.bind, index_col=None
-        ).building_id.values
+        buildings_with_pv = (
+            pd.read_sql(query.statement, query.session.bind, index_col=None)
+            .building_id.drop_duplicates()
+            .sort_values()
+            .values
+        )
     # set different weights for buildings with PV and without PV
     weight_with_pv = 1.5
     weight_without_pv = 1.0
@@ -1556,7 +1559,11 @@ def determine_buildings_with_hp_in_mv_grid(
             min_cap_buildings_wo_hp <= remaining_hp_cap
         ].index
 
-    return buildings_with_hp
+    # Guard against duplicated building ids reaching the caller. A duplicate
+    # would be allocated capacity twice and then silently dropped by
+    # drop_duplicates() in the bulk export, losing that capacity from the
+    # grid's budget without any rescaling.
+    return buildings_with_hp.drop_duplicates()
 
 
 def desaggregate_hp_capacity(min_hp_cap_per_building, hp_cap_mv_grid):

--- a/src/egon/data/datasets/sanity_checks.py
+++ b/src/egon/data/datasets/sanity_checks.py
@@ -2925,6 +2925,18 @@ def heat_gas_load_egon100RE(scn="eGon100RE"):
     print(loads_capacities)
 
 
+def no_sanity_checks_required():
+    print(
+        f"""
+          None of the configured scenarios ({", ".join(SCENARIOS)})
+          have sanity checks implemented. Sanity checks currently only
+          cover the 'eGon2035' and 'eGon100RE' scenarios, so nothing is
+          checked for this run.
+          """
+    )
+    return None
+
+
 tasks = ()
 
 if "eGon2035" in SCENARIOS:
@@ -2954,6 +2966,11 @@ if "eGon100RE" in SCENARIOS:
             heat_gas_load_egon100RE,
         },
     )
+
+if not tasks:
+    # `Dataset` requires at least one task, so fall back to a no-op when
+    # none of the configured scenarios have sanity checks implemented.
+    tasks = (no_sanity_checks_required,)
 
 
 class SanityChecks(Dataset):

--- a/src/egon/data/datasets/scenario_capacities.py
+++ b/src/egon/data/datasets/scenario_capacities.py
@@ -136,11 +136,12 @@ def insert_capacities_status_quo(scenario: str) -> None:
         """)
 
     rural_heat_capacity = {
-        # Convert heat pump count to MW installed capacity
-        # assuming 5 kW_el per heat pump (source: Entwurf des Szenariorahmens NEP 2035,
-        # version 2021, page 47)
-        # Rural heat capacity for 2024 according to NEP 2037/2045, version 2025, table 1
-        "status2024": 2e6 * 5e-3,
+
+        # Rural heat capacity for status2024: 2 Mio. heat pumps, 5 kW average.
+        # TODO: VERIFY — heat-pump count (2e6) and 5 kW average size are
+        #  placeholders and must be confirmed against a primary source
+        #  (e.g. NEP 2025 / BWP).
+        "status2024": 2e6 * 5e-3,  # = 10 000 MW
     }[scenario]
 
     if config.settings()["egon-data"]["--dataset-boundary"] != "Everything":

--- a/src/egon/data/datasets/scenario_capacities.py
+++ b/src/egon/data/datasets/scenario_capacities.py
@@ -401,9 +401,20 @@ def aggr_nep_capacities(carriers):
 
     """
     # Get list of power plants from nep
-    nep_capacities = insert_nep_list_powerplants(export=False)[
-        ["federal_state", "scenario", "carrier", "c2035_capacity", "c2037_capacity", "c2045_capacity"]
-    ]
+    # Depending on the configured scenarios, only one of the NEP power plant
+    # lists may have been loaded, so not all capacity columns are present.
+    # Missing ones are added as NaN, which yields empty per-scenario
+    # aggregations below.
+    nep_capacities = insert_nep_list_powerplants(export=False).reindex(
+        columns=[
+            "federal_state",
+            "scenario",
+            "carrier",
+            "c2035_capacity",
+            "c2037_capacity",
+            "c2045_capacity",
+        ]
+    )
 
     # Sum up capacities per federal state and carrier for eGon2035
     capacities_list_eGon = (
@@ -636,14 +647,20 @@ def insert_nep_list_powerplants(export=True):
         ]
         
         # scale all capacity to the respective population share
+        # Only columns of the NEP lists that were actually loaded are
+        # present, depending on the configured scenarios
         for col in [
-            "capacity",
-            "a2035_capacity",
-            "b2035_capacity",
-            "c2035_capacity",
-            "b2040_capacity",
-            "c2037_capacity",
-            "c2045_capacity",
+            c
+            for c in [
+                "capacity",
+                "a2035_capacity",
+                "b2035_capacity",
+                "c2035_capacity",
+                "b2040_capacity",
+                "c2037_capacity",
+                "c2045_capacity",
+            ]
+            if c in kw_liste_nep.columns
         ]:
             kw_liste_nep.loc[
                 kw_liste_nep[kw_liste_nep.federal_state.isnull()].index, col

--- a/src/egon/data/datasets/scenario_capacities.py
+++ b/src/egon/data/datasets/scenario_capacities.py
@@ -136,12 +136,11 @@ def insert_capacities_status_quo(scenario: str) -> None:
         """)
 
     rural_heat_capacity = {
-
-        # Rural heat capacity for status2024: 2 Mio. heat pumps, 5 kW average.
-        # TODO: VERIFY — heat-pump count (2e6) and 5 kW average size are
-        #  placeholders and must be confirmed against a primary source
-        #  (e.g. NEP 2025 / BWP).
-        "status2024": 2e6 * 5e-3,  # = 10 000 MW
+        # Convert heat pump count to MW installed capacity
+        # assuming 5 kW_el per heat pump (source: Entwurf des Szenariorahmens NEP 2035,
+        # version 2021, page 47)
+        # Rural heat capacity for 2024 according to NEP 2037/2045, version 2025, table 1
+        "status2024": 2e6 * 5e-3,
     }[scenario]
 
     if config.settings()["egon-data"]["--dataset-boundary"] != "Everything":

--- a/src/egon/data/datasets/scenario_parameters/__init__.py
+++ b/src/egon/data/datasets/scenario_parameters/__init__.py
@@ -53,6 +53,32 @@ def get_scenario_year(scenario_name):
     return year
 
 
+def demand_source_scenario(scenario):
+    """Resolve the scenario to query scenario-dependent demand tables for.
+
+    Status-quo-type scenarios don't yet have their own demand data and
+    instead read from an existing scenario as a stand-in, configured in
+    ``datasets.yml`` under ``heat_pumps_status_quo.demand_source_scenario``.
+    """
+    mapping = egon.data.config.datasets()["heat_pumps_status_quo"][
+        "demand_source_scenario"
+    ]
+    return mapping.get(scenario, scenario)
+
+
+def pv_source_scenario(scenario):
+    """Resolve the scenario to query the PV rooftop table for.
+
+    Status-quo-type scenarios don't yet have their own PV data and instead
+    read from an existing scenario as a stand-in, configured in
+    ``datasets.yml`` under ``heat_pumps_status_quo.pv_source_scenario``.
+    """
+    mapping = egon.data.config.datasets()["heat_pumps_status_quo"][
+        "pv_source_scenario"
+    ]
+    return mapping.get(scenario, scenario)
+
+
 def insert_scenarios():
     """Insert scenarios and their parameters to scenario table
 


### PR DESCRIPTION
## What this does

Replaces the `status2024` demand/PV proxying with direct reads, and fixes three defects found
while verifying the resulting heat pump distribution.

Closes #1475 (partially — see **Still missing** below, which is why this is a draft).

## Changes

### 1. Read `status2024` data directly instead of proxying eGon2035

`demand_source_scenario()` and `pv_source_scenario()` now resolve `status2024` to itself. Real
data is present in `egon_peta_heat`, `egon_map_zensus_district_heating_areas` and
`egon_power_plants_pv_roof_building`.

The demand proxy was not cosmetic: `status2024` residential heat demand is **~58 % higher** than
`eGon2035`'s (22.0 vs 13.9 TWh), so heat pumps were being sized from the wrong profile.

The PV mapping pointed at `"status_quo"`, a scenario that **does not exist** in
`egon_power_plants_pv_roof_building` (it holds only `eGon2035` and `status2024`). The lookup
matched zero rows, so every building fell back to equal weight and the PV weighting had no effect
at all — silently, with no error.

### 2. Fix double boundary scaling of the status-quo HP target

`insert_capacities_status_quo()` already reduces the national `rural_heat_pump` target to the
dataset boundary via `population_share()` (3.49 % for Schleswig-Holstein).
`cascade_per_technology()`'s `national` branch then divided by 16 again as a crude
"1 of 16 federal states" proxy.

| | before | after |
|---|---|---|
| national target | 10,000 MW | 10,000 MW |
| × `population_share()` | 349.42 MW | 349.42 MW |
| ÷ 16 | **21.84 MW** | *(removed)* |
| distributed to MV grids | 21.84 MW | **349.42 MW** |

`eGon2035` never hit this: it takes the `federal_states` branch, which reads a per-state row and
has no such division. The `national` branch is used only by status scenarios, so the `/16`
predates them and assumed an unscaled target. Full-Germany runs were unaffected.

### 3. Fix duplicate building ids in the PV-weighted selection

`egon_power_plants_pv_roof_building` contains every `status2024` row **twice** (233,700 rows for
116,850 buildings). Those duplicates entered the `weights` index in
`determine_buildings_with_hp_in_mv_grid()`, so `np.random.choice` could draw the same building
twice. Both copies were allocated capacity, and the second was then silently dropped by
`drop_duplicates("building_id")` in the bulk export — removing that capacity from the grid's
budget with **no rescaling**.

Measured via temporary instrumentation: `pre_dedup_sum` = 349.417503 MW (exactly the budget),
then 72 rows / 1.68 MW dropped before the write.

Deduplicating and **sorting** the PV query result also makes the seeded draw reproducible. The
query has no `ORDER BY`, so the weights index was built in arbitrary order and `--random-seed`
did not pin the outcome — repeated runs returned 87 / 90 / 92 buildings for the same grid.

> The duplicated rows are a bug in `pv_rooftop_to_buildings()` (the accumulator is seeded with the
> status-quo rows before a loop that appends them again). That is filed separately, since it also
> doubles status-quo PV capacity for `home_batteries` and `sanity_checks`. The change here is
> defensive so the HP path is correct regardless.

### 4. Fix `KeyError` when only part of the NEP scenarios are configured

`insert_nep_list_powerplants()` loads NEP2021 for `eGon2035` and NEP2025 for
`reGon2037`/`reGon2045`. With only one group configured the other frame stays empty, so the
concatenated result lacks that list's capacity columns. Two places assumed all columns exist, so
a run with `[status2024, eGon2035]` on a federal-state boundary failed twice in a row:

```
KeyError: 'c2037_capacity'
KeyError: "['c2037_capacity', 'c2045_capacity'] not in index"
```

Pre-existing on `dev`; needs both a partial NEP scenario set **and**
`--dataset-boundary != "Everything"` to trigger, which is why CI has not caught it.

### 5. Let `SanityChecks` build with no implemented scenario checks

Sanity checks only cover `eGon2035` and `eGon100RE`. With neither configured the tasks tuple was
empty and `Dataset` raised, breaking DAG construction. Falls back to a no-op that logs which
scenarios ran unchecked.

## Verification

`status2024` vs `eGon2035` in a Schleswig-Holstein run:

| | `status2024` | `eGon2035` |
|---|---|---|
| heat pumps | 14,934 | 103,022 |
| capacity | 349.417 MW | 1,654.370 MW |
| mean HP size | 23.40 kW | 16.06 kW |
| conservation | 100.0000 % | 99.9998 % |

Checks that hold for both scenarios:

- **Capacity conservation** — `sum(hp_capacity)` equals the `HeatSupply` budget: 349.41800 vs
  349.41750 MW for `status2024` (0.0001 % float rounding), 1654.36000 vs 1654.36833 MW for
  `eGon2035`. Every MV grid reaches its budget.
- **Sizing rule** — every building gets at least `peak_load × (24/18) / 1.7`; no undersized buildings
- **Units** — `hp_capacity` in MW, `peak_load_in_w` in W, eTraGo series length 8760
- **PV weighting active** — PV-owning buildings are over-represented among HP buildings

A review notebook covering these is available on request (not committed — it is analysis, not
pipeline code).

## Still missing (why this is a draft)

- **Sanity checks for status-quo scenarios.** Item 5 only stops their absence from breaking the
  DAG; the checks themselves are unwritten.
- **ADRs 0001 / 0002 are referenced by #1475 but not present** in `docs/adr/`. Either they were
  never committed or they live elsewhere — worth resolving before merge so the references are not
  dangling.

## Out of scope

- Phase E — future scenarios treating `status2024`'s per-building assignments as a fixed floor (#1477)
- Other exact-string scenario gates across `power_plants/`, `chp/`, `demandregio/`, `motorized_individual_travel/`
- The `pv_rooftop_to_buildings()` duplication itself (filed separately)
