### PR TITLE
Features/#1310 ethos builda integration

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,4 +2,4 @@
 Authors
 =======
 
-* Jonathan Amme, Clara Büttner, Ilka Cußmann, Julian Endres, Carlos Epia, Kilian Helfenbein, Stephan Günther, Ulf Müller, Amélia Nadal, Guido Pleßmann, Francesco Witte  - https://github.com/openego/eGon-data
+* Jonathan Amme, Clara Büttner, Ilka Cußmann, Julian Endres, Carlos Epia, Kilian Helfenbein, Jonas Huber, Stephan Günther, Ulf Müller, Amélia Nadal, Guido Pleßmann, Francesco Witte  - https://github.com/openego/eGon-data

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,10 +12,19 @@ Added
   `#1352 <https://github.com/openego/egon-data/issues/1352>`_
 * Add standardized sources and targets definitions across dataset modules
   `#1283 <https://github.com/openego/egon-data/issues/1283>`_
+* Add dataset EthosBuilda, importing the ETHOS.BUILDA synthetic building
+  stock from Zenodo
+  `#1310 <https://github.com/openego/eGon-data/issues/1310>`_
 
 Changed
 -------
 
+* Determine residential buildings by intersecting OSM buildings with
+  ETHOS.BUILDA instead of filtering by OSM tags alone, keeping the ETHOS
+  attributes and the provenance of each match, and read residential
+  buildings alongside the filtered ones in the household load area demand,
+  the building mapping and the PV rooftop potentials
+  `#1310 <https://github.com/openego/eGon-data/issues/1310>`_
 * Set annual electricity demands in scenario parameters
   `#1359 <https://github.com/openego/eGon-data/issues/1359>`_
 * Introduce TaskGroups to group Datasets in the pipeline

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,9 +21,10 @@ Changed
 
 * Determine residential buildings by intersecting OSM buildings with
   ETHOS.BUILDA instead of filtering by OSM tags alone, keeping the ETHOS
-  attributes and the provenance of each match, and read residential
-  buildings alongside the filtered ones in the household load area demand,
-  the building mapping and the PV rooftop potentials
+  attributes and the provenance of each match, retain the previous filter's
+  amenity-based capture of care homes, and read residential buildings
+  alongside the filtered ones in the household load area demand, the
+  building mapping and the PV rooftop potentials
   `#1310 <https://github.com/openego/eGon-data/issues/1310>`_
 * Set annual electricity demands in scenario parameters
   `#1359 <https://github.com/openego/eGon-data/issues/1359>`_

--- a/docs/data/input_data.rst
+++ b/docs/data/input_data.rst
@@ -45,6 +45,23 @@ Currently, two versions are used:
 
 The download is implemented in :class:`MastrData<egon.data.datasets.mastr.MastrData>`.
 
+.. _ethos-builda-ref:
+
+ETHOS.BUILDA
+------------
+
+`ETHOS.BUILDA <https://doi.org/10.5281/zenodo.13771740>`_ is a synthetic
+building stock for Germany, published under ODbL-1.0 and requiring attribution
+of TABULA. It supplies one point per residential building together with
+construction year, size class, refurbishment state and TABULA type, published
+as one CSV per NUTS-1 region.
+
+In eGon-data it is used to decide which OSM building polygons are residential,
+which OSM tags alone do not answer reliably, and to carry the building
+attributes downstream. The download and import is implemented in
+:class:`EthosBuilda<egon.data.datasets.ethos_builda.EthosBuilda>`, the
+intersection in :ref:`building-data-ref`.
+
 .. _osm-ref:
 
 OpenStreetMap
@@ -89,6 +106,13 @@ The data processing steps are:
 
   * All buildings: `openstreetmap.osm_buildings`
   * Filtered buildings: `openstreetmap.osm_buildings_filtered`
+
+* Determine residential buildings by intersecting all buildings with
+  ETHOS.BUILDA (see :ref:`ethos-builda-ref`) rather than by OSM tags alone,
+  see script `osm_buildings_filter_residential.sql`. Each building keeps the
+  provenance of its match in column `source` and, where it was matched, the
+  ETHOS attributes. Resulting table:
+
   * Residential buildings: `openstreetmap.osm_buildings_residential`
 
 * Create a mapping table for building's OSM IDs to the Zensus cells the

--- a/docs/data/input_data.rst
+++ b/docs/data/input_data.rst
@@ -50,7 +50,7 @@ The download is implemented in :class:`MastrData<egon.data.datasets.mastr.MastrD
 ETHOS.BUILDA
 ------------
 
-`ETHOS.BUILDA <https://doi.org/10.5281/zenodo.13771740>`_ is a synthetic
+`ETHOS.BUILDA <https://doi.org/10.5281/zenodo.13771740>`__ is a synthetic
 building stock for Germany, published under ODbL-1.0 and requiring attribution
 of TABULA. It supplies one point per residential building together with
 construction year, size class, refurbishment state and TABULA type, published
@@ -61,6 +61,18 @@ which OSM tags alone do not answer reliably, and to carry the building
 attributes downstream. The download and import is implemented in
 :class:`EthosBuilda<egon.data.datasets.ethos_builda.EthosBuilda>`, the
 intersection in :ref:`building-data-ref`.
+
+.. warning::
+   The four attributes are modelled, not observed, and their provenance differs
+   sharply. **`refurbishment_state` is a random draw** from federal-state
+   statistics for every building in the dataset -- it reproduces the
+   distribution of a state but says nothing about an individual building, so do
+   not evaluate it per building. `construction_year` is estimated by a model for
+   about two thirds of the buildings, `size_class` largely likewise, and
+   `tabula_type` is composed deterministically from the other three. The
+   per-attribute provenance is kept in the columns
+   `construction_year_lineage` and `size_class_lineage`; the other two are
+   constant across the dataset and therefore documented rather than stored.
 
 .. _osm-ref:
 
@@ -114,6 +126,27 @@ The data processing steps are:
   ETHOS attributes. Resulting table:
 
   * Residential buildings: `openstreetmap.osm_buildings_residential`
+
+  Column `source` tells how a building was classified, which is the first thing
+  to look at when a result surprises you:
+
+  * `ethos_intersect` -- an ETHOS point lies inside the polygon
+  * `ethos_nearest` -- nearest ETHOS point within 10 m of the polygon
+  * `osm_tagging` -- no ETHOS point, but the `building` tag is residential
+  * `census_gap_fill` -- added by the next step below, not by the intersection
+
+  .. note::
+     Two known limitations of the classification. Buildings whose residential
+     use is only expressed through `amenity` -- care homes tagged
+     `amenity=nursing_home` or `amenity=social_facility` on a
+     `building=yes` polygon -- are **no longer** classified as residential
+     unless ETHOS happens to cover them; the previous tag-based filter did
+     catch them. They remain in `osm_buildings_filtered` and are therefore
+     still counted, but as CTS rather than residential. Conversely, where an
+     ETHOS point lands on an obvious ancillary building (garage, shed,
+     carport), that building is classified residential on purpose: the point
+     belongs to a real dwelling and merely sits on the neighbouring polygon,
+     so discarding it would lose the dwelling altogether.
 
 * Create a mapping table for building's OSM IDs to the Zensus cells the
   building's centroid is located in.

--- a/docs/data/input_data.rst
+++ b/docs/data/input_data.rst
@@ -133,17 +133,19 @@ The data processing steps are:
   * `ethos_intersect` -- an ETHOS point lies inside the polygon
   * `ethos_nearest` -- nearest ETHOS point within 10 m of the polygon
   * `osm_tagging` -- no ETHOS point, but the `building` tag is residential
+  * `osm_amenity` -- no ETHOS point and an uninformative `building` tag, but a
+    care-home `amenity` (see below)
   * `census_gap_fill` -- added by the next step below, not by the intersection
 
   .. note::
