### PR TITLE
Fixes/#804 grid district reproducibility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -139,6 +139,22 @@ Bug Fixes
   compared to earlier runs: the previous choice was arbitrary, so
   fixing it necessarily settles some assignments differently
   `#804 <https://github.com/openego/eGon-data/issues/804>`_
+* Make the input egon-data hands to osmTGmod reproducible.
+  ``transfer_busses_complete`` was built with ``DISTINCT ON (osm_id)``
+  one level above the subquery holding its ``ORDER BY``, so which of
+  several rows sharing an ``osm_id`` survived was left to the query
+  planner. Such duplicates are common: a substation can appear in both
+  source tables, and ``hvmv_substation.sql`` unions the ``osm_polygon``
+  and ``osm_line`` geometry of the same way, which yields two rows with
+  a different centroid - the one value osmTGmod reads. The table is now
+  built with a deterministic total order, its CSV export is ordered by
+  ``osm_id`` so the rows reach osmTGmod's ``transfer_busses`` table in a
+  fixed order, and the ``bus_id`` sequences of both transfer bus tables
+  are filled in a reproducible order instead of in scan order. Note
+  that this does not close the issue on its own: should osmTGmod's
+  abstraction be non-deterministic internally, its results will still
+  differ despite identical input
+  `#769 <https://github.com/openego/eGon-data/issues/769>`_
 
 Version 2.0.0 (2025-08-20)
 ==========================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -116,6 +116,26 @@ Bug Fixes
   regular pass and inserted a second identical load under the scenario's
   own name, doubling transport demand in status quo scenarios
   `#1483 <https://github.com/openego/eGon-data/issues/1483>`_
+* Fix MV grid district geometries differing between egon-data runs even
+  for identical substation input. Municipalities and municipality
+  fragments without a substation of their own are assigned to the
+  "nearest" neighbouring polygon, but the deciding queries applied
+  ``DISTINCT ON`` one level above the subquery holding their
+  ``ORDER BY``. PostgreSQL leaves the surviving row of such a query to
+  the planner, so the assignment silently changed whenever the plan did.
+  On top of that the primary ordering key, the distance between the two
+  polygons, is exactly 0 for every candidate of the ``touches`` strategy
+  and hence could not break any tie -- on a Schleswig-Holstein run 78 %
+  of these assignments have at least two candidates at distance 0.
+  ``DISTINCT ON`` and ``ORDER BY`` now live in the same query, and the
+  ordering keys are extended by the distance between the polygon
+  centroids and by ``bus_id`` so that a total order remains even for
+  symmetric geometries. The same treatment is applied where a cut
+  polygon containing several substations left ``UPDATE ... FROM`` to
+  pick one of them unpredictably. Note that grid districts change
+  compared to earlier runs: the previous choice was arbitrary, so
+  fixing it necessarily settles some assignments differently
+  `#804 <https://github.com/openego/eGon-data/issues/804>`_
 
 Version 2.0.0 (2025-08-20)
 ==========================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -132,7 +132,10 @@ Bug Fixes
   centroids and by ``bus_id`` so that a total order remains even for
   symmetric geometries. The same treatment is applied where a cut
   polygon containing several substations left ``UPDATE ... FROM`` to
-  pick one of them unpredictably. Note that grid districts change
+  pick one of them unpredictably. The two ``sum()`` aggregates computing
+  ``area`` are ordered as well, because adding ``double precision``
+  values is not associative and the column otherwise wobbled by an ULP
+  on an otherwise byte-identical geometry. Note that grid districts change
   compared to earlier runs: the previous choice was arbitrary, so
   fixing it necessarily settles some assignments differently
   `#804 <https://github.com/openego/eGon-data/issues/804>`_

--- a/src/egon/data/datasets/mv_grid_districts.py
+++ b/src/egon/data/datasets/mv_grid_districts.py
@@ -835,7 +835,7 @@ class mv_grid_districts_setup(Dataset):
     #:
     name: str = "MvGridDistricts"
     #:
