### PR TITLE
Feature/#1471 unify battery target capacity input

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -68,6 +68,9 @@ Changed
   instead of a hard-coded scenario list, and remove obsolete
   status2019/status2023/eGon100RE handling
   `#1483 <https://github.com/openego/eGon-data/issues/1483>`_
+* Allign Methodology for laoding NEP target values for Battery storage for all scenarios
+  `#1471 <https://github.com/openego/eGon-data/issues/1471>`_
+
 
 Bug Fixes
 ---------

--- a/src/egon/data/datasets/scenario_capacities.py
+++ b/src/egon/data/datasets/scenario_capacities.py
@@ -169,7 +169,7 @@ def insert_capacities_status_quo(scenario: str) -> None:
         (component, carrier, capacity, nuts, scenario_name)
         VALUES (
             'storage_units',
-            'battery',
+            'home_battery',
             {small_storages},
             'DE',
             '{scenario}'
@@ -241,7 +241,8 @@ def insert_capacities_per_federal_state_nep():
         "Oel": "oil",
         "Haushaltswaermepumpen": "residential_rural_heat_pump",
         "KWK < 10 MW": "small_chp",
-        "PV-Batteriespeicher": "battery",
+        "PV-Batteriespeicher": "home_battery",
+        "Großbatteriespeicher": "BESS",
     }
     # 'Elektromobilitaet gesamt': 'transport',
     # 'Elektromobilitaet privat': 'transport'}
@@ -261,7 +262,19 @@ def insert_capacities_per_federal_state_nep():
         "PV (Aufdach)",
         "PV (Freiflaeche)",
     ]
-    
+
+    # 'PV-Batteriespeicher' (home battery) and 'Großbatteriespeicher' (BESS)
+    # have no federal-state breakdown at all in the eGon2035 source file -
+    # neither in the main sheet (only the national 'Summe' is filled) nor
+    # in the draft report (no matching row exists there either), so the
+    # scaled_carriers mechanism above cannot be used for them. Handled
+    # below via a single national (nuts='DE') row instead, analogous to
+    # how status2024's small-storage capacity is inserted in
+    # insert_capacities_status_quo(). Not needed for reGon2037/reGon2045,
+    # whose (newer) source file already has real per-federal-state values
+    # for both carriers.
+    national_only_carriers = ["PV-Batteriespeicher", "Großbatteriespeicher"]
+
     insert_data = pd.DataFrame()
     for scenario in scenarios:
         if scenario not in scenario_config:
@@ -287,11 +300,33 @@ def insert_capacities_per_federal_state_nep():
         # values from the wind offshore sheet (convert MW to GW)
         for state in df_windoff_fs.index:
             df.at["Wind offshore", state] = df_windoff_fs.at[state, cfg["windoff_col"]] / 1000
-    
+
+        # Insert 'national_only_carriers' as a single nuts='DE' row instead
+        # of a per-federal-state breakdown (see comment above their
+        # definition)
+        if scenario == "eGon2035":
+            insert_data = pd.concat([
+                insert_data,
+                pd.DataFrame({
+                    "carrier": [rename_carrier[c] for c in national_only_carriers],
+                    "capacity": [
+                        df.loc[c, "Summe"] * 1e3 for c in national_only_carriers
+                    ],
+                    "component": "generator",
+                    "nuts": "DE",
+                    "scenario": scenario,
+                }),
+            ])
+
         for bl in map_nuts.index:
             # Extract capacity data for the current federal state
             data = pd.DataFrame(df[bl])
-            
+
+            # Handled above as a single national row instead, see comment
+            # at national_only_carriers' definition
+            if scenario == "eGon2035":
+                data = data.drop(index=national_only_carriers, errors="ignore")
+
             # For carriers without direct federal state distribution in the final
             # NEP report, scale the draft distribution to match the final national total
             for c in scaled_carriers:

--- a/src/egon/data/datasets/scenario_capacities.py
+++ b/src/egon/data/datasets/scenario_capacities.py
@@ -1006,7 +1006,7 @@ class ScenarioCapacities(Dataset):
     #:
     name: str = "ScenarioCapacities"
     #:
-    version: str = "0.0.23"
+    version: str = "0.0.24"
     sources = DatasetSources(
         files={
             "eGon2035_capacities": "data_bundle_egon_data/nep2035_version2021/NEP2035_V2021_scnC2035.xlsx",

--- a/src/egon/data/datasets/scenario_capacities.py
+++ b/src/egon/data/datasets/scenario_capacities.py
@@ -196,7 +196,7 @@ def insert_capacities_per_federal_state_nep():
     db.execute_sql(f"""
         DELETE FROM {targets.tables['scenario_capacities']}
         WHERE scenario_name IN ('eGon2035', 'reGon2037', 'reGon2045')
-        AND nuts != 'DE'
+        AND (nuts != 'DE' OR carrier IN ('home_battery', 'BESS'))
         """)
     
     # kicks statusquo entries from list
@@ -312,7 +312,7 @@ def insert_capacities_per_federal_state_nep():
                     "capacity": [
                         df.loc[c, "Summe"] * 1e3 for c in national_only_carriers
                     ],
-                    "component": "generator",
+                    "component": "storage_units",
                     "nuts": "DE",
                     "scenario": scenario,
                 }),
@@ -356,7 +356,13 @@ def insert_capacities_per_federal_state_nep():
             # version 2021, page 47)
             data.loc[data.carrier == "residential_rural_heat_pump", bl] *= 5e-6
             data.loc[data.carrier == "residential_rural_heat_pump", "component"] = "link"
-            
+
+            # Storage carriers, mislabeled "generator" by the default above
+            data.loc[
+                data.carrier.isin(["home_battery", "BESS", "pumped_hydro"]),
+                "component",
+            ] = "storage_units"
+
             # Rename capacity column and convert from GW to MW
             data = data.rename(columns={bl: "capacity"})
             data.capacity *= 1e3

--- a/src/egon/data/datasets/storages/__init__.py
+++ b/src/egon/data/datasets/storages/__init__.py
@@ -1,7 +1,5 @@
 """The central module containing all code dealing with power plant data."""
 
-from pathlib import Path
-
 from geoalchemy2 import Geometry
 from sqlalchemy import BigInteger, Column, Float, Integer, Sequence, String
 from sqlalchemy.dialects.postgresql import JSONB
