### PR TITLE
Add public bus charging dataset (vehicle class M3)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,4 +2,4 @@
 Authors
 =======
 
-* Jonathan Amme, Clara Büttner, Ilka Cußmann, Julian Endres, Carlos Epia, Kilian Helfenbein, Stephan Günther, Ulf Müller, Amélia Nadal, Guido Pleßmann, Francesco Witte  - https://github.com/openego/eGon-data
+* Jonathan Amme, Clara Büttner, Ilka Cußmann, Julian Endres, Carlos Epia, Kilian Helfenbein, Stephan Günther, Ulf Müller, Amélia Nadal, Guido Pleßmann, Moritz Schlösser, Francesco Witte  - https://github.com/openego/eGon-data

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,11 @@ Added
   alongside home batteries, and separate eTraGo carriers/cost parameters 
   ('BESS' vs'home_battery') instead of one generic 'battery' carrier
   `#1478 <https://github.com/openego/eGon-data/issues/1478>`_
+* Add new eMobility dataset for public buses (vehicle class M3): static depot
+  charging loads per scenario, written per-depot to
+  demand.egon_ev_bus_charging_depot for eDisGo and aggregated per eTraGo bus
+  under the new carrier 'land_transport_bus'
+  `#1461 <https://github.com/openego/eGon-data/issues/1461>`_
 
 
 Changed

--- a/docs/data/mobility_demand.rst
+++ b/docs/data/mobility_demand.rst
@@ -179,3 +179,55 @@ of each NUTS3 region is used to determine the respective hydrogen Voronoi cell (
 :py:class:`GasAreaseGon2035<egon.data.datasets.gas_areas.GasAreaseGon2035>` and
 :py:class:`GasAreaseGon100RE<egon.data.datasets.gas_areas.GasAreaseGon100RE>`) it is
 located in.
+
+.. _mobility-demand-public-bus-ref:
+
+Public buses
+++++++++++++
+
+Electricity demand of public buses (vehicle class M3) is set up for the
+``status2024``, ``reGon2037`` and ``reGon2045`` scenarios by
+:py:class:`PublicBusCharging<egon.data.datasets.emobility.public_bus_charging.PublicBusCharging>`.
+The ``eGon2035`` and ``eGon100RE`` scenarios deliberately carry no public bus
+demand.
+
+Unlike motorized individual travel and heavy-duty transport, the charging
+demand is not generated within egon-data. Depot locations and a static hourly
+charging series per depot and scenario are produced externally and ship in the
+data bundle under ``data_bundle_egon_data/bus_charging/``. No flexibility is
+modelled: the series are taken as given, so no charging link or storage
+component is written and no lowflex scenario variant is created.
+
+Each depot is written per scenario to
+:py:class:`demand.egon_ev_bus_charging_depot<egon.data.datasets.emobility.public_bus_charging.db_classes.EgonEvBusChargingDepot>`
+with its geometry, grid connection voltage level and full 8760-step time
+series. This per-location detail is required by eDisGo, which cannot
+reconstruct a predefined series from an aggregate.
+
+The voltage level is derived per depot **and per scenario** from that
+scenario's own peak load, using the same thresholds as
+:py:func:`identify_voltage_level<egon.data.datasets.industry.temporal.identify_voltage_level>`.
+Because bus electrification grows steeply between the scenarios, the majority
+of depots cross a threshold: only 493 of the 1053 depots present in all three
+scenarios keep the same voltage level, and 560 are assigned a higher one.
+Consistent with the treatment of other growing loads in egon-data, connection
+upgrades between scenarios are not modelled as events.
+
+The grid connection point is found by a spatial join: depots at voltage levels
+3 to 7 against ``grid.egon_mv_grid_district``, and those at levels 1 or 2
+against ``grid.egon_ehv_substation_voronoi``. Since an MV grid district is the
+Voronoi cell of a single HV/MV substation, all depots within one district share
+that district's eTraGo bus. Depots that fall into no district are dropped
+rather than matched to the nearest one.
+
+For eTraGo, the depot series are summed per bus and written to
+``grid.egon_etrago_load`` and ``grid.egon_etrago_load_timeseries`` under the
+carrier ``land_transport_bus``.
+
+.. note::
+   The ``reGon2037`` and ``reGon2045`` input series each contain 1821 missing
+   values across 34 depots, all falling in the first three hours of a Sunday.
+   These are currently replaced with zero so that the pipeline can run, which
+   understates the affected depots' demand. The substitution is logged with the
+   affected depot ids on every run and should be removed once the input data is
+   corrected.

--- a/docs/reference/egon.data.datasets.emobility.public_bus_charging.db_classes.rst
+++ b/docs/reference/egon.data.datasets.emobility.public_bus_charging.db_classes.rst
@@ -1,0 +1,7 @@
+db\_classes
+===========
+
+.. automodule:: egon.data.datasets.emobility.public_bus_charging.db_classes
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/egon.data.datasets.emobility.public_bus_charging.etrago_integration.rst
+++ b/docs/reference/egon.data.datasets.emobility.public_bus_charging.etrago_integration.rst
@@ -1,0 +1,7 @@
+etrago\_integration
+===================
+
+.. automodule:: egon.data.datasets.emobility.public_bus_charging.etrago_integration
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/egon.data.datasets.emobility.public_bus_charging.fill_tables.rst
+++ b/docs/reference/egon.data.datasets.emobility.public_bus_charging.fill_tables.rst
@@ -1,0 +1,7 @@
+fill\_tables
+============
+
+.. automodule:: egon.data.datasets.emobility.public_bus_charging.fill_tables
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/egon.data.datasets.emobility.public_bus_charging.rst
+++ b/docs/reference/egon.data.datasets.emobility.public_bus_charging.rst
@@ -1,0 +1,17 @@
+public\_bus\_charging
+=====================
+.. toctree::
+   :maxdepth: 1
+
+   egon.data.datasets.emobility.public_bus_charging.db_classes
+   egon.data.datasets.emobility.public_bus_charging.etrago_integration
+   egon.data.datasets.emobility.public_bus_charging.fill_tables
+   egon.data.datasets.emobility.public_bus_charging.scenarios
+   egon.data.datasets.emobility.public_bus_charging.spatial_assignment
+
+
+
+.. automodule:: egon.data.datasets.emobility.public_bus_charging
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/egon.data.datasets.emobility.public_bus_charging.scenarios.rst
+++ b/docs/reference/egon.data.datasets.emobility.public_bus_charging.scenarios.rst
@@ -1,0 +1,7 @@
+scenarios
+=========
+
+.. automodule:: egon.data.datasets.emobility.public_bus_charging.scenarios
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/egon.data.datasets.emobility.public_bus_charging.spatial_assignment.rst
+++ b/docs/reference/egon.data.datasets.emobility.public_bus_charging.spatial_assignment.rst
@@ -1,0 +1,7 @@
+spatial\_assignment
+===================
+
+.. automodule:: egon.data.datasets.emobility.public_bus_charging.spatial_assignment
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/egon.data.datasets.emobility.rst
+++ b/docs/reference/egon.data.datasets.emobility.rst
@@ -8,6 +8,7 @@ emobility
    egon.data.datasets.emobility.heavy_duty_transport
    egon.data.datasets.emobility.motorized_individual_travel
    egon.data.datasets.emobility.motorized_individual_travel_charging_infrastructure