-    version: str = "0.0.5"
+    version: str = "0.0.6"
 
     sources = DatasetSources(
         tables={

--- a/src/egon/data/datasets/mv_grid_districts.py
+++ b/src/egon/data/datasets/mv_grid_districts.py
@@ -310,6 +310,14 @@ def split_multi_substation_municipalities():
                 EgonHvmvSubstation.bus_id,
                 EgonHvmvSubstation.point,
             )
+            # A cut polygon containing more than one substation yields one
+            # row per substation. `UPDATE ... FROM` would then pick one of
+            # them unpredictably, so reduce to the lowest `bus_id` here.
+            .distinct(VoronoiMunicipalityCuts.id)
+            .order_by(
+                VoronoiMunicipalityCuts.id,
+                EgonHvmvSubstation.bus_id,
+            )
             .subquery()
         )
         session.query(VoronoiMunicipalityCuts).filter(
@@ -435,8 +443,8 @@ def assign_substation_municipality_fragments(
 
         * "touches": Only polygons that touch another polygon from
           `with_substation` are considered
-        * "within": Only polygons within a radius of 100 km of polygons
-          without substation are considered for assignment
+        * "min_distance": Only polygons within a radius of 100 km of
+          polygons without substation are considered for assignment
     session: SQLAlchemy session
         SQLAlchemy session object
 
@@ -459,7 +467,28 @@ def assign_substation_municipality_fragments(
         )
     else:
         raise ValueError(f"Invalid input for 'strategy': {strategy}")
-    cut_0subst_nearest_neighbor_sub = (
+    # Select one single assignment polygon (with substation) for each of
+    # the polygons without a substation.
+    #
+    # `DISTINCT ON` and `ORDER BY` have to live in the *same* query:
+    # PostgreSQL only defines which row of a group survives a
+    # `DISTINCT ON` if that very query is ordered. Ordering a subquery and
+    # applying `DISTINCT ON` one level above leaves the choice to the query
+    # planner, which is one of the causes of `#804
+    # <https://github.com/openego/eGon-data/issues/804>`_.
+    #
+    # The ordering keys are, in order of precedence:
+    #
+    # 1. `id`, which has to match `DISTINCT ON`,
+    # 2. the distance between the polygons. This is always 0 for the
+    #    "touches" strategy, so it only discriminates for "min_distance",
+    # 3. the distance between the polygon centroids, which breaks the ties
+    #    left by the previous key,
+    # 4. `bus_id`, to stay deterministic even for symmetric geometries.
+    #    Besides `bus_id`, the only columns taken from `with_substation`
+    #    are `subst_count` and `geom_sub`, both of which are functionally
+    #    dependent on `bus_id`, so ordering by it pins down the whole row.
+    cut_0subst_nearest_neighbor = (
         (
             session.query(
                 *[
@@ -476,33 +505,18 @@ def assign_substation_municipality_fragments(
         )
         .filter(without_substation.c.ags_0 == with_substation.c.ags_0)
         .filter(neighboring_criterion)
+        .distinct(without_substation.c.id)
         .order_by(
             without_substation.c.id,
             func.ST_Distance(
                 without_substation.c.geom, with_substation.c.geom
             ),
+            func.ST_Distance(
+                func.ST_Centroid(without_substation.c.geom),
+                func.ST_Centroid(with_substation.c.geom),
+            ),
+            with_substation.c.bus_id,
         )
-        .subquery()
-    )
-
-    # Group by id of cut polygons which is unique. The reason that multiple
-    # rows for each id exist is that assignment to multiple polygon with
-    # a substations would be possible. The are ordered by distance
-    cut_0subst_nearest_neighbor_grouped = (
-        session.query(cut_0subst_nearest_neighbor_sub.c.id)
-        .group_by(cut_0subst_nearest_neighbor_sub.c.id)
-        .subquery()
-    )
-
-    # Select one single assignment polygon (with substation) for each of
-    # the polygons without a substation
-    cut_0subst_nearest_neighbor = (
-        session.query(cut_0subst_nearest_neighbor_sub)
-        .filter(
-            cut_0subst_nearest_neighbor_sub.c.id
-            == cut_0subst_nearest_neighbor_grouped.c.id
-        )
-        .distinct(cut_0subst_nearest_neighbor_sub.c.id)
         .subquery()
     )
 
@@ -708,7 +722,15 @@ def nearest_polygon_with_substation(
         raise ValueError(f"Invalid input for 'strategy': {strategy}")
 
     # Find nearest neighboring polygon from with_substation for each
-    # polygon from without_substation
+    # polygon from without_substation and keep exactly one candidate per
+    # polygon.
+    #
+    # `DISTINCT ON` and `ORDER BY` have to live in the *same* query, see
+    # the comment in :py:func:`assign_substation_municipality_fragments`
+    # for the reasoning and for the ordering keys, which are identical
+    # here. Note that `ST_Distance` is 0 for every candidate of the
+    # "touches" strategy, so without the two subsequent keys the choice
+    # would be a plain tie.
     all_nearest_neighbors = (
         session.query(
             without_substation.c.id,
@@ -719,34 +741,31 @@ def nearest_polygon_with_substation(
             ),
         )
         .filter(neighboring_criterion)
+        .distinct(without_substation.c.id)
         .order_by(
             without_substation.c.id,
             func.ST_Distance(
                 without_substation.c.geom, with_substation.c.geom
             ),
-            # with_substation.c.id
             func.ST_Distance(
                 func.ST_Centroid(without_substation.c.geom),
                 func.ST_Centroid(with_substation.c.geom),
             ),
+            with_substation.c.bus_id,
         )
         .subquery()
     )
 
-    # Save list of newly assigned polygons
-    newly_assigned = (
-        session.query(all_nearest_neighbors.c.id)
-        .distinct(all_nearest_neighbors.c.id)
-        .all()
-    )
+    # Save list of newly assigned polygons. `all_nearest_neighbors` already
+    # holds exactly one row per polygon, so no de-duplication is needed.
+    newly_assigned = session.query(all_nearest_neighbors.c.id).all()
     newly_assigned_ids = [i for i, in newly_assigned]
 
-    # Take only one candidate polygon for assgning it
     nearest_neighbors = session.query(
         all_nearest_neighbors.c.bus_id,
         all_nearest_neighbors.c.geom,
         all_nearest_neighbors.c.area,
-    ).distinct(all_nearest_neighbors.c.id)
+    )
 
     # Insert polygons with newly assigned substation
     assigned_polygons_insert = (

--- a/src/egon/data/datasets/mv_grid_districts.py
+++ b/src/egon/data/datasets/mv_grid_districts.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
     String,
     func,
 )
+from sqlalchemy.dialects.postgresql import aggregate_order_by
 from sqlalchemy.ext.declarative import declarative_base
 
 from egon.data import db
@@ -569,9 +570,17 @@ def merge_polygons_to_grid_district():
             func.ST_Multi(
                 func.ST_Union(VoronoiMunicipalityCutsAssigned.geom)
             ).label("geom"),
-            func.sum(func.ST_Area(VoronoiMunicipalityCutsAssigned.geom)).label(
-                "area"
-            ),
+            # Order the summands. Adding `double precision` values is not
+            # associative, so an unordered `sum` over a group differs in
+            # its last bits depending on the order the aggregate happens
+            # to see the rows in. Ordering by the value itself makes the
+            # sum a function of the multiset alone.
+            func.sum(
+                aggregate_order_by(
+                    func.ST_Area(VoronoiMunicipalityCutsAssigned.geom),
+                    func.ST_Area(VoronoiMunicipalityCutsAssigned.geom),
+                )
+            ).label("area"),
         ).group_by(VoronoiMunicipalityCutsAssigned.bus_id)
 
         joined_municipality_parts_insert = (
@@ -663,7 +672,13 @@ def merge_polygons_to_grid_district():
                     -0.1,
                 )
             ).label("geom"),
-            func.sum(MvGridDistrictsDissolved.area).label("area"),
+            # Ordered for the same reason as in step 1.
+            func.sum(
+                aggregate_order_by(
+                    MvGridDistrictsDissolved.area,
+                    MvGridDistrictsDissolved.area,
+                )
+            ).label("area"),
         ).group_by(MvGridDistrictsDissolved.bus_id)
 
         joined_mv_grid_district_parts_insert = (
@@ -835,7 +850,7 @@ class mv_grid_districts_setup(Dataset):
     #:
     name: str = "MvGridDistricts"
     #:
-    version: str = "0.0.6"
+    version: str = "0.0.7"
 
     sources = DatasetSources(
         tables={

--- a/src/egon/data/datasets/osmtgmod/__init__.py
+++ b/src/egon/data/datasets/osmtgmod/__init__.py
@@ -377,9 +377,18 @@ def osmtgmod(
         conn.commit()
 
         with open(path_for_transfer_busses, "w") as this_file:
+            # Order explicitly. The rows of this export are inserted into
+            # osmTGmod's `transfer_busses` table one by one below, so the
+            # order they are copied in becomes their physical order there
+            # and thereby part of osmTGmod's input, cf. `#769
+            # <https://github.com/openego/eGon-data/issues/769>`_.
+            # `osm_id` is unique in `transfer_busses_complete`, so this is
+            # a total order.
             cur.copy_expert(
-                """COPY transfer_busses_complete to
-                STDOUT WITH CSV HEADER""",
+                """COPY (
+                    SELECT * FROM transfer_busses_complete
+                    ORDER BY osm_id
+                ) TO STDOUT WITH CSV HEADER""",
                 this_file,
             )
             conn.commit()
@@ -866,7 +875,7 @@ class Osmtgmod(Dataset):
     #:
     name: str = "Osmtgmod"
     #:
-    version: str = "0.0.12"
+    version: str = "0.0.13"
 
     sources = DatasetSources(
         files={

--- a/src/egon/data/datasets/substation/__init__.py
+++ b/src/egon/data/datasets/substation/__init__.py
@@ -91,7 +91,7 @@ class SubstationExtraction(Dataset):
     def __init__(self, dependencies):
         super().__init__(
             name="substation_extraction",
-            version="0.0.5",
+            version="0.0.6",
             dependencies=dependencies,
             tasks=(
                 create_tables,
@@ -220,6 +220,36 @@ def create_sql_functions():
 
 
 def transfer_busses():
+    """Combine EHV and HV/MV transfer buses into one table for osmTGmod.
+
+    The EHV and HV/MV transfer buses are unioned and reduced to a single
+    row per ``osm_id``.
+
+    ``DISTINCT ON`` and ``ORDER BY`` have to live in the *same* query:
+    PostgreSQL only defines which row of a group survives a
+    ``DISTINCT ON`` if that very query is ordered. Ordering the subquery
+    instead, as this used to do, leaves the choice to the query planner,
+    cf. `#769 <https://github.com/openego/eGon-data/issues/769>`_.
+
+    Duplicate ``osm_id``\\ s are the rule rather than the exception here:
+    a substation can show up in both source tables, and
+    ``hvmv_substation.sql`` unions the ``osm_polygon`` and ``osm_line``
+    geometries of the same way, which yields two rows whose centroid -
+    the one value osmTGmod actually reads - differs.
+
+    The tie is broken on ``status`` first, which is 1 where the voltage
+    was tagged explicitly, and then on the content of the row, so that
+    the choice is stable across runs. ``bus_id`` is only the key of last
+    resort, and only usable as one because ``hvmv_substation.sql`` and
+    ``ehv_substation.sql`` now fill their sequences in a defined order -
+    do not drop the ``ORDER BY`` from those two ``INSERT``\\ s without
+    also revisiting this.
+
+    Careful when touching the column list: osmTGmod reads the CSV export
+    of this table by hardcoded column index (see
+    :py:func:`egon.data.datasets.osmtgmod.osmtgmod`), so neither the
+    order nor the number of columns may change.
+    """
 
     db.execute_sql(f"""
         DROP TABLE IF EXISTS {SubstationExtraction.targets.tables['transfer_busses']};
@@ -229,7 +259,9 @@ def transfer_busses():
         UNION SELECT bus_id, lon, lat, point, polygon, voltage,
         power_type, substation, osm_id, osm_www, frequency, subst_name,
         ref, operator, dbahn, status
-        FROM {SubstationExtraction.targets.tables['hvmv_substation']} ORDER BY osm_id) as foo;
+        FROM {SubstationExtraction.targets.tables['hvmv_substation']}) as foo
+        ORDER BY osm_id, status, ST_AsBinary(point), voltage,
+                 ST_AsBinary(polygon), bus_id;
         """)
 
 

--- a/src/egon/data/datasets/substation/ehv_substation.sql
+++ b/src/egon/data/datasets/substation/ehv_substation.sql
@@ -156,7 +156,11 @@ CREATE VIEW 		grid.egon_final_result_hoes AS
 -- insert results
 INSERT INTO grid.egon_ehv_transfer_buses (lon, lat, point, polygon, voltage, power_type, substation, osm_id, osm_www, frequency, subst_name, ref, operator, dbahn, status)
 	SELECT 	lon, lat, point, polygon, voltage, power_type, substation, osm_id, osm_www, frequency, subst_name, ref, operator, dbahn, status
-	FROM 	grid.egon_final_result_hoes;
+	FROM 	grid.egon_final_result_hoes
+	-- Order explicitly so that the bus_id sequence is filled in a
+	-- reproducible order instead of in scan order, see
+	-- https://github.com/openego/eGon-data/issues/769
+	ORDER BY osm_id;
 
 
 -- drop

--- a/src/egon/data/datasets/substation/hvmv_substation.sql
+++ b/src/egon/data/datasets/substation/hvmv_substation.sql
@@ -180,7 +180,11 @@ CREATE VIEW 		grid.egon_final_result AS
 -- insert results
 INSERT INTO grid.egon_hvmv_transfer_buses (lon, lat, point, polygon, voltage, power_type, substation, osm_id, osm_www, frequency, subst_name, ref, operator, dbahn, status)
 	SELECT lon, lat, point, polygon, voltage, power_type, substation, osm_id, osm_www, frequency, subst_name, ref, operator, dbahn, status
-	FROM grid.egon_final_result;
+	FROM grid.egon_final_result
+	-- Order explicitly so that the bus_id sequence is filled in a
+	-- reproducible order instead of in scan order, see
+	-- https://github.com/openego/eGon-data/issues/769
+	ORDER BY osm_id;
 
 -- update voltage level if split by '/' instead of ';' or contains '--'
 UPDATE grid.egon_hvmv_transfer_buses


### PR DESCRIPTION
Fixes #804.
Contributes to #769, but does not close it - see the note at the end.

MV grid district geometries differed between egon-data runs even when
the substation input was identical. Fixing that turned out to need two
independent changes, so both are in this branch: the grid district
algorithm itself was non-deterministic, and the input egon-data hands to
osmTGmod was not stable either. The second removes egon-data's own
contribution to that instability; it does not remove osmTGmod's, which is
why #769 stays open. They are in one branch because the second is what
made the first testable across full runs.

**Cause, grid districts (#804).** Municipalities and municipality fragments without a substation of their own are assigned to the "nearest" neighbouring polygon. The two queries deciding this put `DISTINCT ON` one level above the subquery holding their `ORDER BY`, and PostgreSQL leaves the surviving row of such a query to the planner. On top of that the primary ordering key - the distance between the two polygons - is exactly 0 for every candidate of the `touches` strategy, so it broke no ties at all. On a Schleswig-Holstein run, 78 % of these assignments have two or more candidates at distance 0, so the exposure was the normal case rather than a corner case.

**Cause, osmTGmod input (#769).** `transfer_busses_complete` was built with the same `DISTINCT ON` / `ORDER BY` mismatch, and duplicate `osm_id`s are the rule there rather than the exception: a substation can appear in both source tables, and `hvmv_substation.sql` unions the `osm_polygon` and `osm_line` geometry of the same way. Its CSV export was then copied without `ORDER BY`, and those rows are inserted into osmTGmod's `transfer_busses` one by one - so the copy order became their physical order and thereby part of osmTGmod's input. Both result `INSERT`s of the substation extraction also filled their `bus_id` sequences in scan order.

**Change.** `DISTINCT ON` and `ORDER BY` now sit in the same query everywhere, and the ordering keys are extended so a total order remains for symmetric geometries - by centroid distance and `bus_id` for the grid districts, by `status` and row content for the transfer buses. Same fix where a cut polygon with several substations left `UPDATE ... FROM` to pick one unpredictably. The osmTGmod CSV export and the two substation `INSERT`s are ordered explicitly. Additionally the two `sum()` aggregates computing the `area` column are ordered, because adding `double precision` values is not associative and `area` otherwise wobbled by an ULP on an otherwise byte-identical geometry.

Dataset versions: `MvGridDistricts` 0.0.5 → 0.0.7, `substation_extraction` 0.0.5 → 0.0.6, `Osmtgmod` 0.0.12 → 0.0.13.

**Verification, part 1 - determinism given fixed input.** `define_mv_grid_districts()` was re-run (SH run) ten times against one database with different query plans forced, on two independent pipeline runs (201 and 202 substations):

| | without fix | with fix |
|---|---|---|
| run 3 | 3 differing results out of 10 | all 10 identical |
| run 4 | 3 differing results out of 10 | all 10 identical |

The polygon that changes hands under a plan toggle is the same 19,589,258 m² municipality that moved between districts in the two runs that prompted the issue, so the reproducer and the reported symptom are the same event.

**Verification, part 2 - reproducibility across full runs.** Five full pipeline runs in test mode, each preceded by deleting the recorded rows of `Osmtgmod`, `substation_extraction`, `substation_voronoi` and `MvGridDistricts` from `metadata.datasets` so that all four genuinely re-executed every time. Four of the five produced the same substation set, and for those four `grid.egon_hvmv_substation`, `grid.egon_hvmv_substation_voronoi` and `grid.egon_mv_grid_district` came back **byte-identical in all six pairwise comparisons** - same geometries, same `bus_id`s, same full-precision `area` values. The fifth run lost two substations to the osmTGmod issue below and its districts differ accordingly, as they must.

Worth noting for anyone repeating this: without that reset, re-triggering the DAG against the same database does *not* re-execute a dataset whose version is unchanged, so its tables keep the content of an earlier run while everything around them is refreshed. Comparisons made that way look stable but prove nothing.

! **Grid districts change compared to previously published data.** Around six assignments per run settle differently from the answer the old default plan happened to produce. This is unavoidable - the old answer was arbitrary - but downstream consumers (ding0, eDisGo) will see different MVGD geometries.

(i)️ **#769 stays open deliberately, and this PR does not make full runs reproducible on its own.** osmTGmod remains irreproducible internally - 680 / 681 / 681 / 683 / 681 buses in `osmtgmod_results.bus_data` over the five runs, differing in every pairwise comparison. Of 245 substation-bearing `osm_substation_id`s, four are unstable, and all four anomalies fall in the same single run out of five, which suggests one divergence in the abstraction cascading rather than four independent ones:

| `osm_substation_id` | 4 of 5 runs | the outlier run |
|---|---|---|
| 493166214 (bus 1837) | `base_kv` 110 | `base_kv` 220 |
| 733670960 (bus 1867) | `base_kv` 110 | `base_kv` 380 |
| 96630857 (bus 1680) | `cntr_id` DK | `cntr_id` DE |
| 0 (foreign placeholder) | `bus_i` shuffles in every run | - |

Because `osmtgmod/substation.py` keeps only buses with `base_kv <= 110`, the first two rows cost two HV/MV substations in that run, which is what moved its grid districts. So the input to the grid district algorithm is still not stable; what this PR guarantees is that the algorithm turns a given input into the same districts every time. The variation also reaches `grid.egon_etrago_bus`, `egon_etrago_line` and `egon_etrago_transformer` via `to_pypsa()`. The `cntr_id` flip on a border substation looks like an arbitrary pick in an admin-boundary join and is probably the easiest thread to pull on the osmTGmod side.

---

## 🧑‍💻 Contributor Checklist

Before requesting a review, make sure you've completed all of the following:

- [ ] All **tests pass** locally or via CI
      _(for more information on local test, check `tox` in the [Contributing section](https://egon-data.readthedocs.io/en/latest/contributing.html#))_
      _(CI tests are automatically executed when creating a PR, you can see the results of the checks below)_
- [ ] Workflow has run at least once in **Test mode**
      _(optional if no dataset changes are involved)_
- [ ] Relevant **documentation is updated** (API, new features, etc.)
- [ ] Dataset-versions are updated when existing datasets are adjusted.
- [ ] Added a note to `CHANGELOG.rst` about the changes
- [ ] Added yourself to `AUTHORS.rst`

Optional:

- [ ] Changes have been tested in **Everything mode**
- [ ] Extend the checklist for reviewers: Which aspects should be reviewed in particular?

---

## 🔍 Reviewer Checklist

During your review, please check the following:

```markdown
Two places deserve the attention, both about the tie-breaking rules
rather than the mechanics:

1. `src/egon/data/datasets/mv_grid_districts.py`, in
   `assign_substation_municipality_fragments` and
   `nearest_polygon_with_substation`:
   - is `bus_id` a sufficient final tiebreaker, i.e. can `subst_count`
     and `geom_sub` vary between rows sharing a `bus_id`?
   - is "nearest centroid" the rule we want, or would something like the
     longest shared boundary be better? Either is deterministic; this PR
     deliberately keeps the rule the code already intended rather than
     changing the semantics.

2. `src/egon/data/datasets/substation/transfer_busses()`: the surviving
   row per `osm_id` is picked by `status`, then point, voltage, polygon,
   and `bus_id` last. On Schleswig-Holstein all 17 contested `osm_id`s
   carry an identical `point`, so the choice does not currently change
   what osmTGmod sees - but it will on other extents, and a
   domain-motivated rule (prefer the polygon-derived centroid over the
   line-derived one? prefer HV/MV over EHV?) may be better than the
   content-derived order used here.

Note that the `area` ordering (commit "Order the area sums in MV grid
districts") is the one change here that has not been through a full
pipeline run - the four runs cited above predate it. It cannot affect
geometries, only the `area` column.
```

- [ ] **Is the code clean, readable, and efficient?** Are there any oddities or obvious inefficiencies?
- [ ] Does the code work as expected? _(should already be verified by contributor)_
- [ ] Do all tests pass? (see CI results)
- [ ] Is the documentation complete and up to date?
- [ ] Is `CHANGELOG.rst` updated accordingly?
- [ ] Is all necessary metadata complete and correct?
  - [ ] If metadata is pending: Is there an appropriate issue filed?