@@ -54,7 +52,6 @@ class Storages(Dataset):
     sources = DatasetSources(
         files={
             "mastr_storage": "./bnetza_mastr/dump_2025-02-09/bnetza_mastr_storage_cleaned.csv",
-            "nep_capacities": "NEP2035_V2021_scnC2035.xlsx",
             "mastr_location": "location_elec_generation_raw.csv",
         },
         tables={
@@ -630,7 +627,8 @@ def allocate_storage_units_sq(scn_name, storage_types):
 def home_batteries_per_scenario(scenario):
     """Allocates home batteries which define a lower boundary for extendable
     battery storage units. The overall installed capacity is taken from NEP
-    for eGon2035 scenario. The spatial distribution of installed battery
+    (supply.egon_scenario_capacities, carrier='home_battery'), the same way
+    for all scenarios. The spatial distribution of installed battery
     capacities is based on the installed pv rooftop capacity.
 
     Parameters
@@ -644,45 +642,27 @@ def home_batteries_per_scenario(scenario):
 
     dataset = config.settings()["egon-data"]["--dataset-boundary"]
 
-    if scenario == "eGon2035":
-        target_file = (
-            Path(".")
-            / "data_bundle_egon_data"
-            / "nep2035_version2021"
-            / Storages.sources.files["nep_capacities"]
-        )
+    target_df = db.select_dataframe(f"""
+        SELECT capacity
+        FROM {Storages.sources.tables['capacities']}
+        WHERE scenario_name = '{scenario}'
+        AND carrier = 'home_battery';
+        """)
 
-        capacities_nep = pd.read_excel(
-            target_file,
-            sheet_name="1.Entwurf_NEP2035_V2021",
-            index_col="Unnamed: 0",
-        )
+    # Sum over all returned federal states: status2024 and eGon2035 each
+    # have a single national row (nuts='DE') - their underlying NEP source
+    # files provide no federal-state breakdown for home batteries -
+    # reGon2037/reGon2045 have one row per federal state which is already
+    # scoped to the active --dataset-boundary
+    target = target_df.capacity.sum()
 
-        # Select national target value in MW
-        target = capacities_nep.Summe["PV-Batteriespeicher"] * 1000
-
-        if dataset == "Schleswig-Holstein":
-            # break down national target to SH's rough share
-            target = target / 16
-
-    else:
-        target_df = db.select_dataframe(f"""
-            SELECT capacity
-            FROM {Storages.sources.tables['capacities']}
-            WHERE scenario_name = '{scenario}'
-            AND carrier = 'battery';
-            """)
-
-        # Sum over all returned federal states: status quo has a single
-        # national row (nuts='DE'), reGon2037/reGon2045 have one row per
-        # federal state which is already scoped to the active
-        # --dataset-boundary
-        target = target_df.capacity.sum()
-
-        if "status" in scenario and dataset == "Schleswig-Holstein":
-            # status quo target is always national (nuts='DE'), still
-            # needs to be broken down to SH's rough share in test mode
-            target = target / 16
+    if (
+        ("status" in scenario or scenario == "eGon2035")
+        and dataset == "Schleswig-Holstein"
+    ):
+        # national-only target, still needs to be broken down to SH's
+        # rough share in test mode
+        target = target / 16
 
     pv_rooftop = db.select_dataframe(f"""
         SELECT bus, p_nom, generator_id

--- a/src/egon/data/datasets/storages/__init__.py
+++ b/src/egon/data/datasets/storages/__init__.py
@@ -108,7 +108,7 @@ class Storages(Dataset):
     #:
     name: str = "Storages"
     #:
-    version: str = "0.0.12"
+    version: str = "0.0.13"
 
     def __init__(self, dependencies):
         super().__init__(


### PR DESCRIPTION
Fixes #1471 . 
**Description**
Implement same methodology for loading home_battery target values for all scenarios


### 📋 Pull Request Guidelines

> Please read the [Pull Request Guidelines](https://egon-data.readthedocs.io/en/latest/contributing.html#pull-request-guidelines) carefully before creating your PR.

---

## 🧑‍💻 Contributor Checklist

Before requesting a review, make sure you've completed all of the following:

- [ ] All **tests pass** locally or via CI
      _(for more information on local test, check `tox` in the [Contributing section](https://egon-data.readthedocs.io/en/latest/contributing.html#))_
      _(CI tests are automatically executed when creating a PR, you can see the results of the checks below)_
- [ ] Workflow has run at least once in **Test mode**
      _(optional if no dataset changes are involved)_
- [ ] Relevant **documentation is updated** (API, new features, etc.)
- [ ] Dataset-versions are updated when existing datasets are adjusted.
- [ ] Added a note to `CHANGELOG.rst` about the changes
- [ ] Added yourself to `AUTHORS.rst`

**Notes**

- [x] Changes have been tested in **SH-Mode**


---

## 🔍 Reviewer Checklist

During your review, please check the following:

- [ ] **Is the code clean, readable, and efficient?** Are there any oddities or obvious inefficiencies?
- [ ] Does the code work as expected? _(should already be verified by contributor)_
- [ ] Do all tests pass? (see CI results)
- [ ] Is the documentation complete and up to date?
- [ ] Is `CHANGELOG.rst` updated accordingly?
- [ ] Is all necessary metadata complete and correct?
  - [ ] If metadata is pending: Is there an appropriate issue filed?


---

## 📝 Additional Notes (optional)

<!-- Add any extra context or known issues here (e.g., performance, design decisions, etc.) -->

---

💡 **Tip:** If you add multiple reviewers, clarify who should check what — this saves time and avoids duplicated efforts.
