### PR TITLE
Fixes/#1510 re gon nep2025 scenarios conventional and pumped hydro power plant allocation broken

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -118,6 +118,16 @@ Bug Fixes
   regular pass and inserted a second identical load under the scenario's
   own name, doubling transport demand in status quo scenarios
   `#1483 <https://github.com/openego/eGon-data/issues/1483>`_
+* Fix conventional non-CHP and pumped hydro power plant allocation for the
+  reGon2037/reGon2045 scenarios: the NEP2025 Kraftwerksliste has no
+  ``bnetza_id`` column (only ``mastr_id``) and stores the CHP flag as
+  lowercase ``ja``/``nein``, so ``select_nep_power_plants`` /
+  ``select_nep_pumped_hydro`` crashed with ``UndefinedColumn`` and, once
+  that was worked around, allocated nothing because every ``chp = 'Nein'``
+  filter missed. ``bnetza_id`` is now only selected for eGon2035,
+  pumped hydro uses ``mastr_id`` for the reGon path, and the CHP flag is
+  normalized to ``Ja``/``Nein`` on import
+  `#1510 <https://github.com/openego/eGon-data/issues/1510>`_
 
 Version 2.0.0 (2025-08-20)
 ==========================

--- a/src/egon/data/datasets/power_plants/__init__.py
+++ b/src/egon/data/datasets/power_plants/__init__.py
@@ -1510,7 +1510,7 @@ class PowerPlants(Dataset):
     #:
     name: str = "PowerPlants"
     #:
-    version: str = "0.0.37"
+    version: str = "0.0.38"
 
     def __init__(self, dependencies):
         super().__init__(

--- a/src/egon/data/datasets/power_plants/conventional.py
+++ b/src/egon/data/datasets/power_plants/conventional.py
@@ -36,9 +36,14 @@ def select_nep_power_plants(carrier, scn):
     nep_scenario = "eGon2035" if scn == "eGon2035" else "reGon"
     capacity_column = f"c{get_scenario_year(scn)}_capacity"
 
+    # The NEP2021 Kraftwerksliste (eGon2035) carries a "bnetza_id" column; the
+    # NEP2025 list (reGon2037/reGon2045) does not. It is only passed through and
+    # never used for the allocation, so only select it where it exists.
+    id_column = "bnetza_id, " if nep_scenario == "eGon2035" else ""
+
     # Select plants with geolocation from list of conventional power plants
     nep = db.select_dataframe(f"""
-        SELECT bnetza_id, name, carrier, capacity, postcode, city,
+        SELECT {id_column}name, carrier, capacity, postcode, city,
         federal_state, {capacity_column}
         FROM {sources.tables['nep_conv']}
         WHERE carrier = '{carrier}'
@@ -54,7 +59,8 @@ def select_nep_power_plants(carrier, scn):
     nep = nep[~nep["postcode"].str.contains("L")]
     nep = nep[~nep["postcode"].str.contains("nan")]
 
-    nep["bnetza_id"] = nep["bnetza_id"].str[0:7]
+    if "bnetza_id" in nep.columns:
+        nep["bnetza_id"] = nep["bnetza_id"].str[0:7]
 
     return nep
 

--- a/src/egon/data/datasets/scenario_capacities.py
+++ b/src/egon/data/datasets/scenario_capacities.py
@@ -688,7 +688,11 @@ def insert_nep_list_powerplants(export=True):
     
     # Map NEP carrier names to internal eGon-data carrier names
     kw_liste_nep["carrier"] = map_carrier()[kw_liste_nep.carrier_nep].values
-    kw_liste_nep["chp"] = kw_liste_nep["chp"].replace("ja", "Ja")
+    # The NEP2021 list uses "Ja"/"Nein", the NEP2025 list uses "ja"/"nein".
+    # Downstream queries filter on the capitalized form, so normalize both.
+    kw_liste_nep["chp"] = kw_liste_nep["chp"].replace(
+        {"ja": "Ja", "nein": "Nein"}
+    )
 
     if export is True:
         # Insert data to db
@@ -971,7 +975,7 @@ class ScenarioCapacities(Dataset):
     #:
     name: str = "ScenarioCapacities"
     #:
-    version: str = "0.0.23"
+    version: str = "0.0.24"
     sources = DatasetSources(
         files={
             "eGon2035_capacities": "data_bundle_egon_data/NEP/NEP_V2021_scnC2035.xlsx",

--- a/src/egon/data/datasets/storages/__init__.py
+++ b/src/egon/data/datasets/storages/__init__.py
@@ -111,7 +111,7 @@ class Storages(Dataset):
     #:
     name: str = "Storages"
     #:
-    version: str = "0.0.12"
+    version: str = "0.0.13"
 
     def __init__(self, dependencies):
         super().__init__(

--- a/src/egon/data/datasets/storages/pumped_hydro.py
+++ b/src/egon/data/datasets/storages/pumped_hydro.py
@@ -35,12 +35,20 @@ def select_nep_pumped_hydro(scn):
 
     carrier = "pumped_hydro"
 
+    # The NEP2021 list (eGon2035) identifies plants by "bnetza_id"; the NEP2025
+    # list (reGon2037/reGon2045) has no such column and uses "mastr_id" instead.
+    # Alias it so the downstream handling stays identical.
+    nep_scenario = "eGon2035" if scn == "eGon2035" else "reGon"
+    id_column = (
+        "bnetza_id" if nep_scenario == "eGon2035" else "mastr_id AS bnetza_id"
+    )
+
     if "status" in scn:
         # Select plants with geolocation from list of conventional power plants
         year = int(scn[-4:])
 
         nep_ph = db.select_dataframe(f"""
-            SELECT bnetza_id, name, carrier, postcode, capacity, city,
+            SELECT {id_column}, name, carrier, postcode, capacity, city,
             federal_state
             FROM {sources.tables['nep_conv']}
             WHERE carrier = '{carrier}'
@@ -56,11 +64,10 @@ def select_nep_pumped_hydro(scn):
         # year (e.g. c2035_capacity, c2037_capacity, c2045_capacity).
         # eGon2035 plants are tagged 'eGon2035', reGon2037/reGon2045 share
         # the same NEP2025 list (tagged 'reGon')
-        nep_scenario = "eGon2035" if scn == "eGon2035" else "reGon"
         capacity_column = f"c{get_scenario_year(scn)}_capacity"
 
         nep_ph = db.select_dataframe(f"""
-            SELECT bnetza_id, name, carrier, postcode, capacity, city,
+            SELECT {id_column}, name, carrier, postcode, capacity, city,
             federal_state, {capacity_column}
             FROM {sources.tables['nep_conv']}
             WHERE carrier = '{carrier}'
@@ -78,8 +85,10 @@ def select_nep_pumped_hydro(scn):
     nep_ph = nep_ph[~nep_ph["postcode"].str.contains("L")]
     nep_ph = nep_ph[~nep_ph["postcode"].str.contains("nan")]
 
-    # Remove the subunits from the bnetza_id
-    nep_ph["bnetza_id"] = nep_ph["bnetza_id"].str[0:7]
+    if nep_scenario == "eGon2035":
+        # Remove the subunits from the bnetza_id (NEP2021 list only; the
+        # NEP2025 mastr_id carries no subunit suffix)
+        nep_ph["bnetza_id"] = nep_ph["bnetza_id"].str[0:7]
 
     return nep_ph
 


### PR DESCRIPTION
Fixes #1510.

Already tested for Germany. Results in server run.

**Abstract of changes:**

- Make the conventional non-CHP and pumped-hydro power plant allocation work with the NEP2025 Kraftwerksliste (reGon2037/reGon2045), which identifies plants by `mastr_id` instead of `bnetza_id`. the id column is now chosen per NEP list version instead of being hard-coded.
- Normalize the NEP CHP flag to `Ja`/`Nein` on import, so the lowercase `ja`/`nein` of the NEP2025 list no longer slips past the downstream `chp = 'Nein'` filters and silently drops every non-CHP reGon plant.
- Bump the affected dataset versions (`PowerPlants`, `ScenarioCapacities`, `Storages`) so the corrected steps re-run.