-     Two known limitations of the classification. Buildings whose residential
-     use is only expressed through `amenity` -- care homes tagged
-     `amenity=nursing_home` or `amenity=social_facility` on a
-     `building=yes` polygon -- are **no longer** classified as residential
-     unless ETHOS happens to cover them; the previous tag-based filter did
-     catch them. They remain in `osm_buildings_filtered` and are therefore
-     still counted, but as CTS rather than residential. Conversely, where an
-     ETHOS point lands on an obvious ancillary building (garage, shed,
+     Two properties of the classification worth knowing. Care homes whose
+     residential use is expressed only through `amenity` -- tagged
+     `amenity=nursing_home` or `amenity=social_facility` on an uninformative
+     `building=yes` polygon -- are matched by a dedicated branch and carry
+     `source = 'osm_amenity'`. Without it they would fall through both rules:
+     the tag whitelist deliberately excludes `building=yes`, and it is checked
+     against the `building` column, where OSM does not put these values. And
+     where an ETHOS point lands on an obvious ancillary building (garage, shed,
      carport), that building is classified residential on purpose: the point
      belongs to a real dwelling and merely sits on the neighbouring polygon,
      so discarding it would lose the dwelling altogether.

--- a/docs/reference/egon.data.datasets.ethos_builda.rst
+++ b/docs/reference/egon.data.datasets.ethos_builda.rst
@@ -1,0 +1,8 @@
+ethos\_builda
+=============
+
+
+.. automodule:: egon.data.datasets.ethos_builda
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/egon.data.datasets.rst
+++ b/docs/reference/egon.data.datasets.rst
@@ -41,6 +41,7 @@ datasets
    egon.data.datasets.electricity_demand
    egon.data.datasets.electricity_demand_timeseries
    egon.data.datasets.emobility
+   egon.data.datasets.ethos_builda
    egon.data.datasets.gas_neighbours
    egon.data.datasets.heat_demand
    egon.data.datasets.heat_demand_timeseries

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -39,6 +39,7 @@ from egon.data.datasets.emobility.motorized_individual_travel_charging_infrastru
     MITChargingInfrastructure,
 )
 from egon.data.datasets.era5 import WeatherData
+from egon.data.datasets.ethos_builda import EthosBuilda
 from egon.data.datasets.etrago_setup import EtragoSetup
 from egon.data.datasets.fill_etrago_gen import Egon_etrago_gen
 from egon.data.datasets.fix_ehv_subnetworks import FixEhvSubnetworks
@@ -157,9 +158,12 @@ with airflow.DAG(
             dependencies=[zensus_population, zensus_vg250, data_bundle]
         )
 
+        # ETHOS.BUILDA residential building data
+        ethos_builda = EthosBuilda(dependencies=[setup])
+
         # OSM (OpenStreetMap) buildings, streets and amenities
         osm_buildings_streets = OsmBuildingsStreets(
-            dependencies=[osm, zensus_miscellaneous]
+            dependencies=[osm, zensus_miscellaneous, ethos_builda]
         )
 
         # Import saltcavern storage potentials

--- a/src/egon/data/datasets/electricity_demand_timeseries/cts_buildings.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/cts_buildings.py
@@ -230,10 +230,11 @@ class CtsDemandBuildings(Dataset):
     #:
     name: str = "CtsDemandBuildings"
     #:
-    version: str = "0.0.9"
+    version: str = "0.0.10"
     sources = DatasetSources(
         tables={
             "osm_buildings_filtered": "openstreetmap.osm_buildings_filtered",
+            "osm_buildings_residential": "openstreetmap.osm_buildings_residential",
             "osm_amenities_shops_filtered": "openstreetmap.osm_amenities_shops_filtered",
             "osm_amenities_not_in_buildings_filtered": "openstreetmap.osm_amenities_not_in_buildings_filtered",
             "osm_buildings_synthetic": "openstreetmap.osm_buildings_synthetic",

--- a/src/egon/data/datasets/electricity_demand_timeseries/mapping.py
+++ b/src/egon/data/datasets/electricity_demand_timeseries/mapping.py
@@ -40,6 +40,10 @@ def map_all_used_buildings():
     )
     EgonMapZensusMvgdBuildings.__table__.create(bind=db.engine())
 
+    # Residential buildings are not a subset of osm_buildings_filtered
+    # since #1310: the ETHOS.BUILDA intersection matches buildings whose
+    # OSM tag is missing from the filter list, plus ancillary buildings
+    # that are kept on purpose. UNION deduplicates the overlap.
     db.execute_sql(sql_string=f"""
         INSERT INTO {EgonMapZensusMvgdBuildings.__table_args__["schema"]}.
         {EgonMapZensusMvgdBuildings.__tablename__}
@@ -54,6 +58,9 @@ def map_all_used_buildings():
                 UNION
                 SELECT "id"::integer, geom_point
                 FROM {cts_s.tables["osm_buildings_filtered"]}
+                UNION
+                SELECT "id"::integer, geom_point
+                FROM {cts_s.tables["osm_buildings_residential"]}
             ) AS bld,
                 {cts_t.tables["building_electricity_peak_loads"]} AS peak,
                 {hh_s.tables["destatis_zensus_population_per_ha"]} AS zensus,

--- a/src/egon/data/datasets/ethos_builda/__init__.py
+++ b/src/egon/data/datasets/ethos_builda/__init__.py
@@ -1,0 +1,324 @@
+"""The central module containing all code dealing with importing ETHOS.BUILDA.
+
+ETHOS.BUILDA is a synthetic building stock dataset for Germany. It supplies one
+point per residential building together with construction year, size class,
+refurbishment state and TABULA type. eGon-data uses it to classify OSM building
+polygons as residential by spatial intersection instead of relying on OSM tags
+alone, see
+:py:mod:`osm_buildings_streets <egon.data.datasets.osm_buildings_streets>`.
+
+The data is published per NUTS-1 region (federal state) as one CSV each, which
+is also how the test mode is implemented: only Schleswig-Holstein (``DEF``) is
+downloaded and imported.
+"""
+
+from pathlib import Path
+from urllib.request import urlretrieve
+import hashlib
+import os
+
+from sqlalchemy import text
+
+from egon.data import db, logger
+from egon.data.config import settings
+from egon.data.datasets import Dataset, DatasetSources, DatasetTargets
+import egon.data.subprocess as subprocess
+
+#: Zenodo record of ETHOS.BUILDA v2.0.0, DOI 10.5281/zenodo.13771740
+ZENODO_RECORD = "13771740"
+
+#: Template for a file download from the Zenodo REST API
+ZENODO_FILE_URL = (
+    "https://zenodo.org/api/records/{record}/files/{filename}/content"
+)
+
+#: Local download directory, relative to the egon-data working directory
+DOWNLOAD_DIRECTORY = Path(".") / "ethos_builda"
+
+#: One CSV per NUTS-1 region, with size and MD5 checksum as published on
+#: Zenodo. Size is used to detect an already complete download, the checksum
+#: verifies a fresh one.
+ETHOS_FILES = {
+    "DE1": {"size": 840685377, "md5": "aab2d48de4a826c71004543333455327"},
+    "DE2": {"size": 1275700666, "md5": "a37c61c533f74f4783b404c258eb055c"},
+    "DE3": {"size": 103955160, "md5": "c0166995f74f38503ceb8b9542d78924"},
+    "DE4": {"size": 288550765, "md5": "c8b3c4371ffa0d5e0c014af625778dba"},
+    "DE5": {"size": 44734828, "md5": "e951342ad810f396415a3d4a18a05569"},
+    "DE6": {"size": 88055813, "md5": "fa9c147ca0c5527a02cb66681466ab9d"},
+    "DE7": {"size": 714990713, "md5": "210750cb89c0a061d8957385ebde8e0e"},
+    "DE8": {"size": 95970367, "md5": "58ac122303efe1fac646ca4ebbe69c8f"},
+    "DE9": {"size": 857126161, "md5": "5ae5a296d8a7fe16c3e2c84fc10a9938"},
+    "DEA": {"size": 1601606107, "md5": "2696cf5189bc089231ee4fdb09943601"},
+    "DEB": {"size": 360513970, "md5": "d6dba34ca3665befea6b80d15ac2121b"},
+    "DEC": {"size": 103194206, "md5": "fd4c6344d16b5368d4974f0ff7708d05"},
+    "DED": {"size": 323823386, "md5": "bfbfd45d792fd130a39ba816789e6fb6"},
+    "DEE": {"size": 319897115, "md5": "2db4d12a20769be9991600df046d641b"},
+    "DEF": {"size": 221670474, "md5": "721036d1ca2255164e3ab86604d7b4f9"},
+    "DEG": {"size": 271610575, "md5": "0d6b6a8e848803318d2ea7168af53f4e"},
+}
+
+#: NUTS-1 region imported in test mode (Schleswig-Holstein)
+TESTMODE_NUTS1 = "DEF"
+
+
+def nuts1_regions():
+    """NUTS-1 regions to import, depending on the dataset boundary.
+
+    Returns
+    -------
+    list of str
+        All 16 NUTS-1 codes for ``Everything``, only
+        :py:data:`TESTMODE_NUTS1` otherwise.
+    """
+    if settings()["egon-data"]["--dataset-boundary"] == "Everything":
+        return sorted(ETHOS_FILES)
+    logger.info(f"Using testmode dataset, only {TESTMODE_NUTS1}.")
+    return [TESTMODE_NUTS1]
+
+
+def download():
+    """Download the ETHOS.BUILDA CSV files from Zenodo.
+
+    Files already present with the published size are kept. A freshly
+    downloaded file is verified against its published MD5 checksum; an
+    existing one is not re-hashed, since that would read several gigabytes on
+    every pipeline run.
+    """
+    DOWNLOAD_DIRECTORY.mkdir(exist_ok=True)
+
+    for nuts1 in nuts1_regions():
+        filename = EthosBuilda.targets.files[nuts1]
+        target_file = DOWNLOAD_DIRECTORY / filename
+        published = ETHOS_FILES[nuts1]
+
+        if (
+            target_file.is_file()
+            and target_file.stat().st_size == published["size"]
+        ):
+            logger.info(f"{filename} already downloaded, skipping.")
+            continue
+
+        logger.info(f"Downloading {filename} ({published['size']} bytes)...")
+        urlretrieve(EthosBuilda.sources.urls[nuts1], target_file)
+
+        digest = hashlib.md5()
+        with open(target_file, "rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                digest.update(chunk)
+        if digest.hexdigest() != published["md5"]:
+            raise ValueError(
+                f"MD5 mismatch for {filename}: expected {published['md5']}, "
+                f"got {digest.hexdigest()}."
+            )
+        logger.info(f"{filename} downloaded and MD5 verified.")
+
+
+def to_postgres():
+    """Import the ETHOS.BUILDA CSV files into the database.
+
+    The CSVs carry the four building attributes as JSON objects
+    ``{"value", "source", "lineage"}``, so they are streamed into an unlogged
+    staging table with ``jsonb`` columns first and unpacked from there. Only
+    ``value`` is kept as a column; of the four lineages, two are constant
+    across the whole dataset (documented in the metadata) and two are
+    retained, because ``source`` determines ``lineage`` uniquely.
+
+    The regions are loaded one at a time and the staging table is truncated in
+    between, which bounds its size to the largest single CSV instead of the
+    full 7.5 GB.
+    """
+    target_table = EthosBuilda.targets.tables["ethos_builda_buildings"]
+    staging_table = f"{EthosBuilda.schema}.ethos_builda_staging"
+
+    db.execute_sql(f"CREATE SCHEMA IF NOT EXISTS {EthosBuilda.schema};")
+    db.execute_sql(f"DROP TABLE IF EXISTS {target_table} CASCADE;")
+    db.execute_sql(
+        f"""
+        CREATE TABLE {target_table} (
+            id                        text PRIMARY KEY,
+            nuts1                     text,
+            geom_point                geometry(Point, 3035),
+            construction_year         int,
+            construction_year_lineage text,
+            size_class                text,
+            size_class_lineage        text,
+            refurbishment_state       text,
+            tabula_type               text
+        );
+        """
+    )
+
+    db.execute_sql(f"DROP TABLE IF EXISTS {staging_table};")
+    db.execute_sql(
+        f"""
+        CREATE UNLOGGED TABLE {staging_table} (
+            id                  text,
+            position            text,
+            construction_year   jsonb,
+            size_class          jsonb,
+            refurbishment_state jsonb,
+            tabula_type         jsonb
+        );
+        """
+    )
+
+    for nuts1 in nuts1_regions():
+        csv_file = (
+            DOWNLOAD_DIRECTORY / EthosBuilda.targets.files[nuts1]
+        ).resolve()
+        logger.info(f"Importing {csv_file.name}...")
+        copy_csv_to_staging(csv_file, staging_table)
+
+        # ETHOS positions are WKT points in EPSG:3035 already, no reprojection
+        db.execute_sql(
+            f"""
+            INSERT INTO {target_table}
+            SELECT
+                id,
+                substring(id, 1, 3) AS nuts1,
+                ST_GeomFromText(position, 3035) AS geom_point,
+                (construction_year ->> 'value')::int AS construction_year,
+                construction_year ->> 'lineage' AS construction_year_lineage,
+                size_class ->> 'value' AS size_class,
+                size_class ->> 'lineage' AS size_class_lineage,
+                refurbishment_state ->> 'value' AS refurbishment_state,
+                tabula_type ->> 'value' AS tabula_type
+            FROM {staging_table};
+            """
+        )
+        count = count_rows(target_table, f"nuts1 = '{nuts1}'")
+        logger.info(f"{nuts1}: {count} buildings imported.")
+        db.execute_sql(f"TRUNCATE {staging_table};")
+
+    db.execute_sql(f"DROP TABLE {staging_table};")
+    db.execute_sql(f"CREATE INDEX ON {target_table} USING gist (geom_point);")
+    db.execute_sql(f"ANALYZE {target_table};")
+
+    logger.info(
+        f"ETHOS.BUILDA imported: {count_rows(target_table)} buildings."
+    )
+
+
+def count_rows(table, condition=None):
+    """Count rows of a table, for the import log.
+
+    Parameters
+    ----------
+    table : str
+        Schema-qualified table name.
+    condition : str, optional
+        A ``WHERE`` clause without the keyword.
+
+    Returns
+    -------
+    int
+        Number of rows.
+    """
+    query = f"SELECT count(*) FROM {table}"
+    if condition is not None:
+        query += f" WHERE {condition}"
+    with db.session_scope() as session:
+        return session.execute(text(query)).scalar()
+
+
+def copy_csv_to_staging(csv_file, staging_table):
+    """Stream one CSV into the staging table using ``psql``'s ``\\copy``.
+
+    ``\\copy`` runs client side, so the file does not have to be visible
+    inside the database container. Reading the CSV into pandas first was
+    measured at a ~12.9 GB memory peak and discarded.
+
+    Parameters
+    ----------
+    csv_file : pathlib.Path
+        Absolute path of the CSV to import.
+    staging_table : str
+        Schema-qualified name of the staging table.
+    """
+    docker_db_config = db.credentials()
+
+    subprocess.run(
+        [
+            "psql",
+            "-h",
+            f"{docker_db_config['HOST']}",
+            "-p",
+            f"{docker_db_config['PORT']}",
+            "-d",
+            f"{docker_db_config['POSTGRES_DB']}",
+            "-U",
+            f"{docker_db_config['POSTGRES_USER']}",
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-c",
+            rf"\copy {staging_table} FROM '{csv_file}' "
+            r"WITH (FORMAT csv, HEADER true)",
+        ],
+        env={
+            **os.environ,
+            "PGPASSWORD": docker_db_config["POSTGRES_PASSWORD"],
+        },
+    )
+
+
+class EthosBuilda(Dataset):
+    """
+    Download ETHOS.BUILDA building data and write it to the database.
+
+    ETHOS.BUILDA v2.0.0 (DOI `10.5281/zenodo.13771740
+    <https://doi.org/10.5281/zenodo.13771740>`_) is a synthetic building stock
+    for Germany: one point per residential building, with construction year,
+    size class, refurbishment state and TABULA type. It is published under
+    ODbL-1.0 and requires attribution of TABULA.
+
+    Raw data acquisition is kept separate from processing, mirroring
+    :py:class:`OpenStreetMap <egon.data.datasets.osm.OpenStreetMap>` and
+    :py:class:`OsmBuildingsStreets
+    <egon.data.datasets.osm_buildings_streets.OsmBuildingsStreets>`, so the
+    ETHOS attributes are available to other datasets as well.
+
+    *Dependencies*
+      * :py:func:`Setup <egon.data.datasets.database.setup>`
+
+    *Resulting Tables*
+      * society.egon_ethos_builda_buildings is created and filled (table has
+        no associated python class)
+
+    **Details and Steps**
+
+    * Download one CSV per NUTS-1 region from Zenodo, verifying the published
+      MD5 checksum. In test mode only Schleswig-Holstein (``DEF``) is fetched.
+    * Import them via a staging table, unpacking the ``value`` of the four
+      JSON-encoded attributes and building the point geometry from the WKT
+      ``position`` column, which is EPSG:3035 already.
+    """
+
+    #:
+    name: str = "EthosBuilda"
+    #:
+    version: str = "0.0.1"
+
+    schema: str = "society"
+
+    sources = DatasetSources(
+        urls={
+            nuts1: ZENODO_FILE_URL.format(
+                record=ZENODO_RECORD, filename=f"{nuts1}.csv"
+            )
+            for nuts1 in ETHOS_FILES
+        }
+    )
+    targets = DatasetTargets(
+        files={nuts1: f"{nuts1}.csv" for nuts1 in ETHOS_FILES},
+        tables={
+            "ethos_builda_buildings": "society.egon_ethos_builda_buildings"
+        },
+    )
+
+    def __init__(self, dependencies):
+        super().__init__(
+            name=self.name,
+            version=self.version,
+            dependencies=dependencies,
+            tasks=(download, to_postgres),
+        )

--- a/src/egon/data/datasets/loadarea/__init__.py
+++ b/src/egon/data/datasets/loadarea/__init__.py
@@ -110,7 +110,7 @@ class LoadArea(Dataset):
     #:
     name: str = "LoadArea"
     #:
-    version: str = "0.0.4"
+    version: str = "0.0.5"
 
     sources = DatasetSources(
         files={

--- a/src/egon/data/datasets/loadarea/loadareas_add_demand_hh.sql
+++ b/src/egon/data/datasets/loadarea/loadareas_add_demand_hh.sql
@@ -55,6 +55,15 @@ UPDATE demand.egon_loadarea AS t1
                             UNION
                             SELECT "id"::integer, geom_point
                             FROM openstreetmap.osm_buildings_filtered
+                            UNION
+                            -- residential buildings are not a subset of
+                            -- osm_buildings_filtered since #1310: ETHOS matches
+                            -- buildings whose tag is missing from the filter
+                            -- list, plus ancillary buildings that are kept on
+                            -- purpose. UNION (not UNION ALL) deduplicates the
+                            -- overlap, verified free of double counting.
+                            SELECT "id"::integer, geom_point
+                            FROM openstreetmap.osm_buildings_residential
                         ) AS bld
                     WHERE
                         peak.scenario = 'eGon2035' AND
@@ -115,6 +124,15 @@ UPDATE demand.egon_loadarea AS t1
                             UNION
                             SELECT "id"::integer, geom_point
                             FROM openstreetmap.osm_buildings_filtered
+                            UNION
+                            -- residential buildings are not a subset of
+                            -- osm_buildings_filtered since #1310: ETHOS matches
+                            -- buildings whose tag is missing from the filter
+                            -- list, plus ancillary buildings that are kept on
+                            -- purpose. UNION (not UNION ALL) deduplicates the
+                            -- overlap, verified free of double counting.
+                            SELECT "id"::integer, geom_point
+                            FROM openstreetmap.osm_buildings_residential
                         ) AS bld
                     WHERE
                         peak.scenario = 'eGon100RE' AND

--- a/src/egon/data/datasets/osm_buildings_streets/__init__.py
+++ b/src/egon/data/datasets/osm_buildings_streets/__init__.py
@@ -194,7 +194,7 @@ class OsmBuildingsStreets(Dataset):
     #:
     name: str = "OsmBuildingsStreets"
     #:
-    version: str = "0.0.10"
+    version: str = "0.0.11"
 
     sources = DatasetSources(
         tables={

--- a/src/egon/data/datasets/osm_buildings_streets/__init__.py
+++ b/src/egon/data/datasets/osm_buildings_streets/__init__.py
@@ -118,6 +118,7 @@ class OsmBuildingsStreets(Dataset):
 
     *Dependencies*
       * :py:class:`OpenStreetMap <egon.data.datasets.osm.OpenStreetMap>`
+      * :py:class:`EthosBuilda <egon.data.datasets.ethos_builda.EthosBuilda>`
       * :py:class:`ZensusMiscellaneous <egon.data.datasets.zensus.ZensusMiscellaneous>`
 
     *Resulting Tables*
@@ -142,11 +143,20 @@ class OsmBuildingsStreets(Dataset):
       * All buildings: `openstreetmap.osm_buildings`
       * Filtered buildings: `openstreetmap.osm_buildings_filtered`
       * Residential buildings: `openstreetmap.osm_buildings_residential`
-        * 1st step: Filter by tags (see `osm_buildings_filter_residential.sql`)
+        * 1st step: Intersect with ETHOS.BUILDA, which supplies one point per
+          residential building, in a three step cascade -- point inside the
+          polygon, nearest neighbour within 10 m, and OSM tags for what is
+          left (see `osm_buildings_filter_residential.sql`). Filtering by tags
+          alone overestimated the stock by about a third against Zensus 2022.
         * 2nd step: Table is extended by finding census cells with population
           but no residential buildings and extended by commercial/retail/office/
           hotel buildings (see `osm_buildings_extend_residential.sql`) since they
           often include apartments as well.
+        * Each building carries the provenance of its match in `source`
+          (`ethos_intersect`, `ethos_nearest`, `osm_tagging` or
+          `census_gap_fill`), the matched `ethos_id`, the `match_distance` and
+          the ETHOS attributes `construction_year`, `size_class`,
+          `refurbishment_state` and `tabula_type`.
     * Extract amenities and filter using relevant tags, e.g. shops and restaurants,
       see script `osm_amenities_shops_preprocessing.sql` for the full list of tags.
       Resulting table: `openstreetmap.osm_amenities_shops_filtered`
@@ -184,7 +194,7 @@ class OsmBuildingsStreets(Dataset):
     #:
     name: str = "OsmBuildingsStreets"
     #:
-    version: str = "0.0.9"
+    version: str = "0.0.10"
 
     sources = DatasetSources(
         tables={
@@ -194,6 +204,7 @@ class OsmBuildingsStreets(Dataset):
             "osm_ways": "openstreetmap.osm_ways",
             "zensus_apartments": "society.egon_destatis_zensus_apartment_building_population_per_ha",
             "zensus_population": "society.destatis_zensus_population_per_ha",
+            "ethos_builda_buildings": "society.egon_ethos_builda_buildings",
         }
     )
 

--- a/src/egon/data/datasets/osm_buildings_streets/__init__.py
+++ b/src/egon/data/datasets/osm_buildings_streets/__init__.py
@@ -132,8 +132,8 @@ class OsmBuildingsStreets(Dataset):
       * openstreetmap.osm_ways_preprocessed is created and filled (table has no associated python class)
       * openstreetmap.osm_ways_with_segments is created and filled (table has no associated python class)
       * boundaries.egon_map_zensus_buildings_filtered is created and filled (table has no associated python class)
+      * boundaries.egon_map_zensus_buildings_filtered_all is created and filled (table has no associated python class)
       * boundaries.egon_map_zensus_buildings_residential is created and filled (table has no associated python class)
-      * openstreetmap.osm_buildings is created and filled (table has no associated python class)
 
     **Details and Steps**
 
@@ -144,18 +144,21 @@ class OsmBuildingsStreets(Dataset):
       * Filtered buildings: `openstreetmap.osm_buildings_filtered`
       * Residential buildings: `openstreetmap.osm_buildings_residential`
         * 1st step: Intersect with ETHOS.BUILDA, which supplies one point per
-          residential building, in a three step cascade -- point inside the
-          polygon, nearest neighbour within 10 m, and OSM tags for what is
-          left (see `osm_buildings_filter_residential.sql`). Filtering by tags
-          alone overestimated the stock by about a third against Zensus 2022.
+          residential building, in a four stage cascade -- point inside the
+          polygon, nearest neighbour within 10 m, OSM tags for what is left,
+          and care homes that express their residential use only through
+          `amenity` on an uninformative `building=yes` polygon (see
+          `osm_buildings_filter_residential.sql`). Filtering by tags alone
+          overestimated the stock by 65 % against Zensus 2022 (33.0 M against
+          20.0 M residential buildings); the cascade yields 18.9 M.
         * 2nd step: Table is extended by finding census cells with population
           but no residential buildings and extended by commercial/retail/office/
           hotel buildings (see `osm_buildings_extend_residential.sql`) since they
           often include apartments as well.
         * Each building carries the provenance of its match in `source`
-          (`ethos_intersect`, `ethos_nearest`, `osm_tagging` or
-          `census_gap_fill`), the matched `ethos_id`, the `match_distance` and
-          the ETHOS attributes `construction_year`, `size_class`,
+          (`ethos_intersect`, `ethos_nearest`, `osm_tagging`, `osm_amenity`
+          or `census_gap_fill`), the matched `ethos_id`, the `match_distance`
+          and the ETHOS attributes `construction_year`, `size_class`,
           `refurbishment_state` and `tabula_type`.
     * Extract amenities and filter using relevant tags, e.g. shops and restaurants,
       see script `osm_amenities_shops_preprocessing.sql` for the full list of tags.

--- a/src/egon/data/datasets/osm_buildings_streets/osm_buildings_extend_residential.sql
+++ b/src/egon/data/datasets/osm_buildings_streets/osm_buildings_extend_residential.sql
@@ -8,9 +8,33 @@
 -- Mark commercial, retail, office, hotel buildings as residential in those   --
 -- cells.                                                                     --
 --------------------------------------------------------------------------------
+/*
+ * This safety net predates the ETHOS.BUILDA intersection and is kept: ETHOS
+ * covers residential buildings, so census cells with population but without a
+ * matched building can still occur. Those buildings carry
+ * source = 'census_gap_fill' and no ETHOS attributes, which makes their share
+ * measurable against the intersection.
+ *
+ * The column list is explicit because the target table is wider than
+ * osm_buildings_filtered since #1310; SELECT * would break here.
+ */
 
-INSERT INTO openstreetmap.osm_buildings_residential
-	SELECT *
+INSERT INTO openstreetmap.osm_buildings_residential (
+	id, osm_id, amenity, building, name,
+	geom_building, area, geom_point, tags,
+	source, ethos_id, match_distance,
+	construction_year, size_class, refurbishment_state, tabula_type
+)
+	SELECT
+		id, osm_id, amenity, building, name,
+		geom_building, area, geom_point, tags,
+		'census_gap_fill'      AS source,
+		NULL::text             AS ethos_id,
+		NULL::double precision AS match_distance,
+		NULL::int              AS construction_year,
+		NULL::text             AS size_class,
+		NULL::text             AS refurbishment_state,
+		NULL::text             AS tabula_type
 	FROM openstreetmap.osm_buildings_filtered
 	WHERE id IN (
 		SELECT id FROM (

--- a/src/egon/data/datasets/osm_buildings_streets/osm_buildings_filter_residential.sql
+++ b/src/egon/data/datasets/osm_buildings_streets/osm_buildings_filter_residential.sql
@@ -1,39 +1,149 @@
 /*
  * Original Autor: IsGut (johnrobert@t-online.de)
  * Adapted by: nesnoj (jonathan.amme@rl-institut.de)
+ * Rewritten for the ETHOS.BUILDA intersection, see
+ *   https://github.com/openego/eGon-data/issues/1310
 */
 
 --------------------------------------------------------------------------
--- extract residential buildings only, calculate area, create centroids --
+-- Extract residential buildings from the OSM x ETHOS.BUILDA            --
+-- intersection, keeping the ETHOS attributes and the match provenance. --
 --------------------------------------------------------------------------
-DROP TABLE if exists openstreetmap.osm_buildings_residential;
-CREATE TABLE openstreetmap.osm_buildings_residential as
-    select *
-    from openstreetmap.osm_buildings bld
-    where
-        bld.building like 'yes'
-        or bld.building like 'apartments'
-        or bld.building like 'detached'
-        or bld.building like 'farm'
-        or bld.building like 'house'
-        or bld.building like 'residential'
-        or bld.building like 'semidetached_house'
-        or bld.building like 'terrace'
-        or bld.building like 'dormitory'
-        or bld.building like 'terraced_house'
+/*
+ * Before, residential buildings were selected by their OSM tags alone, which
+ * overestimated the stock by roughly a third against Zensus 2022. ETHOS.BUILDA
+ * supplies one point per residential building; a building is residential if
+ * such a point falls on it.
+ *
+ * Method after Till Krebber (RLI), a three step cascade:
+ *   1. ETHOS point inside the OSM polygon        -> source = ethos_intersect
+ *   2. Remainder: nearest neighbour within 10 m
+ *      of the polygon's representative point     -> source = ethos_nearest
+ *   3. Remainder: building tag on the
+ *      residential whitelist                     -> source = osm_tagging
+ *
+ * The 10 m threshold is his, calibrated over radii of 1 to 30 m; recomputed in
+ * EPSG:3035 without his per-state decomposition, the knee stays at 9 m.
+ *
+ * Deviations from his reference implementation, all measured on
+ * Schleswig-Holstein:
+ *   - Duplicate rule: one building at most once, one ETHOS point at most once,
+ *     resolved geometrically and deterministically. He has none; without a
+ *     rule the primary key below breaks. Affects 180 buildings (0.031 %) and
+ *     9 points (0.002 %).
+ *   - Stage 2 measures to ST_PointOnSurface (= geopandas
+ *     representative_point()), not to geom_point (= ST_Centroid), to stay
+ *     faithful to his code. The centroid would match 342 points more.
+ *   - Stage 3 omits building='yes'. With it, 531,674 buildings return and the
+ *     result lands at 1.33 x Zensus 2022, back in the overestimation the
+ *     intersection is meant to remove.
+ *   - Obvious ancillary buildings (garage, shed, carport, ...) are kept when
+ *     ETHOS hits them (~500 in SH, 0.08 %): the point belongs to a real
+ *     dwelling and merely sits on the wrong polygon, so dropping it would
+ *     lose the building altogether.
+ *
+ * Result on Schleswig-Holstein: 618,208 buildings = 0.713 x Zensus 2022,
+ * against 607,490 = 0.700 for his reference run.
+ */
 
-        -- retirement and assisted homes
-        or bld.amenity like 'retirement_home'
-        or (
-            bld.amenity like 'social_facility'
-			and tags::hstore -> 'social_facility' in ('nursing_home', 'assisted_living', 'group_home')
-        )
-        or bld.amenity like 'nursing_home'
-        or bld.amenity like 'assisted_living'
-        or bld.amenity like 'group_home';
+DROP TABLE IF EXISTS openstreetmap.osm_buildings_residential;
+CREATE TABLE openstreetmap.osm_buildings_residential AS
+
+WITH
+-- ---------------------------------------------------------------- Stage 1 ---
+s1_raw AS (
+    SELECT b.id AS building_id, e.id AS ethos_id, b.area,
+           ST_Distance(ST_PointOnSurface(b.geom_building), e.geom_point) AS d
+    FROM openstreetmap.osm_buildings b
+    JOIN society.egon_ethos_builda_buildings e
+      ON ST_Contains(b.geom_building, e.geom_point)
+),
+-- an ETHOS point claims only ONE building: smallest area wins (the more
+-- specific geometry where building and building:part are nested)
+s1_one_b AS (
+    SELECT DISTINCT ON (ethos_id) building_id, ethos_id, d
+    FROM s1_raw ORDER BY ethos_id, area ASC, building_id ASC
+),
+-- a building appears exactly ONCE: nearest point to its representative point
+s1 AS (
+    SELECT DISTINCT ON (building_id) building_id, ethos_id,
+           0::double precision AS match_distance
+    FROM s1_one_b ORDER BY building_id, d ASC, ethos_id ASC
+),
+
+-- ---------------------------------------------------------------- Stage 2 ---
+rest_e AS (
+    SELECT e.* FROM society.egon_ethos_builda_buildings e
+    WHERE NOT EXISTS (SELECT 1 FROM s1 WHERE s1.ethos_id = e.id)
+),
+rest_b AS (
+    SELECT b.* FROM openstreetmap.osm_buildings b
+    WHERE NOT EXISTS (SELECT 1 FROM s1 WHERE s1.building_id = b.id)
+),
+-- prefilter candidates through the INDEXED polygon. Admissible because the
+-- representative point lies inside the polygon, so dist(pt, repr) >=
+-- dist(pt, polygon) -- the polygon candidates are a superset. Then compute
+-- the exact distance.
+s2_cand AS (
+    SELECT e.id AS ethos_id, b.id AS building_id,
+           ST_Distance(ST_PointOnSurface(b.geom_building), e.geom_point) AS d
+    FROM rest_e e
+    JOIN rest_b b ON ST_DWithin(b.geom_building, e.geom_point, 10)
+),
+s2_one_b AS (
+    SELECT DISTINCT ON (ethos_id) ethos_id, building_id, d
+    FROM s2_cand WHERE d <= 10 ORDER BY ethos_id, d ASC, building_id ASC
+),
+s2 AS (
+    SELECT DISTINCT ON (building_id) building_id, ethos_id,
+           d AS match_distance
+    FROM s2_one_b ORDER BY building_id, d ASC, ethos_id ASC
+),
+
+-- ---------------------------------------------------------------- Stage 3 ---
+s3 AS (
+    SELECT b.id AS building_id,
+           NULL::text             AS ethos_id,
+           NULL::double precision AS match_distance
+    FROM openstreetmap.osm_buildings b
+    WHERE NOT EXISTS (SELECT 1 FROM s1 WHERE s1.building_id = b.id)
+      AND NOT EXISTS (SELECT 1 FROM s2 WHERE s2.building_id = b.id)
+      -- the reference implementation's residential whitelist, checked against
+      -- the building column as it does. The last three are amenity values in
+      -- OSM, so they contribute almost nothing -- exactly 5 buildings in SH
+      -- (nursing_home 4, retirement_home 1). Kept for fidelity; without them
+      -- the result is 618,203 instead of 618,208.
+      AND b.building IN ('residential','house','apartments','detached',
+                         'semidetached_house','dormitory','terraced_house',
+                         'terrace','bungalow','farm','farmhouse',
+                         'assisted_living','nursing_home','retirement_home')
+),
+
+matched AS (
+    SELECT building_id, ethos_id, match_distance, 'ethos_intersect'::text AS source FROM s1
+    UNION ALL
+    SELECT building_id, ethos_id, match_distance, 'ethos_nearest'         AS source FROM s2
+    UNION ALL
+    SELECT building_id, ethos_id, match_distance, 'osm_tagging'           AS source FROM s3
+)
+
+SELECT
+    b.id, b.osm_id, b.amenity, b.building, b.name,
+    b.geom_building, b.area, b.geom_point, b.tags,
+    m.source,
+    m.ethos_id,
+    m.match_distance,
+    e.construction_year,
+    e.size_class,
+    e.refurbishment_state,
+    e.tabula_type
+FROM matched m
+JOIN openstreetmap.osm_buildings b ON b.id = m.building_id
+LEFT JOIN society.egon_ethos_builda_buildings e ON e.id = m.ethos_id;
 
 ALTER TABLE openstreetmap.osm_buildings_residential
     ADD CONSTRAINT osm_buildings_residential_id_pkey PRIMARY KEY (id);
 
 CREATE INDEX ON openstreetmap.osm_buildings_residential USING gist (geom_building);
 CREATE INDEX ON openstreetmap.osm_buildings_residential USING gist (geom_point);
+CREATE INDEX ON openstreetmap.osm_buildings_residential (source);

--- a/src/egon/data/datasets/osm_buildings_streets/osm_buildings_filter_residential.sql
+++ b/src/egon/data/datasets/osm_buildings_streets/osm_buildings_filter_residential.sql
@@ -21,6 +21,8 @@
  *      of the polygon's representative point     -> source = ethos_nearest
  *   3. Remainder: building tag on the
  *      residential whitelist                     -> source = osm_tagging
+ *   3b. Remainder: care home identified by amenity
+ *      alone (deviation, see below)               -> source = osm_amenity
  *
  * The 10 m threshold is his, calibrated over radii of 1 to 30 m; recomputed in
  * EPSG:3035 without his per-state decomposition, the knee stays at 9 m.
@@ -37,13 +39,20 @@
  *   - Stage 3 omits building='yes'. With it, 531,674 buildings return and the
  *     result lands at 1.33 x Zensus 2022, back in the overestimation the
  *     intersection is meant to remove.
+ *   - Care homes tagged only via amenity are recovered in stage 3b. The
+ *     previous tag-based filter matched them; the reference whitelist names
+ *     the values but checks them against the building column, where OSM does
+ *     not put them, so it never matches. 80 buildings in SH (0.013 %).
  *   - Obvious ancillary buildings (garage, shed, carport, ...) are kept when
  *     ETHOS hits them (~500 in SH, 0.08 %): the point belongs to a real
  *     dwelling and merely sits on the wrong polygon, so dropping it would
  *     lose the building altogether.
  *
- * Result on Schleswig-Holstein: 618,208 buildings = 0.713 x Zensus 2022,
- * against 607,490 = 0.700 for his reference run.
+ * Result on Schleswig-Holstein: 618,288 buildings = 0.713 x Zensus 2022,
+ * against 607,490 = 0.700 for his reference run. By source:
+ * ethos_intersect 579,076 - osm_tagging 38,084 - ethos_nearest 1,048 -
+ * osm_amenity 80. The census gap filler adds a further 866 rows in the next
+ * task, which the reference method has no counterpart for.
  */
 
 DROP TABLE IF EXISTS openstreetmap.osm_buildings_residential;
@@ -119,12 +128,45 @@ s3 AS (
                          'assisted_living','nursing_home','retirement_home')
 ),
 
+-- ------------------------------------------------------- Stage 3b (amenity) ---
+-- Care homes whose residential use is expressed ONLY through amenity, on an
+-- uninformative building=yes polygon. They fall through both rules above:
+-- stage 3 drops building='yes' on purpose, and the whitelist is checked
+-- against the building column, where OSM practically never puts these values
+-- (8 buildings in Schleswig-Holstein).
+--
+-- These clauses are the ones the previous tag-based filter used, kept verbatim.
+-- Gated by amenity, so this does NOT reintroduce the building='yes'
+-- overestimation: measured on SH it recovers 80 buildings (0.013 %), while
+-- allowing building='yes' generally would add 531,674.
+--
+-- This is a deliberate DEVIATION from the reference implementation, not a
+-- reproduction of it: its whitelist names these values but never matches them.
+s3b AS (
+    SELECT b.id AS building_id,
+           NULL::text             AS ethos_id,
+           NULL::double precision AS match_distance
+    FROM openstreetmap.osm_buildings b
+    WHERE NOT EXISTS (SELECT 1 FROM s1  WHERE s1.building_id  = b.id)
+      AND NOT EXISTS (SELECT 1 FROM s2  WHERE s2.building_id  = b.id)
+      AND NOT EXISTS (SELECT 1 FROM s3  WHERE s3.building_id  = b.id)
+      AND (
+            b.amenity IN ('retirement_home', 'nursing_home',
+                          'assisted_living', 'group_home')
+         OR (b.amenity = 'social_facility'
+             AND (b.tags::hstore -> 'social_facility')
+                 IN ('nursing_home', 'assisted_living', 'group_home'))
+      )
+),
+
 matched AS (
     SELECT building_id, ethos_id, match_distance, 'ethos_intersect'::text AS source FROM s1
     UNION ALL
     SELECT building_id, ethos_id, match_distance, 'ethos_nearest'         AS source FROM s2
     UNION ALL
     SELECT building_id, ethos_id, match_distance, 'osm_tagging'           AS source FROM s3
+    UNION ALL
+    SELECT building_id, ethos_id, match_distance, 'osm_amenity'           AS source FROM s3b
 )
 
 SELECT

--- a/src/egon/data/datasets/osm_buildings_streets/osm_buildings_residential_zensus_mapping.sql
+++ b/src/egon/data/datasets/osm_buildings_streets/osm_buildings_residential_zensus_mapping.sql
@@ -21,3 +21,7 @@ CREATE TABLE boundaries.egon_map_zensus_buildings_residential as
         on ST_Within(bld.geom_point, zensus.geom)
     ) bld2
     where bld2.id is not null and bld2.grid_id is not null;
+
+-- the only one of the three census mapping tables without a primary key
+ALTER TABLE boundaries.egon_map_zensus_buildings_residential
+    ADD CONSTRAINT pk_egon_map_zensus_buildings_residential PRIMARY KEY (id);

--- a/src/egon/data/datasets/power_plants/__init__.py
+++ b/src/egon/data/datasets/power_plants/__init__.py
@@ -1510,7 +1510,7 @@ class PowerPlants(Dataset):
     #:
     name: str = "PowerPlants"
     #:
-    version: str = "0.0.37"
+    version: str = "0.0.38"
 
     def __init__(self, dependencies):
         super().__init__(

--- a/src/egon/data/datasets/power_plants/pv_rooftop_buildings.py
+++ b/src/egon/data/datasets/power_plants/pv_rooftop_buildings.py
@@ -374,12 +374,45 @@ class OsmBuildingsFiltered(Base):
     id = Column(BigInteger, primary_key=True, index=True)
 
 
+class OsmBuildingsResidential(Base):
+    """
+    Class definition of table openstreetmap.osm_buildings_residential.
+
+    Only the columns needed here are mapped; the table also carries the
+    ETHOS.BUILDA attributes and the provenance of the match, see
+    :py:mod:`osm_buildings_streets
+    <egon.data.datasets.osm_buildings_streets>`.
+    """
+
+    __tablename__ = "osm_buildings_residential"
+    __table_args__ = {"schema": "openstreetmap"}
+
+    osm_id = Column(BigInteger)
+    amenity = Column(String)
+    building = Column(String)
+    name = Column(String)
+    geom_building = Column(Geometry(srid=SRID), index=True)
+    area = Column(Float)
+    geom_point = Column(Geometry(srid=SRID), index=True)
+    tags = Column(HSTORE)
+    id = Column(BigInteger, primary_key=True, index=True)
+
+
 @timer_func
 def osm_buildings(
     to_crs: CRS,
 ) -> gpd.GeoDataFrame:
     """
     Read OSM buildings data from eGo^n Database.
+
+    Buildings come from `openstreetmap.osm_buildings_filtered` and
+    `openstreetmap.osm_buildings_residential`. Since #1310 the residential
+    table is not a subset of the filtered one: the ETHOS.BUILDA intersection
+    also matches buildings whose OSM tag is missing from the filter list, plus
+    ancillary buildings that are kept on purpose. The two overlap heavily, so
+    the returned frame has a non-unique index -- it is deduplicated in
+    :py:func:`load_building_data`, where the synthetic buildings are
+    concatenated as well.
 
     Parameters
     -----------
@@ -391,14 +424,30 @@ def osm_buildings(
         GeoDataFrame containing OSM buildings data.
     """
     with db.session_scope() as session:
-        query = session.query(
+        filtered_query = session.query(
             OsmBuildingsFiltered.id,
             OsmBuildingsFiltered.area,
             OsmBuildingsFiltered.geom_point.label("geom"),
         )
+        residential_query = session.query(
+            OsmBuildingsResidential.id,
+            OsmBuildingsResidential.area,
+            OsmBuildingsResidential.geom_point.label("geom"),
+        )
 
-    return gpd.read_postgis(
-        query.statement, query.session.bind, index_col="id"
+    filtered_gdf = gpd.read_postgis(
+        filtered_query.statement, filtered_query.session.bind, index_col="id"
+    )
+    residential_gdf = gpd.read_postgis(
+        residential_query.statement,
+        residential_query.session.bind,
+        index_col="id",
+    )
+
+    return gpd.GeoDataFrame(
+        pd.concat([filtered_gdf, residential_gdf]),
+        geometry="geom",
+        crs=filtered_gdf.crs,
     ).to_crs(to_crs)
 
 
@@ -508,9 +557,12 @@ def load_building_data():
     Tables:
 
     * `openstreetmap.osm_buildings_filtered` (from OSM)
+    * `openstreetmap.osm_buildings_residential` (from OSM x ETHOS.BUILDA)
     * `openstreetmap.osm_buildings_synthetic` (synthetic, created by us)
 
-    Use column `id` for both as it is unique hence you concat both datasets.
+    Use column `id` for all of them as it is unique across the OSM derived
+    tables and the synthetic ones. The filtered and the residential table
+    overlap, though, so the concatenated index is deduplicated below.
     If INCLUDE_SYNTHETIC_BUILDINGS is False synthetic buildings will not be
     loaded.
 
@@ -545,6 +597,18 @@ def load_building_data():
         buildings_gdf = osm_buildings_gdf.rename(
             columns={"area": "building_area"}
         )
+
+    # The filtered and the residential table overlap (#1310), and both are
+    # concatenated in pandas rather than unioned in SQL, so the index has to be
+    # deduplicated here. Without it, buildings_gdf.loc[building_ids] below
+    # returns the shared buildings twice and doubles their roof potential.
+    duplicates = buildings_gdf.index.duplicated()
+    if duplicates.any():
+        logger.debug(
+            f"Dropping {duplicates.sum()} buildings that appear in more than "
+            f"one source table."
+        )
+        buildings_gdf = buildings_gdf[~duplicates]
 
     if ONLY_BUILDINGS_WITH_DEMAND:
         building_ids = egon_building_peak_loads()


### PR DESCRIPTION
Fixes #1310. Addresses the residential half of #1311.

Residential buildings were selected by their OSM tags alone, which overestimates
the stock by about a third against Zensus 2022. ETHOS.BUILDA supplies one point
per residential building, so this PR decides "is this building residential?" by
intersecting OSM building polygons with those points instead.

**New dataset `EthosBuilda`** (`society.egon_ethos_builda_buildings`) downloads
one CSV per NUTS-1 region from Zenodo (record `13771740`, ETHOS.BUILDA v2.0.0,
ODbL-1.0), verifies the published MD5, and imports it through an unlogged
staging table — the four building attributes are JSON objects
`{"value","source","lineage"}`, not scalars, and are unpacked there. Regions are
loaded one at a time with the staging table truncated in between, which bounds
it to the largest single CSV (1.6 GB) instead of the full 7.5 GB. In test mode
only Schleswig-Holstein (`DEF`) is fetched and imported.

**`osm_buildings_filter_residential.sql` is rewritten** as the three-step
cascade of Till Krebber's method (RLI):

1. ETHOS point inside the OSM polygon → `source = 'ethos_intersect'`
2. remainder: nearest neighbour within 10 m of `ST_PointOnSurface` →
   `source = 'ethos_nearest'`
3. remainder: `building` tag on the residential whitelist →
   `source = 'osm_tagging'`

`osm_buildings_residential` gains 7 columns: `source`, `ethos_id`,
`match_distance` and the four ETHOS attributes (`construction_year`,
`size_class`, `refurbishment_state`, `tabula_type`). The census gap filler
`osm_buildings_extend_residential.sql` stays as a safety net and marks its rows
`source = 'census_gap_fill'`; its `INSERT ... SELECT *` had to become an explicit
column list because the target table is now wider than
`osm_buildings_filtered`.

**Downstream consequence, and the reason this PR is not confined to the building
dataset:** residential buildings are no longer a subset of the filtered ones.
Measured on SH, 2,165 residential buildings (0.35 %) sit outside
`osm_buildings_filtered` — 1,621 plausible dwellings whose OSM tag the filter
list does not carry, plus 544 ancillary buildings that ETHOS hits and that are
kept deliberately. So everywhere the filtered table stood for "all buildings
that can carry a demand", the residential table is now read alongside it:
`loadareas_add_demand_hh.sql` (both UNION blocks), `mapping.py`, and
`pv_rooftop_buildings.py`. The first two use `UNION` (not `UNION ALL`), verified
free of double counting: the 616,043 overlapping rows have 0 deviations in
`geom_point`. The third merges with `pd.concat` in pandas rather than in SQL, so
its index is deduplicated explicitly.

Also adds the missing `PRIMARY KEY (id)` on
`boundaries.egon_map_zensus_buildings_residential` — the only one of the three
census mapping tables without one.

### Measured on Schleswig-Holstein

| Task | Time | Result |
|---|---:|---|
| `EthosBuilda.to_postgres` | 73.2 s | 581,222 rows |
| `filter_buildings_residential` | 45.5 s | **618,208** buildings, 618,208 distinct ids |

618,208 = **0.713 × Zensus 2022**, against 607,490 = 0.700 for the reference
implementation (+1.8 %). Sources: `ethos_intersect` 579,076 (93.67 %),
`osm_tagging` 38,084 (6.16 %), `ethos_nearest` 1,048 (0.17 %).

### 📋 Pull Request Guidelines

> Please read the [Pull Request Guidelines](https://egon-data.readthedocs.io/en/latest/contributing.html#pull-request-guidelines) carefully before creating your PR.

---

## 🧑‍💻 Contributor Checklist

Before requesting a review, make sure you've completed all of the following:

- [ ] All **tests pass** locally or via CI
      _(for more information on local test, check `tox` in the [Contributing section](https://egon-data.readthedocs.io/en/latest/contributing.html#))_
      _(CI tests are automatically executed when creating a PR, you can see the results of the checks below)_
- [ ] Workflow has run at least once in **Test mode**
      _(optional if no dataset changes are involved)_
- [x] Relevant **documentation is updated** (API, new features, etc.)
- [x] Dataset-versions are updated when existing datasets are adjusted.
- [x] Added a note to `CHANGELOG.rst` about the changes
- [x] Added yourself to `AUTHORS.rst`

Optional:

- [ ] Changes have been tested in **Everything mode**
- [x] Extend the checklist for reviewers: Which aspects should be reviewed in particular?

```markdown
Please focus on these four, in this order:

1. `pv_rooftop_buildings.py` — `load_building_data()`. This is the riskiest
   change in the PR and the one least exercised so far. `osm_buildings()` now
   reads two tables that overlap heavily, and they are merged with `pd.concat`,
   not a SQL UNION. Without the index dedup, `buildings_gdf.loc[building_ids]`
   returns the 616,043 shared buildings twice and doubles their roof potential —
   a worse bug than the one being fixed. Please check the dedup sits where the
   index must be unique and that no earlier `.loc`/`.reindex` runs before it.

2. The three UNION additions (`loadareas_add_demand_hh.sql` ×2, `mapping.py`).
   `UNION` is deliberate; `UNION ALL` would double-count. `mapping.py` resolves
   the table via `cts_s.tables[...]`, which is why `osm_buildings_residential`
   had to be added to `CtsDemandBuildings.sources`.

3. `osm_buildings_extend_residential.sql` — the explicit column list. It has
   only been exercised against three synthetic census cells so far (see notes),
   so a second pair of eyes on the column/type mapping is worth more than usual.

4. Stage 3 of the cascade omits `building='yes'`. This is a measurement, not a
   preference: with it, 531,674 buildings return and the result lands at
   1.33 × Zensus 2022, back in the overestimation the intersection removes.
```

---

## 🔍 Reviewer Checklist

During your review, please check the following:

- [ ] **Is the code clean, readable, and efficient?** Are there any oddities or obvious inefficiencies?
- [ ] Does the code work as expected? _(should already be verified by contributor)_
- [ ] Do all tests pass? (see CI results)
- [ ] Is the documentation complete and up to date?
- [ ] Is `CHANGELOG.rst` updated accordingly?
- [ ] Is all necessary metadata complete and correct?
  - [ ] If metadata is pending: Is there an appropriate issue filed?

---

## 📝 Additional Notes (optional)

**Two checkboxes are deliberately left unchecked. Here is exactly what was and
was not run.**

*What ran:* the changed tasks individually against a Schleswig-Holstein
database — `EthosBuilda.download`, `EthosBuilda.to_postgres`,
`filter_buildings_residential`, `extend_buildings_residential` and
`create_buildings_residential_zensus_mapping`, with the numbers above.

*What did not run:* a full DAG run in test mode, and therefore none of the three
touched downstream datasets (`LoadArea`, `CtsDemandBuildings`, `PowerPlants`).
The local environment has a virtualenv built for a different branch — `omi`
without `omi.dialects`, which breaks `import egon.data.metadata` and with it
`pipeline.py` — so `tox` and an Airflow run were not possible. `pipeline.py`
compiles and `EthosBuilda` instantiates correctly inside a DAG context
(`ethos_builda.download`, `ethos_builda.to-postgres`). **Reviewers should treat
the downstream changes as unexecuted**, in particular point 1 of the focus list.

`extend_buildings_residential` and the census mapping were validated against a
stand-in table carrying the real schema and three real test cells (100 m
envelopes around commercial buildings with no residential building inside):
3 rows inserted, `source = 'census_gap_fill'`, all six ETHOS columns `NULL`.
That is a structural validation of the column list, not a quantity validation.

**OSM snapshot caveat.** eGon-data pins `germany-250101.osm.pbf`, which is the
snapshot the reference implementation used — that is what makes an ID-level
comparison meaningful. The local workdir, however, held
`schleswig-holstein-240101.osm.pbf`, so the 618,208 above may rest on the 2024
extract rather than the 2025 one. `download()` fetches the pinned file (the
target filename differs), so a fresh test-mode run settles it. Until then, treat
the comparison against 607,490 as indicative rather than snapshot-matched.

**Deliberate deviations from the reference implementation**, all measured on SH,
so a reviewer can attribute differences rather than guess:

- *Duplicate rule* — the reference has none; here a building appears at most
  once and an ETHOS point claims at most one building, resolved geometrically
  and deterministically. Without it the primary key breaks. Affects 180
  buildings (0.031 %) and 9 points (0.002 %).
- *Stage 2 measures to `ST_PointOnSurface`*, not the centroid, to stay faithful
  to the reference code — the centroid would match 342 points more.
- *Ancillary buildings are kept* when ETHOS hits them (~500 in SH, 0.08 %): the
  point belongs to a real dwelling and merely sits on the wrong polygon, so
  dropping it would lose the building entirely.
- *Care homes captured via `amenity` are lost.* The previous residential filter
  also matched `amenity IN ('retirement_home','nursing_home','assisted_living',
  'group_home')` and `amenity='social_facility'` with the corresponding
  `social_facility` tag. The reference whitelist carries those values too, but
  checks them against the `building` column, where OSM almost never puts them
  (8 buildings in SH). Measured on SH: the old clause matched **389** buildings,
  of which **80** are no longer residential — all `building='yes'`, 50
  `social_facility` and 30 `nursing_home`; the other 309 are picked up by the
  intersection anyway. The loss arises only from the *combination* of dropping
  `building='yes'` in stage 3 and checking the whitelist against `building`
  alone. All 80 remain in `osm_buildings_filtered`, so they stay in the
  downstream union and merely count as CTS rather than residential. A targeted
  `amenity` branch in stage 3 would recover exactly those 80 without
  reintroducing `building='yes'` — say so in review if you want it.
- *The 10 m threshold was recomputed*, not assumed: in EPSG:3035 without the
  reference implementation's per-state decomposition the knee stays at 9 m, and
  up to 10 m the reference matches 1,010 points against 1,014 here.

**Metadata.** oemetadata resources for both tables
(`society_egon_ethos_builda_buildings`,
`openstreetmap_osm_buildings_residential`) are written and validated as
`complete` against the assembler, but they are **not in this PR**: the resource
store exists only on `features/#1177-update-to-oemetadata-v2` (20 resource YAMLs
there, none on `dev`), so they will be added on that branch. Worth noting for
the metadata checkbox above: the store's dataset template declares
`dl-by-de/2.0`, which a resource without its own block inherits silently — the
result here is a Derivative Database of two ODbL-1.0 sources (OSM and ETHOS) and
must declare ODbL-1.0 explicitly. TABULA attribution is mandatory, not
courtesy.

**Full-Germany run and validation** against the reference results per federal
state and Zensus 2022 are not part of this PR; they run on a workstation
afterwards. The intersection stages are cheap on SH, but stage 2 is a nearest
neighbour over `ST_DWithin` and the building count rises by roughly a factor of
28 nationwide, so runtime there is estimated, not measured.

**Out of scope, deliberately:** the missing residential tags in
`osm_buildings_filter.sql`. `bungalow` alone is 60 % of the gap between the two
tables and stands in the reference whitelist but not in eGon's filter list. That
is a real bug, but it predates ETHOS, has nationwide effects on CTS
distribution and PV potentials, and needs its own validation — it will be filed
separately.