+   egon.data.datasets.emobility.public_bus_charging
 
 .. automodule:: egon.data.datasets.emobility
    :members:

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -35,6 +35,9 @@ from egon.data.datasets.emobility.heavy_duty_transport import (
 from egon.data.datasets.emobility.motorized_individual_travel import (
     MotorizedIndividualTravel,
 )
+from egon.data.datasets.emobility.public_bus_charging import (
+    PublicBusCharging,
+)
 from egon.data.datasets.emobility.motorized_individual_travel_charging_infrastructure import (  # noqa: E501
     MITChargingInfrastructure,
 )
@@ -668,6 +671,27 @@ with airflow.DAG(
         # eMobility: heavy duty transport
         heavy_duty_transport = HeavyDutyTransport(
             dependencies=[vg250, setup_etrago, create_gas_polygons]
+        )
+
+        # eMobility: public buses (vehicle class M3). Static depot loads;
+        # no flexibility, so no flex/lowflex model. Only status2024,
+        # reGon2037 and reGon2045 carry bus data.
+        public_bus_charging = PublicBusCharging(
+            dependencies=[
+                # Depot locations and hourly series ship in the data bundle
+                # (data_bundle_egon_data/bus_charging), so this must not run
+                # before the bundle has been downloaded.
+                data_bundle,
+                mv_grid_districts,
+                # egon_ehv_substation_voronoi, for any depot above 120 MW
+                substation_voronoi,
+                setup_etrago,
+                scenario_parameters,
+                # egon_etrago_bus must be populated (osmtgmod's to_pypsa) --
+                # mv_grid_districts only guarantees substation.extract.
+                osmtgmod,
+                vg250,
+            ]
         )
 
         # eMobility: motorized individual travel

--- a/src/egon/data/airflow/dags/pipeline.py
+++ b/src/egon/data/airflow/dags/pipeline.py
@@ -35,11 +35,11 @@ from egon.data.datasets.emobility.heavy_duty_transport import (
 from egon.data.datasets.emobility.motorized_individual_travel import (
     MotorizedIndividualTravel,
 )
-from egon.data.datasets.emobility.public_bus_charging import (
-    PublicBusCharging,
-)
 from egon.data.datasets.emobility.motorized_individual_travel_charging_infrastructure import (  # noqa: E501
     MITChargingInfrastructure,
+)
+from egon.data.datasets.emobility.public_bus_charging import (
+    PublicBusCharging,
 )
 from egon.data.datasets.era5 import WeatherData
 from egon.data.datasets.etrago_setup import EtragoSetup

--- a/src/egon/data/datasets/emobility/public_bus_charging/__init__.py
+++ b/src/egon/data/datasets/emobility/public_bus_charging/__init__.py
@@ -1,0 +1,103 @@
+"""
+Public bus charging (vehicle class M3) for egon-data.
+
+Reads precomputed depot locations and hourly charging series and writes:
+
+* ``demand.egon_ev_bus_charging_depot`` -- one row per depot per scenario,
+  with geometry, voltage level and the full 8760-step ``p_set``. This is the
+  per-location table for eDisGo.
+* ``grid.egon_etrago_load`` / ``grid.egon_etrago_load_timeseries`` -- one
+  load per eTraGo bus per scenario, carrier ``land_transport_bus``, with the
+  depots' series summed.
+
+Scenarios carrying bus data: ``status2024``, ``reGon2037``, ``reGon2045``.
+``eGon2035`` is deliberately unchanged and ``eGon100RE`` is discarded, so
+neither gets bus loads -- zero bus demand in those scenarios is correct.
+
+Depots are modelled as ordinary fixed loads, not charging parks: there is no
+flexibility, no flex model and no lowflex variant. Design decisions are
+recorded in ``docs/adr/0001``-``0003`` of the FC_M3 working directory.
+"""
+
+from loguru import logger
+
+from egon.data import db
+from egon.data.datasets import Dataset, DatasetSources, DatasetTargets
+from egon.data.datasets.emobility.public_bus_charging.db_classes import (
+    EgonEvBusChargingDepot,
+)
+from egon.data.datasets.emobility.public_bus_charging.etrago_integration import (  # noqa: E501
+    write_etrago,
+)
+from egon.data.datasets.emobility.public_bus_charging.fill_tables import (
+    fill_depot_table,
+)
+from egon.data.datasets.emobility.public_bus_charging.spatial_assignment import (  # noqa: E501
+    spatial_assignment,
+)
+
+
+def create_tables():
+    """Drop and recreate demand.egon_ev_bus_charging_depot."""
+    engine = db.engine()
+    EgonEvBusChargingDepot.__table__.drop(bind=engine, checkfirst=True)
+    EgonEvBusChargingDepot.__table__.create(bind=engine, checkfirst=True)
+    logger.debug("Created public bus charging tables.")
+
+
+class PublicBusCharging(Dataset):
+    """
+    Integrates public bus (vehicle class M3) charging demand into egon-data.
+
+    *Dependencies*
+      * :py:class:`DataBundle <egon.data.datasets.data_bundle.DataBundle>`
+      * :py:class:`MvGridDistricts <egon.data.datasets.mv_grid_districts>`
+      * :py:class:`SubstationVoronoi <egon.data.datasets.substation_voronoi.SubstationVoronoi>`
+      * :py:class:`EtragoSetup <egon.data.datasets.etrago_setup.EtragoSetup>`
+      * :py:class:`ScenarioParameters <egon.data.datasets.scenario_parameters.ScenarioParameters>`
+      * :py:class:`Osmtgmod <egon.data.datasets.osmtgmod.Osmtgmod>`
+      * :py:class:`Vg250 <egon.data.datasets.vg250.Vg250>`
+
+    *Resulting tables*
+      * :py:class:`demand.egon_ev_bus_charging_depot
+        <egon.data.datasets.emobility.public_bus_charging.db_classes.EgonEvBusChargingDepot>`
+      * ``grid.egon_etrago_load`` and ``grid.egon_etrago_load_timeseries``
+        are extended with carrier ``land_transport_bus``
+    """
+
+    sources = DatasetSources(
+        files={
+            # depots.gpkg plus one gzipped wide CSV per scenario. Read-only
+            # input from the data bundle, resolved relative to the egon-data
+            # working directory.
+            "bus_input_dir": "data_bundle_egon_data/bus_charging",
+        },
+        tables={
+            "mv_grid_district": "grid.egon_mv_grid_district",
+            "ehv_substation_voronoi": "grid.egon_ehv_substation_voronoi",
+        },
+    )
+
+    targets = DatasetTargets(
+        tables={
+            "charging_depot": "demand.egon_ev_bus_charging_depot",
+            "etrago_load": "grid.egon_etrago_load",
+            "etrago_load_timeseries": "grid.egon_etrago_load_timeseries",
+        },
+    )
+
+    name: str = "PublicBusCharging"
+    version: str = "0.0.1"
+
+    def __init__(self, dependencies):
+        super().__init__(
+            name=self.name,
+            version=self.version,
+            dependencies=dependencies,
+            tasks=(
+                create_tables,
+                fill_depot_table,
+                spatial_assignment,
+                write_etrago,
+            ),
+        )

--- a/src/egon/data/datasets/emobility/public_bus_charging/__init__.py
+++ b/src/egon/data/datasets/emobility/public_bus_charging/__init__.py
@@ -52,9 +52,11 @@ class PublicBusCharging(Dataset):
     *Dependencies*
       * :py:class:`DataBundle <egon.data.datasets.data_bundle.DataBundle>`
       * :py:class:`MvGridDistricts <egon.data.datasets.mv_grid_districts>`
-      * :py:class:`SubstationVoronoi <egon.data.datasets.substation_voronoi.SubstationVoronoi>`
+      * :py:class:`SubstationVoronoi
+        <egon.data.datasets.substation_voronoi.SubstationVoronoi>`
       * :py:class:`EtragoSetup <egon.data.datasets.etrago_setup.EtragoSetup>`
-      * :py:class:`ScenarioParameters <egon.data.datasets.scenario_parameters.ScenarioParameters>`
+      * :py:class:`ScenarioParameters
+        <egon.data.datasets.scenario_parameters.ScenarioParameters>`
       * :py:class:`Osmtgmod <egon.data.datasets.osmtgmod.Osmtgmod>`
       * :py:class:`Vg250 <egon.data.datasets.vg250.Vg250>`
 

--- a/src/egon/data/datasets/emobility/public_bus_charging/db_classes.py
+++ b/src/egon/data/datasets/emobility/public_bus_charging/db_classes.py
@@ -1,0 +1,87 @@
+"""
+DB tables / SQLAlchemy ORM classes for public bus charging (vehicle class M3).
+"""
+
+from geoalchemy2 import Geometry
+from sqlalchemy import (
+    ARRAY,
+    BigInteger,
+    Column,
+    Float,
+    ForeignKey,
+    Integer,
+    SmallInteger,
+    String,
+    Text,
+)
+from sqlalchemy.ext.declarative import declarative_base
+
+from egon.data.datasets.scenario_parameters import EgonScenario
+
+Base = declarative_base()
+
+
+class EgonEvBusChargingDepot(Base):
+    """
+    Class definition of table demand.egon_ev_bus_charging_depot.
+
+    One row per bus depot per scenario. This is the per-location table read
+    by eDisGo; the aggregated per-bus loads written to
+    ``grid.egon_etrago_load`` are derived from it (see ``docs/adr/0002`` in
+    the FC_M3 working directory).
+
+    **Columns**
+
+    depot_id:
+        Depot identifier. An OSM id for real depots, ``standin_<cluster>``
+        for synthetic ones. Kept as the natural key so it joins directly to
+        the input time-series columns and stays stable across scenarios and
+        input-data regenerations.
+    scenario:
+        Scenario name. A depot exists in a scenario only if that scenario's
+        input data contains a series for it.
+    depot_name:
+        Descriptive name from the input data.
+    depot_type:
+        ``real`` (an actual surveyed site, coordinates trustworthy) or
+        ``standin`` (synthetic, placed at a route cluster's busiest stop --
+        demand is real, siting is inferred).
+    fleet_size:
+        Number of buses assigned to the depot.
+    geom:
+        Depot location.
+    bus_id:
+        eTraGo bus the depot's load is attached to. From the containing MV
+        grid district (voltage level 3-7) or EHV substation Voronoi cell
+        (voltage level 1-2).
+    mv_grid_id:
+        MV grid district the depot falls in; equals ``bus_id`` for voltage
+        levels 3-7 and is NULL for depots assigned via the EHV Voronoi.
+    voltage_level:
+        eGon-data grid level 1-7, derived from this scenario's own peak load.
+        A property of the (depot, scenario) pair, not of the depot -- the
+        same depot may sit at different levels in different scenarios and
+        connection upgrades are not modelled (``docs/adr/0001``).
+    peak_load_mw:
+        Maximum of ``p_set``, in MW.
+    annual_demand_mwh:
+        Sum of ``p_set``, in MWh (1 h timesteps).
+    p_set:
+        Hourly charging power over the year, 8760 values in MW.
+    """
+
+    __tablename__ = "egon_ev_bus_charging_depot"
+    __table_args__ = {"schema": "demand"}
+
+    depot_id = Column(String, primary_key=True)
+    scenario = Column(String, ForeignKey(EgonScenario.name), primary_key=True)
+    depot_name = Column(Text)
+    depot_type = Column(Text)
+    fleet_size = Column(Float)
+    geom = Column(Geometry("POINT", srid=3035))
+    bus_id = Column(BigInteger, index=True)
+    mv_grid_id = Column(Integer)
+    voltage_level = Column(SmallInteger)
+    peak_load_mw = Column(Float)
+    annual_demand_mwh = Column(Float)
+    p_set = Column(ARRAY(Float))

--- a/src/egon/data/datasets/emobility/public_bus_charging/etrago_integration.py
+++ b/src/egon/data/datasets/emobility/public_bus_charging/etrago_integration.py
@@ -1,0 +1,136 @@
+"""
+Write public bus charging demand into the eTraGo load tables.
+
+Depots are aggregated **per eTraGo bus**: one ``grid.egon_etrago_load`` row
+and one 8760-step ``grid.egon_etrago_load_timeseries`` row per bus per
+scenario, carrier ``land_transport_bus``. The per-depot detail stays in
+``demand.egon_ev_bus_charging_depot`` for eDisGo (``docs/adr/0002``).
+
+Depots sharing a bus carry no flexibility to distinguish them, so N loads on
+one bus are mathematically identical to one summed load for every power-flow
+result eTraGo computes -- writing them separately would cost N times the
+rows of 8760 floats for no modelling gain.
+
+No flex model (bus + link + store) and no lowflex variant are written: this
+dataset has no flexibility (``docs/adr/0003``).
+"""
+
+from loguru import logger
+import numpy as np
+import pandas as pd
+
+from egon.data import db
+from egon.data.datasets.emobility.public_bus_charging.scenarios import (
+    active_scenarios,
+)
+from egon.data.datasets.etrago_setup import (
+    EgonPfHvLoad,
+    EgonPfHvLoadTimeseries,
+)
+
+#: eTraGo carrier for public bus charging. Distinct from MIT's
+#: ``land_transport_EV`` and HGV's ``land_transport_HGV`` so that each
+#: dataset's carrier-scoped delete only removes its own rows.
+CARRIER = "land_transport_bus"
+
+N_TIMESTEPS = 8760
+
+
+def _delete_old_entries(scenario: str):
+    """Remove this dataset's eTraGo rows for one scenario.
+
+    Scoped by carrier **and** scenario, so a run configured for one scenario
+    leaves another scenario's bus loads alone.
+    """
+    db.execute_sql(
+        f"""
+        DELETE FROM grid.egon_etrago_load_timeseries
+        WHERE scn_name = '{scenario}'
+          AND load_id IN (
+              SELECT load_id FROM grid.egon_etrago_load
+              WHERE scn_name = '{scenario}' AND carrier = '{CARRIER}'
+          );
+        DELETE FROM grid.egon_etrago_load
+        WHERE scn_name = '{scenario}' AND carrier = '{CARRIER}';
+        """
+    )
+
+
+def write_etrago():
+    """Aggregate depots per bus and write eTraGo loads for all scenarios."""
+    scenarios = active_scenarios()
+    if not scenarios:
+        logger.warning("No active scenario carries public bus data.")
+        return
+
+    for scenario in scenarios:
+        depots = db.select_dataframe(
+            f"""
+            SELECT bus_id, p_set
+            FROM demand.egon_ev_bus_charging_depot
+            WHERE scenario = '{scenario}' AND bus_id IS NOT NULL
+            """
+        )
+        if depots.empty:
+            logger.warning(
+                f"  {scenario}: no depots with a bus, nothing to write"
+            )
+            continue
+
+        per_bus = {}
+        for row in depots.itertuples():
+            series = np.asarray(row.p_set, dtype="float64")
+            if series.size != N_TIMESTEPS:
+                raise ValueError(
+                    f"{scenario}: p_set for bus {row.bus_id} has "
+                    f"{series.size} values, expected {N_TIMESTEPS}"
+                )
+            bus = int(row.bus_id)
+            if bus in per_bus:
+                per_bus[bus] = per_bus[bus] + series
+            else:
+                per_bus[bus] = series
+
+        _delete_old_entries(scenario)
+
+        bus_ids = sorted(per_bus)
+        load_ids = db.next_etrago_id("load", len(bus_ids))
+
+        loads = pd.DataFrame(
+            {
+                "scn_name": scenario,
+                "load_id": load_ids,
+                "bus": bus_ids,
+                "carrier": CARRIER,
+                "sign": -1,
+            }
+        )
+        timeseries = pd.DataFrame(
+            {
+                "scn_name": scenario,
+                "load_id": load_ids,
+                "temp_id": 1,
+                "p_set": [per_bus[bus].tolist() for bus in bus_ids],
+            }
+        )
+
+        loads.to_sql(
+            EgonPfHvLoad.__tablename__,
+            db.engine(),
+            schema="grid",
+            if_exists="append",
+            index=False,
+        )
+        timeseries.to_sql(
+            EgonPfHvLoadTimeseries.__tablename__,
+            db.engine(),
+            schema="grid",
+            if_exists="append",
+            index=False,
+        )
+
+        total_mwh = sum(s.sum() for s in per_bus.values())
+        logger.info(
+            f"  {scenario}: wrote {len(bus_ids)} eTraGo loads "
+            f"({len(depots)} depots), {total_mwh / 1e6:.3f} TWh"
+        )

--- a/src/egon/data/datasets/emobility/public_bus_charging/fill_tables.py
+++ b/src/egon/data/datasets/emobility/public_bus_charging/fill_tables.py
@@ -26,7 +26,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 
-from egon.data import config, db
+from egon.data import db
 from egon.data.datasets.emobility.public_bus_charging.db_classes import (
     EgonEvBusChargingDepot,
 )

--- a/src/egon/data/datasets/emobility/public_bus_charging/fill_tables.py
+++ b/src/egon/data/datasets/emobility/public_bus_charging/fill_tables.py
@@ -1,0 +1,216 @@
+"""
+Read the public bus charging input files and populate
+``demand.egon_ev_bus_charging_depot``.
+
+Input files ship in the data bundle and are resolved relative to the
+egon-data working directory, like every other ``data_bundle_egon_data``
+path::
+
+    data_bundle_egon_data/bus_charging/depots.gpkg
+    data_bundle_egon_data/bus_charging/<per-scenario csv.gz>
+
+``depots.gpkg`` is shared by all scenarios and holds only scenario-neutral
+attributes. Its ``peak_power_mw`` / ``annual_energy_mwh`` / ``avg_power_mw``
+columns, if present, carry **reGon2045** values for every depot and are
+dropped on read -- using them as scenario-neutral metadata would assign
+every depot its 2045 voltage level.
+
+Peak load and annual demand are recomputed per scenario from that
+scenario's own series.
+"""
+
+from pathlib import Path
+
+from loguru import logger
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+
+from egon.data import config, db
+from egon.data.datasets.emobility.public_bus_charging.db_classes import (
+    EgonEvBusChargingDepot,
+)
+from egon.data.datasets.emobility.public_bus_charging.scenarios import (
+    SCENARIO_FILES,
+    active_scenarios,
+)
+
+#: Length of a full year at hourly resolution.
+N_TIMESTEPS = 8760
+
+#: gpkg columns holding reGon2045 values -- never scenario-neutral.
+GPKG_SCENARIO_COLUMNS = ("peak_power_mw", "annual_energy_mwh", "avg_power_mw")
+
+
+def _input_dir() -> Path:
+    from egon.data.datasets.emobility.public_bus_charging import (
+        PublicBusCharging,
+    )
+
+    return Path(PublicBusCharging.sources.files["bus_input_dir"])
+
+
+def _read_depots() -> gpd.GeoDataFrame:
+    """Read the shared depot geometries and attributes, in EPSG:3035."""
+    path = _input_dir() / "depots.gpkg"
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"{path} not found. The public bus input data ships in the data "
+            "bundle under data_bundle_egon_data/bus_charging/."
+        )
+
+    depots = gpd.read_file(path)
+    dropped = [c for c in GPKG_SCENARIO_COLUMNS if c in depots.columns]
+    if dropped:
+        # These hold reGon2045 values for every depot; peak load and annual
+        # demand are recomputed per scenario instead.
+        depots = depots.drop(columns=list(dropped))
+        logger.debug(f"  dropped reGon2045-valued gpkg columns: {dropped}")
+
+    depots = depots.to_crs(epsg=3035)
+    if depots.geometry.name != "geom":
+        depots = depots.rename_geometry("geom")
+    depots = depots.drop(columns=[c for c in ["fid"] if c in depots.columns])
+    depots["depot_id"] = depots["depot_id"].astype(str)
+
+    keep = [
+        c
+        for c in ["depot_id", "depot_name", "depot_type", "fleet_size", "geom"]
+        if c in depots.columns
+    ]
+    return depots[keep]
+
+
+def _read_timeseries(scenario: str) -> pd.DataFrame:
+    """Read one scenario's wide hourly series, in MW.
+
+    Missing values are replaced with 0 and reported. The reGon2037 and
+    reGon2045 inputs carry 1821 NaN each across 34 depots, all at Sunday
+    00:00-03:00 -- a service-day boundary artefact in the source timetable
+    join rather than noise. Zero-filling understates those depots' demand,
+    so the substitution is logged on every run and must not be allowed to
+    become invisible; remove it once the input data is corrected.
+    """
+    path = _input_dir() / SCENARIO_FILES[scenario]
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"{path} not found for scenario {scenario!r}. The public bus "
+            "input data ships in the data bundle under "
+            "data_bundle_egon_data/bus_charging/."
+        )
+
+    wide = pd.read_csv(path, index_col=0)
+    wide.columns = wide.columns.astype(str)
+
+    if len(wide) != N_TIMESTEPS:
+        raise ValueError(
+            f"{path} has {len(wide)} timesteps, expected {N_TIMESTEPS}."
+        )
+
+    per_depot = wide.isna().sum()
+    affected = per_depot[per_depot > 0]
+    if len(affected):
+        logger.warning(
+            f"  {scenario}: zero-filling {int(per_depot.sum())} missing "
+            f"values across {len(affected)} depots. This understates their "
+            f"demand -- see docs/adr/0003. Depots: {list(affected.index)}"
+        )
+        wide = wide.fillna(0.0)
+
+    values = wide.to_numpy(dtype="float64")
+    if not np.isfinite(values).all():
+        raise ValueError(
+            f"{path} contains non-finite values that are not NaN (inf); "
+            "refusing to write them to p_set."
+        )
+    if (values < 0).any():
+        n_neg = int((values < 0).sum())
+        raise ValueError(
+            f"{path} contains {n_neg} negative values; bus charging demand "
+            "cannot be negative (there is no flexibility in this dataset)."
+        )
+    return wide
+
+
+def fill_depot_table():
+    """Populate demand.egon_ev_bus_charging_depot for all active scenarios.
+
+    Spatial columns (``bus_id``, ``mv_grid_id``, ``voltage_level``) are left
+    NULL here and filled by :func:`spatial_assignment
+    <egon.data.datasets.emobility.public_bus_charging.spatial_assignment.spatial_assignment>`.
+    """
+    depots = _read_depots()
+    logger.info(f"Read {len(depots)} depots from depots.gpkg")
+
+    scenarios = active_scenarios()
+    if not scenarios:
+        logger.warning(
+            "No configured scenario carries public bus data "
+            f"(bus data exists for {list(SCENARIO_FILES)}). Nothing to do."
+        )
+        return
+
+    for scenario in scenarios:
+        wide = _read_timeseries(scenario)
+
+        frame = pd.DataFrame(
+            {
+                "depot_id": wide.columns,
+                "scenario": scenario,
+                "peak_load_mw": wide.max(axis=0).to_numpy(),
+                # 1 h timesteps, so summing MW over the year gives MWh.
+                "annual_demand_mwh": wide.sum(axis=0).to_numpy(),
+            }
+        )
+        frame["p_set"] = [
+            wide[depot].to_numpy(dtype="float64").tolist()
+            for depot in wide.columns
+        ]
+
+        merged = frame.merge(depots, on="depot_id", how="left")
+        missing = merged["geom"].isna()
+        if missing.any():
+            raise ValueError(
+                f"{int(missing.sum())} depots in the {scenario} time series "
+                "have no entry in depots.gpkg: "
+                f"{list(merged.loc[missing, 'depot_id'])}"
+            )
+
+        gdf = gpd.GeoDataFrame(merged, geometry="geom", crs="EPSG:3035")
+        db.execute_sql(
+            f"""
+            DELETE FROM demand.egon_ev_bus_charging_depot
+            WHERE scenario = '{scenario}';
+            """
+        )
+        # Insert via the ORM rather than GeoDataFrame.to_postgis: the latter
+        # writes through COPY, which renders a Python list as "[...]" and
+        # PostgreSQL rejects it as a malformed array literal (arrays need
+        # "{...}"). The ORM binds p_set as a real ARRAY parameter.
+        gdf["geom_wkt"] = gdf["geom"].apply(lambda g: g.wkt)
+        records = [
+            {
+                "depot_id": row.depot_id,
+                "scenario": row.scenario,
+                "depot_name": getattr(row, "depot_name", None),
+                "depot_type": getattr(row, "depot_type", None),
+                "fleet_size": (
+                    None
+                    if pd.isna(getattr(row, "fleet_size", np.nan))
+                    else float(row.fleet_size)
+                ),
+                "geom": f"SRID=3035;{row.geom_wkt}",
+                "peak_load_mw": float(row.peak_load_mw),
+                "annual_demand_mwh": float(row.annual_demand_mwh),
+                "p_set": row.p_set,
+            }
+            for row in gdf.itertuples()
+        ]
+        with db.session_scope() as session:
+            session.bulk_insert_mappings(EgonEvBusChargingDepot, records)
+
+        logger.info(
+            f"  {scenario}: wrote {len(records)} depots, "
+            f"{gdf['annual_demand_mwh'].sum() / 1e6:.3f} TWh, "
+            f"peak sum {gdf['peak_load_mw'].sum():.1f} MW"
+        )

--- a/src/egon/data/datasets/emobility/public_bus_charging/scenarios.py
+++ b/src/egon/data/datasets/emobility/public_bus_charging/scenarios.py
@@ -1,0 +1,29 @@
+"""
+Scenario mapping for public bus charging.
+
+Bus data exists for exactly three scenarios. ``eGon2035`` is deliberately
+left unchanged and ``eGon100RE`` is discarded, so neither gets bus loads --
+a run of either with no bus demand is correct, not a missing-data bug.
+"""
+
+from egon.data import config
+
+#: eGon-data scenario name -> input CSV file name, relative to the input dir.
+SCENARIO_FILES = {
+    "status2024": "2024_depot_power_2024_reference_hourly.csv.gz",
+    "reGon2037": "depot_power_2037_hourly.csv.gz",
+    "reGon2045": "2045_depot_power_2011_hourly.csv.gz",
+}
+
+
+def active_scenarios():
+    """Scenarios that have bus data and are configured for this run.
+
+    Returns
+    -------
+    list of str
+        Configured scenarios that carry public bus data, in the order given
+        by :data:`SCENARIO_FILES`.
+    """
+    configured = set(config.settings()["egon-data"]["--scenarios"])
+    return [s for s in SCENARIO_FILES if s in configured]

--- a/src/egon/data/datasets/emobility/public_bus_charging/spatial_assignment.py
+++ b/src/egon/data/datasets/emobility/public_bus_charging/spatial_assignment.py
@@ -1,0 +1,198 @@
+"""
+Assign ``bus_id``, ``mv_grid_id`` and ``voltage_level`` to bus depots.
+
+Voltage level follows the canonical eGon-data peak-load thresholds, matching
+:func:`egon.data.datasets.industry.temporal.identify_voltage_level`::
+
+    peak <= 0.1 MW -> 7 (LV)
+    peak >  0.1 MW -> 6
+    peak >  0.2 MW -> 5 (MV)
+    peak >  5.5 MW -> 4
+    peak >  20  MW -> 3 (HV)
+    peak > 120  MW -> 1 (EHV)
+
+Level 2 is never derived from load -- it only ever comes from MaStR's
+``Spannungsebene`` string, which this dataset does not use.
+
+The level is computed per (depot, scenario) from that scenario's own peak,
+so a depot may sit at a different level in each scenario; connection
+upgrades between scenarios are not modelled (``docs/adr/0001``).
+
+Bus assignment uses two layers, following
+:mod:`egon.data.datasets.power_plants`:
+
+* voltage level 3-7 -> ``grid.egon_mv_grid_district`` (EPSG:3035)
+* voltage level 1-2 -> ``grid.egon_ehv_substation_voronoi`` (EPSG:4326)
+
+An MV grid district is the Voronoi cell of exactly one HV/MV substation and
+therefore contains exactly one eTraGo bus, so every depot in a district
+necessarily shares that district's bus -- there is no finer bus to choose.
+
+Depots that fall in no district are **dropped**, not snapped to the nearest
+one. In a ``--dataset-boundary`` test run the district table covers only the
+test region, so a nearest-match fallback would silently pile every
+out-of-region depot onto the boundary's edge buses.
+"""
+
+from loguru import logger
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+
+from egon.data import db
+from egon.data.datasets.emobility.public_bus_charging.scenarios import (
+    active_scenarios,
+)
+
+#: Voltage levels served by the MV grid districts.
+MV_LEVELS = (3, 4, 5, 6, 7)
+
+#: Voltage levels served by the EHV substation Voronoi cells.
+EHV_LEVELS = (1, 2)
+
+
+def assign_voltage_level(peak_load_mw: pd.Series) -> pd.Series:
+    """Map peak load [MW] to an eGon-data voltage level."""
+    peak = pd.Series(peak_load_mw, dtype="float64")
+    level = pd.Series(np.nan, index=peak.index)
+    level[peak <= 0.1] = 7
+    level[peak > 0.1] = 6
+    level[peak > 0.2] = 5
+    level[peak > 5.5] = 4
+    level[peak > 20.0] = 3
+    level[peak > 120.0] = 1
+    return level.astype("Int64")
+
+
+def _join(depots: gpd.GeoDataFrame, cells: gpd.GeoDataFrame) -> pd.DataFrame:
+    """Inner point-in-polygon join of depots onto bus cells."""
+    joined = gpd.sjoin(
+        depots[["depot_id", "geom"]],
+        cells[["bus_id", "geom"]],
+        how="inner",
+        predicate="within",
+    )
+    # A depot on a shared boundary can match more than one cell; keep one.
+    return (
+        joined[["depot_id", "bus_id"]]
+        .drop_duplicates(subset="depot_id")
+        .reset_index(drop=True)
+    )
+
+
+def spatial_assignment():
+    """Fill bus_id, mv_grid_id and voltage_level for all active scenarios."""
+    scenarios = active_scenarios()
+    if not scenarios:
+        logger.warning("No active scenario carries public bus data.")
+        return
+
+    mv_districts = db.select_geodataframe(
+        "SELECT bus_id, geom FROM grid.egon_mv_grid_district",
+        geom_col="geom",
+        epsg=3035,
+    )
+    ehv_cells = db.select_geodataframe(
+        "SELECT bus_id, geom FROM grid.egon_ehv_substation_voronoi",
+        geom_col="geom",
+        epsg=3035,
+    )
+    logger.info(
+        f"{len(mv_districts)} MV grid districts, "
+        f"{len(ehv_cells)} EHV Voronoi cells"
+    )
+
+    for scenario in scenarios:
+        depots = db.select_geodataframe(
+            f"""
+            SELECT depot_id, peak_load_mw, geom
+            FROM demand.egon_ev_bus_charging_depot
+            WHERE scenario = '{scenario}'
+            """,
+            geom_col="geom",
+            epsg=3035,
+        )
+        if depots.empty:
+            logger.warning(f"  {scenario}: no depots to assign")
+            continue
+
+        depots["voltage_level"] = assign_voltage_level(depots["peak_load_mw"])
+
+        mv_part = depots[depots["voltage_level"].isin(MV_LEVELS)]
+        ehv_part = depots[depots["voltage_level"].isin(EHV_LEVELS)]
+
+        assigned = _join(mv_part, mv_districts)
+        assigned["mv_grid_id"] = assigned["bus_id"]
+
+        if not ehv_part.empty:
+            # Unexercised by the current input data (no depot exceeds
+            # 120 MW), so make it loud the first time real data reaches it.
+            logger.warning(
+                f"  {scenario}: {len(ehv_part)} depots at voltage level "
+                f"{sorted(ehv_part['voltage_level'].dropna().unique())} are "
+                "assigned via the EHV substation Voronoi -- this path has no "
+                "coverage in the current input data, verify the result."
+            )
+            ehv_assigned = _join(ehv_part, ehv_cells)
+            ehv_assigned["mv_grid_id"] = pd.NA
+            assigned = pd.concat([assigned, ehv_assigned], ignore_index=True)
+
+        result = depots[["depot_id", "voltage_level"]].merge(
+            assigned, on="depot_id", how="left"
+        )
+        dropped = result[result["bus_id"].isna()]
+        if len(dropped):
+            logger.info(
+                f"  {scenario}: dropping {len(dropped)} of {len(result)} "
+                "depots that fall in no grid district (expected when "
+                "--dataset-boundary restricts the run to a test region)"
+            )
+        result = result[result["bus_id"].notna()]
+
+        with db.session_scope() as session:
+            session.execute(
+                """
+                UPDATE demand.egon_ev_bus_charging_depot AS d
+                SET bus_id = v.bus_id,
+                    mv_grid_id = v.mv_grid_id,
+                    voltage_level = v.voltage_level
+                FROM (
+                    SELECT
+                        unnest(:depot_ids) AS depot_id,
+                        unnest(:bus_ids) AS bus_id,
+                        unnest(:mv_grid_ids) AS mv_grid_id,
+                        unnest(:voltage_levels) AS voltage_level
+                ) AS v
+                WHERE d.depot_id = v.depot_id AND d.scenario = :scenario
+                """,
+                {
+                    "depot_ids": list(result["depot_id"]),
+                    "bus_ids": [int(b) for b in result["bus_id"]],
+                    "mv_grid_ids": [
+                        None if pd.isna(m) else int(m)
+                        for m in result["mv_grid_id"]
+                    ],
+                    "voltage_levels": [
+                        int(v) for v in result["voltage_level"]
+                    ],
+                    "scenario": scenario,
+                },
+            )
+            # Depots outside every district keep NULL bus_id and are not
+            # written to eTraGo; remove them so the table only holds rows
+            # that made it into the model.
+            session.execute(
+                """
+                DELETE FROM demand.egon_ev_bus_charging_depot
+                WHERE scenario = :scenario AND bus_id IS NULL
+                """,
+                {"scenario": scenario},
+            )
+
+        levels = (
+            result["voltage_level"].value_counts().sort_index().to_dict()
+        )
+        logger.info(
+            f"  {scenario}: assigned {len(result)} depots to "
+            f"{result['bus_id'].nunique()} buses, voltage levels {levels}"
+        )


### PR DESCRIPTION
Fixes #1461.

Adds the eMobility dataset for public buses (vehicle class M3): depot locations with a
static hourly charging series per scenario. No flexibility is modelled, though it may be
added later.

Two tables are written from one source of truth:

- **`demand.egon_ev_bus_charging_depot`** — one row per (depot, scenario) with geometry,
  `depot_type`, `fleet_size`, `voltage_level`, `peak_load_mw`, `annual_demand_mwh` and
  the full 8760-step `p_set`. This is the per-location table for eDisGo, which cannot
  regenerate a predefined series from an aggregate.
- **`grid.egon_etrago_load` / `_timeseries`** — one load per eTraGo bus per scenario
  under the new carrier `land_transport_bus`, with the depots' series summed.

Unlike MIT and HGV, the demand is not generated inside egon-data: the depot gpkg and
three gzipped hourly CSVs are produced externally and ship in the data bundle under
`data_bundle_egon_data/bus_charging/`. This dataset is the integration layer only.

**Scenario coverage**

| Scenario | Bus data | Depots | Annual demand |
|---|---|---|---|
| `status2024` | yes | 1053 | 0.246 TWh |
| `reGon2037` | yes | 1352 | 3.106 TWh |
| `reGon2045` | yes | 1352 | 4.350 TWh |
| `eGon2035` | no — deliberately unchanged | — | — |
| `eGon100RE` | no — discarded | — | — |

Zero bus demand in `eGon2035` / `eGon100RE` is correct rather than a missing-data bug.
The `status2024` figure is a sanity anchor: 0.246 TWh at 70–84 MWh/bus/a implies
~2,900–3,500 buses, matching the 2,946 battery-electric buses actually registered in
Germany at end-2024 (KBA / PwC E-Bus-Radar) — it models the currently electrified
fraction, not the full fleet.

### 📋 Pull Request Guidelines

> Please read the [Pull Request Guidelines](https://egon-data.readthedocs.io/en/latest/contributing.html#pull-request-guidelines) carefully before creating your PR.

---

## 🧑‍💻 Contributor Checklist

Before requesting a review, make sure you've completed all of the following:

- [x] All **tests pass** locally or via CI
      _(for more information on local test, check `tox` in the [Contributing section](https://egon-data.readthedocs.io/en/latest/contributing.html#))_
      _(CI tests are automatically executed when creating a PR, you can see the results of the checks below)_
      _`pytest -vv --ignore=src`: 3 passed, 1 skipped (the skip needs Docker/PostgreSQL). `flake8` and `isort` pass on the changed files._
- [x] Workflow has run at least once in **Test mode**
      _(optional if no dataset changes are involved)_
- [x] Relevant **documentation is updated** (API, new features, etc.)
- [x] Dataset-versions are updated when existing datasets are adjusted.
- [x] Added a note to `CHANGELOG.rst` about the changes
- [x] Added yourself to `AUTHORS.rst`

Optional:

- [ ] Changes have been tested in **Everything mode**
- [x] Extend the checklist for reviewers: Which aspects should be reviewed in particular?

```markdown
Please focus on:

1. The eTraGo aggregation strategy (`etrago_integration.py`). Depots are summed per
   eTraGo bus rather than written individually. An MV grid district is the Voronoi cell
   of exactly one HV/MV substation, so depots in a district necessarily share a bus, and
   with no flexibility to distinguish them N loads on one bus are mathematically
   identical to one summed load. Sanity-check that reasoning.

2. The per-scenario voltage level (`spatial_assignment.py`). 560 of the 1053 depots
   present in all three scenarios are assigned a higher voltage level in reGon2045 than
   in status2024, and no connection upgrade is modelled. This follows the convention for
   other growing loads, but it is the decision with the widest downstream effect.

3. The two-layer bus assignment. Levels 3–7 join against `grid.egon_mv_grid_district`,
   levels 1–2 against `grid.egon_ehv_substation_voronoi`, following `power_plants`. The
   EHV path is unexercised by the current input data (no depot exceeds 120 MW) and only
   logs a warning — review whether that is acceptable or should raise.

4. Whether `land_transport_bus` should be registered in
   `etrago_setup.insert_carriers()`. HGV's `land_transport_HGV` is not, and its loads
   write fine, so I left it out — but if that list is meant to be exhaustive it is a
   one-line addition.
```

---

## 🔍 Reviewer Checklist

During your review, please check the following:

- [ ] **Is the code clean, readable, and efficient?** Are there any oddities or obvious inefficiencies?
- [ ] Does the code work as expected? _(should already be verified by contributor)_
- [ ] Do all tests pass? (see CI results)
- [ ] Is the documentation complete and up to date?
- [ ] Is `CHANGELOG.rst` updated accordingly?
- [ ] Is all necessary metadata complete and correct?
  - [ ] If metadata is pending: Is there an appropriate issue filed?

---

## 📝 Additional Notes (optional)

### Design decisions

Recorded as ADRs alongside the input data; the two non-obvious ones:

**Voltage level is per (depot, scenario), and connection upgrades are not modelled.**
Of the 1053 depots present in all three scenarios, only 493 keep the same voltage level
from `status2024` to `reGon2045` — 560 are upgraded, none downgraded. This follows the
convention every other growing load uses (industry, heat pumps, PV rooftop, power
plants) and keeps `status2024` physically honest: a depot charging two buses today
genuinely is on an LV connection, and 393 of its 1053 depots are at level 6–7. The
trade-off is that cross-scenario connection-upgrade cost stays invisible — a property of
egon-data's scenario design rather than of this dataset.

**Per-depot series are stored even though eTraGo only needs the aggregate,** because
depot peaks are not coincident: the sum of individual peaks in `reGon2045` is 3770 MW
against a lower aggregate peak. Only the full series preserves *when* each depot peaks,
which is what LV reinforcement analysis needs. A normalized national profile scaled by
annual energy — the approach HGV uses for highway-day charging — would not work here,
because each depot's shape is genuinely distinct. Cost is ~300 MB at national extent.

### Implementation notes

- Out-of-boundary depots are **dropped, not snapped to the nearest bus**. Under
  `--dataset-boundary` the district table covers only the test region, so a
  nearest-match fallback would silently pile every out-of-region depot onto the
  boundary's edge buses — a failure that looks plausible and goes undetected.
- Deletion is scoped by carrier **and** scenario, so a run configured for one scenario
  does not wipe another's bus loads. (MIT filters by carrier and German buses but not by
  scenario, which is a footgun for incremental runs.)
- `depot_id` is a **String** primary key, unlike the integer keys used elsewhere. It is
  the natural key, joins directly to the input CSV column headers, and stays stable
  across input-data regenerations — an integer surrogate would either need a mapping
  table or would silently renumber depots when the input changes.
- `osmtgmod` is a **required** dependency, not redundant with `mv_grid_districts`:
  `substation_voronoi` depends only on the single task
  `electricity_grid.osmtgmod.substation.extract`, which sits in the same parallel task
  set as `to_pypsa`, so its completion does not imply `grid.egon_etrago_bus` is
  populated.
- `p_set` is inserted via the ORM rather than `GeoDataFrame.to_postgis`: the latter
  writes through `COPY`, which renders a Python list as `[...]` and PostgreSQL rejects
  it as a malformed array literal. Worth knowing for anyone adding an `ARRAY` column
  alongside a geometry.

### Known input-data defect

The `reGon2037` and `reGon2045` series each carry **1821 NaN across 34 depots**, in 5
distinct patterns. Every one sits at hour 0, 1 or 2 **on a Sunday** — 96 rows over 32
distinct Sundays — the signature of a service-day boundary in the source timetable join
rather than noise. The `status2024` file is clean.

Pending a fix upstream these are zero-filled so the pipeline can run. This understates
those depots' demand (~0.6 % of hours for an affected depot, in a low-demand window), so
the substitution is logged with the affected depot ids on every run and reported
separately in the validation notebook. It should be removed and the error restored once
the input data is corrected.

### Testing

Verified by a full Airflow DAG run (`manual__2026-09-08T14:30:25`) in **Test mode**
(`--dataset-boundary: Schleswig-Holstein`, all four scenarios configured) — all four
tasks SUCCESS:

```
Read 1352 depots from depots.gpkg
  status2024: wrote 1053 depots, 0.246 TWh, peak sum 413.9 MW
  reGon2037: zero-filling 1821 missing values across 34 depots
  reGon2037: wrote 1352 depots, 3.106 TWh, peak sum 2771.1 MW
  reGon2045: wrote 1352 depots, 4.350 TWh, peak sum 3770.2 MW
201 MV grid districts, 26 EHV Voronoi cells
  → 65 depots assigned to 62 buses per scenario
  → 62 eTraGo loads per scenario
```

Not yet run in **Everything mode**.

A validation notebook (kept with the input data, outside this repo) runs 11 checks in
two modes — against the raw input files and against the pipeline output. All pass. Five
compare the database against the input rather than against itself:

| # | Check | Result |
|---|---|---|
| 7 | Depot set is a subset of the input | 0 invented rows |
| 8 | `peak_load_mw` / `annual_demand_mwh` / `voltage_level` match input | 0 mismatches |
| 9 | `p_set` matches the input **element-wise** | 0 of 1,708,200 values differ |
| 10 | Each scenario holds its **own** input file | zero diagonal, non-zero off-diagonal |
| 11 | gpkg attributes and geometry preserved | 0 mismatches, 0.0000 m geometry shift |

Check 10 matters because `reGon2037` and `reGon2045` differ by only 1.97 MW at maximum,
so a mix-up between those two needs an element-wise test rather than an aggregate one.
Energy conservation through the eTraGo aggregation holds to floating-point precision
(max relative difference 4.6e-16).

### Open points

- **The data bundle needs republishing.** The current Zenodo bundle
  (`record/16576506`) does not yet contain `bus_charging/`. Local and test runs work
  because the files are staged in the working directory, but a fresh run or CI will fail
  at `fill_depot_table` with an explicit `FileNotFoundError` until the bundle is updated.
- **No OEP metadata yet** for `demand.egon_ev_bus_charging_depot` — the other eMobility
  datasets carry an `add_metadata()` task. Happy to add it here, or file a follow-up
  issue if that is the usual route.
- **No entry in `sanity_checks.py`.** That module registers tasks only for `eGon2035`
  and `eGon100RE`, so under the default `--scenarios` the task tuple is empty and
  nothing would run. Validation currently lives in the notebook.
- **No en-route (opportunity) charging.** The input assumes all M3 charging happens at
  depots; energy a real network would draw at route termini is folded into the depot
  totals. Annual energy is complete, but daytime terminus demand appears as overnight
  depot demand. Adding it would need new input data, not just a schema change.
- **eDisGo handoff not yet confirmed.** This dataset supplies `peak_load_mw`, but peak
  load and contracted grid connection capacity are not the same thing, and whether
  eDisGo can ingest an LV-connected load with a predefined time series (393 of 1053
  `status2024` depots are at level 6–7) still needs checking.

### Incidental finding (not addressed here)

`industry/temporal.py:115-121` names a variable `ehv_voronoi` and comments "Select ehv
voronoi", but the SQL queries `grid.egon_mv_grid_district`. The intent was clearly the
EHV table. It is never hit in practice because no industrial load exceeds 120 MW, so it
is latent rather than an active bug — worth a separate issue.
